### PR TITLE
Fix startup script preview default and backend AI import resilience

### DIFF
--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -22,7 +22,7 @@ class AiService:
 
         if self.api_key:
             if genai is None:
-                self.ai_disabled_reason = f"Provider import failed: {_genai_import_error}"
+                self.ai_disabled_reason = "Provider import failed"
                 logger.error(
                     "AI provider unavailable: %s. AI features disabled.",
                     _genai_import_error,
@@ -36,15 +36,15 @@ class AiService:
                 )
                 logger.info("AI Service Initialized (Gemini Pro)")
             except Exception as e:
-                self.ai_disabled_reason = f"Provider initialization failed: {e}"
-                logger.error(f"Failed to initialize AI: {e}")
+                self.ai_disabled_reason = "Provider initialization failed"
+                logger.exception("Failed to initialize AI: %s", e)
         else:
             self.ai_disabled_reason = "API key ausente"
             logger.warning("GOOGLE_API_KEY not found. AI features disabled.")
 
     async def get_chat_response(self, message: str) -> str:
         if not self.model:
-            reason = self.ai_disabled_reason or "API key ausente"
+            reason = self.ai_disabled_reason or "AI service not configured"
             raise ServiceError(
                 f"Serviço de IA não configurado ({reason}).", service="AI"
             )

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -18,9 +18,11 @@ class AiService:
     def __init__(self):
         self.api_key = os.environ.get("GOOGLE_API_KEY")
         self.model = None
+        self.ai_disabled_reason: str | None = None
 
         if self.api_key:
             if genai is None:
+                self.ai_disabled_reason = f"Provider import failed: {_genai_import_error}"
                 logger.error(
                     "AI provider unavailable: %s. AI features disabled.",
                     _genai_import_error,
@@ -34,14 +36,17 @@ class AiService:
                 )
                 logger.info("AI Service Initialized (Gemini Pro)")
             except Exception as e:
+                self.ai_disabled_reason = f"Provider initialization failed: {e}"
                 logger.error(f"Failed to initialize AI: {e}")
         else:
+            self.ai_disabled_reason = "API key ausente"
             logger.warning("GOOGLE_API_KEY not found. AI features disabled.")
 
     async def get_chat_response(self, message: str) -> str:
         if not self.model:
+            reason = self.ai_disabled_reason or "API key ausente"
             raise ServiceError(
-                "Serviço de IA não configurado (API Key ausente).", service="AI"
+                f"Serviço de IA não configurado ({reason}).", service="AI"
             )
 
         try:

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -1,7 +1,13 @@
 import logging
 import os
 
-import google.generativeai as genai
+try:
+    import google.generativeai as genai
+    _genai_import_error: Exception | None = None
+except Exception as exc:
+    # Keep backend startup resilient when optional AI provider deps are broken.
+    genai = None
+    _genai_import_error = exc
 
 from ..config.exceptions import ServiceError
 
@@ -14,6 +20,13 @@ class AiService:
         self.model = None
 
         if self.api_key:
+            if genai is None:
+                logger.error(
+                    "AI provider unavailable: %s. AI features disabled.",
+                    _genai_import_error,
+                )
+                return
+
             try:
                 genai.configure(api_key=self.api_key)  # pyright: ignore[reportPrivateImportUsage]
                 self.model = genai.GenerativeModel(  # pyright: ignore[reportPrivateImportUsage]

--- a/start_nesh_dev.bat
+++ b/start_nesh_dev.bat
@@ -8,6 +8,8 @@ set "RUN_BACKEND=1"
 set "CHECKLIST_FILE=%TEMP%\nesh_dev_startup.txt"
 set "CHECKLIST_SHOWN=0"
 set "FAIL_REASON="
+set "BACKEND_UV_SYNC_MODE=no-sync"
+set "BACKEND_BOOT_CMD=uv run --no-sync Nesh.py"
 
 set "CHK_NODE=PENDENTE"
 set "CHK_NPM=PENDENTE"
@@ -17,9 +19,16 @@ set "CHK_BACKEND_PORT=PENDENTE"
 set "CHK_BACKEND_HEALTH=PENDENTE"
 set "CHK_FRONTEND_ENV=PENDENTE"
 set "CHK_FRONTEND_DEPS=PENDENTE"
+set "CHK_FRONTEND_BUILD=PENDENTE"
 set "CHK_FRONTEND_PORT=PENDENTE"
 
-set "FRONTEND_BOOT_CMD=npm run dev"
+set "FRONTEND_MODE=preview"
+set "FRONTEND_PORT=4173"
+set "FRONTEND_WAIT_ATTEMPTS=90"
+set "FRONTEND_BOOT_CMD=npm run build && npm run preview -- --host 0.0.0.0 --port 4173 --strictPort"
+set "FRONTEND_WINDOW_TITLE=Nesh Client (Preview)"
+set "FRONTEND_LOCAL_URL=http://127.0.0.1:4173"
+set "FRONTEND_PUBLIC_URL="
 
 :parse_args
 if "%~1"=="" goto args_done
@@ -27,12 +36,35 @@ if /I "%~1"=="--auth-debug" (
     set "ENABLE_AUTH_DEBUG=1"
 ) else if /I "%~1"=="--frontend-only" (
     set "RUN_BACKEND=0"
+) else if /I "%~1"=="--backend-sync" (
+    set "BACKEND_UV_SYNC_MODE=sync"
+    set "BACKEND_BOOT_CMD=uv run Nesh.py"
+) else if /I "%~1"=="--public-preview" (
+    set "FRONTEND_MODE=preview"
+    set "FRONTEND_PORT=4173"
+    set "FRONTEND_WAIT_ATTEMPTS=90"
+    set "FRONTEND_BOOT_CMD=npm run build && npm run preview -- --host 0.0.0.0 --port 4173 --strictPort"
+    set "FRONTEND_WINDOW_TITLE=Nesh Client (Preview)"
+    set "FRONTEND_LOCAL_URL=http://127.0.0.1:4173"
+) else if /I "%~1"=="--dev-hmr" (
+    set "FRONTEND_MODE=dev"
+    set "FRONTEND_PORT=5173"
+    set "FRONTEND_WAIT_ATTEMPTS=50"
+    set "FRONTEND_BOOT_CMD=npm run dev"
+    set "FRONTEND_WINDOW_TITLE=Nesh Client (Dev)"
+    set "FRONTEND_LOCAL_URL=http://127.0.0.1:5173"
 ) else (
     echo [WARN] Argumento ignorado: %~1
 )
 shift
 goto parse_args
 :args_done
+
+if /I "!FRONTEND_MODE!"=="preview" (
+    set "CHK_FRONTEND_BUILD=PENDENTE"
+) else (
+    set "CHK_FRONTEND_BUILD=IGNORADO"
+)
 
 where node >nul 2>&1
 if errorlevel 1 (
@@ -88,22 +120,27 @@ if "!RUN_BACKEND!"=="1" (
 )
 
 if "!ENABLE_AUTH_DEBUG!"=="1" (
-    echo [INFO] Modo auth debug habilitado para o frontend: VITE_AUTH_DEBUG=true nesta sessao.
-    set "FRONTEND_BOOT_CMD=set VITE_AUTH_DEBUG=true && npm run dev"
+    if /I "!FRONTEND_MODE!"=="preview" (
+        echo [INFO] --auth-debug ignorado no modo preview de producao.
+    ) else (
+        echo [INFO] Modo auth debug habilitado para o frontend: VITE_AUTH_DEBUG=true nesta sessao.
+        set "FRONTEND_BOOT_CMD=set VITE_AUTH_DEBUG=true && npm run dev"
+    )
 )
 
 if "!RUN_BACKEND!"=="1" (
     echo.
     echo [3/7] Iniciando backend local...
+    if /I "!BACKEND_UV_SYNC_MODE!"=="no-sync" echo [INFO] Backend iniciado com uv --no-sync para evitar erro de permissao no .venv.
     call :stop_listener_port 8000 backend
-    start "Nesh API (Dev)" cmd /k "cd /d ""%~dp0"" && uv run Nesh.py"
+    start "Nesh API (Dev)" cmd /k "cd /d ""%~dp0"" && !BACKEND_BOOT_CMD!"
 
     echo.
     echo [4/7] Aguardando a API abrir na porta 8000...
     call :wait_port_open 8000 70
     if errorlevel 1 (
         set "CHK_BACKEND_PORT=FALHA"
-        set "FAIL_REASON=Backend nao abriu a porta 8000."
+        set "FAIL_REASON=Backend nao abriu a porta 8000. Se houver erro de permissao no .venv, rode com padrao (no-sync) ou feche processos que travam .venv."
         goto fail
     )
     set "CHK_BACKEND_PORT=OK"
@@ -132,22 +169,33 @@ if errorlevel 1 (
 set "CHK_FRONTEND_DEPS=OK"
 
 echo.
-echo [7/7] Iniciando frontend com Hot Reload...
-call :stop_listener_port 5173 frontend
-start "Nesh Client (Dev)" cmd /k "cd /d ""%~dp0client"" && !FRONTEND_BOOT_CMD!"
+if /I "!FRONTEND_MODE!"=="preview" (
+    echo [7/7] Iniciando frontend em modo PREVIEW (build de producao)...
+) else (
+    echo [7/7] Iniciando frontend com Hot Reload...
+)
+call :stop_listener_port !FRONTEND_PORT! frontend
+start "!FRONTEND_WINDOW_TITLE!" cmd /k "cd /d ""%~dp0client"" && !FRONTEND_BOOT_CMD!"
 cd /d "%~dp0"
 
 echo.
-echo [7/7] Aguardando o Vite abrir na porta 5173...
-call :wait_port_open 5173 50
+echo [7/7] Aguardando o frontend abrir na porta !FRONTEND_PORT!...
+call :wait_port_open !FRONTEND_PORT! !FRONTEND_WAIT_ATTEMPTS!
 if errorlevel 1 (
+    if /I "!FRONTEND_MODE!"=="preview" set "CHK_FRONTEND_BUILD=FALHA"
     set "CHK_FRONTEND_PORT=FALHA"
-    set "FAIL_REASON=Frontend nao abriu a porta 5173."
+    set "FAIL_REASON=Frontend nao abriu a porta !FRONTEND_PORT!."
     goto fail
 )
+if /I "!FRONTEND_MODE!"=="preview" set "CHK_FRONTEND_BUILD=OK"
 set "CHK_FRONTEND_PORT=OK"
 
-start "" "http://127.0.0.1:5173"
+call :resolve_lan_frontend_url !FRONTEND_PORT!
+if defined FRONTEND_PUBLIC_URL (
+    start "" "!FRONTEND_PUBLIC_URL!"
+) else (
+    start "" "!FRONTEND_LOCAL_URL!"
+)
 
 echo.
 echo Ambiente de desenvolvimento pronto.
@@ -156,7 +204,13 @@ call :write_checklist_file "SUCESSO"
 call :open_checklist_file
 echo.
 if "!RUN_BACKEND!"=="1" echo Backend Local:  http://127.0.0.1:8000/api/status
-echo Frontend Local: http://127.0.0.1:5173
+echo Frontend Local: !FRONTEND_LOCAL_URL!
+if defined FRONTEND_PUBLIC_URL echo Frontend Publico ^(rede local^): !FRONTEND_PUBLIC_URL!
+if /I "!FRONTEND_MODE!"=="preview" (
+    echo Frontend em modo PREVIEW de producao.
+) else (
+    echo Frontend em modo DEV com Hot Reload.
+)
 pause
 exit /b 0
 
@@ -232,6 +286,15 @@ if "%TARGET_PORT%"=="" exit /b 0
 powershell -NoProfile -ExecutionPolicy Bypass -Command "$port=%TARGET_PORT%; $label='%TARGET_LABEL%'; $processIds = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique; if ($processIds) { Write-Host ('[INFO] Encerrando listener existente na porta ' + $port + ' (' + $label + ')...'); foreach ($processId in $processIds) { try { Stop-Process -Id $processId -Force -ErrorAction Stop } catch {} } Start-Sleep -Milliseconds 600 }"
 exit /b 0
 
+:resolve_lan_frontend_url
+set "TARGET_PORT=%~1"
+set "FRONTEND_PUBLIC_URL="
+if "%TARGET_PORT%"=="" exit /b 0
+for /f "usebackq delims=" %%I in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$ip = Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue | Where-Object { $_.IPAddress -ne '127.0.0.1' -and $_.IPAddress -notlike '169.254*' -and $_.InterfaceAlias -notmatch 'Loopback|vEthernet|VirtualBox|VMware|Hyper-V|WSL|Tailscale|ZeroTier' } | Select-Object -First 1 -ExpandProperty IPAddress; if ($ip) { Write-Output $ip }"`) do (
+    set "FRONTEND_PUBLIC_URL=http://%%I:%TARGET_PORT%"
+)
+exit /b 0
+
 :print_checklist
 echo.
 echo =================== CHECKLIST DEV ===================
@@ -243,7 +306,8 @@ call :print_check_item "Backend ativo na porta 8000" "!CHK_BACKEND_PORT!" "Verif
 call :print_check_item "Healthcheck /api/status ok" "!CHK_BACKEND_HEALTH!" "Confirme logs do backend local."
 call :print_check_item "client/.env.local configurado" "!CHK_FRONTEND_ENV!" "Defina pelo menos VITE_CLERK_PUBLISHABLE_KEY."
 call :print_check_item "Dependencias frontend prontas" "!CHK_FRONTEND_DEPS!" "Execute npm install em client/."
-call :print_check_item "Frontend ativo na porta 5173" "!CHK_FRONTEND_PORT!" "Verifique a janela Nesh Client (Dev)."
+call :print_check_item "Build de frontend (preview)" "!CHK_FRONTEND_BUILD!" "Use --dev-hmr para voltar ao modo hot reload."
+call :print_check_item "Frontend ativo na porta !FRONTEND_PORT!" "!CHK_FRONTEND_PORT!" "Verifique a janela !FRONTEND_WINDOW_TITLE!."
 echo =====================================================
 exit /b 0
 
@@ -302,11 +366,13 @@ echo - Backend ativo na porta 8000: !CHK_BACKEND_PORT!
 echo - Healthcheck /api/status ok: !CHK_BACKEND_HEALTH!
 echo - client/.env.local configurado: !CHK_FRONTEND_ENV!
 echo - Dependencias frontend prontas: !CHK_FRONTEND_DEPS!
-echo - Frontend ativo na porta 5173: !CHK_FRONTEND_PORT!
+echo - Build de frontend (preview): !CHK_FRONTEND_BUILD!
+echo - Frontend ativo na porta !FRONTEND_PORT!: !CHK_FRONTEND_PORT!
 echo.
 echo [Links]
 echo - Backend Local:  http://127.0.0.1:8000/api/status
-echo - Frontend Local: http://127.0.0.1:5173
+echo - Frontend Local: !FRONTEND_LOCAL_URL!
+if defined FRONTEND_PUBLIC_URL echo - Frontend Publico (rede local): !FRONTEND_PUBLIC_URL!
 ) > "%CHECKLIST_FILE%"
 exit /b 0
 

--- a/start_nesh_dev.bat
+++ b/start_nesh_dev.bat
@@ -133,7 +133,7 @@ if "!RUN_BACKEND!"=="1" (
     echo [3/7] Iniciando backend local...
     if /I "!BACKEND_UV_SYNC_MODE!"=="no-sync" echo [INFO] Backend iniciado com uv --no-sync para evitar erro de permissao no .venv.
     call :stop_listener_port 8000 backend
-    start "Nesh API (Dev)" cmd /k "cd /d ""%~dp0"" && !BACKEND_BOOT_CMD!"
+    start "Nesh API (Dev)" cmd /k "cd /d ""%~dp0."" && !BACKEND_BOOT_CMD!"
 
     echo.
     echo [4/7] Aguardando a API abrir na porta 8000...
@@ -191,10 +191,12 @@ if /I "!FRONTEND_MODE!"=="preview" set "CHK_FRONTEND_BUILD=OK"
 set "CHK_FRONTEND_PORT=OK"
 
 call :resolve_lan_frontend_url !FRONTEND_PORT!
-if defined FRONTEND_PUBLIC_URL (
-    start "" "!FRONTEND_PUBLIC_URL!"
-) else (
+if defined FRONTEND_LOCAL_URL (
     start "" "!FRONTEND_LOCAL_URL!"
+) else (
+    if defined FRONTEND_PUBLIC_URL (
+        start "" "!FRONTEND_PUBLIC_URL!"
+    )
 )
 
 echo.

--- a/start_nesh_dev.bat
+++ b/start_nesh_dev.bat
@@ -23,11 +23,11 @@ set "CHK_FRONTEND_BUILD=PENDENTE"
 set "CHK_FRONTEND_PORT=PENDENTE"
 
 set "FRONTEND_MODE=preview"
-set "FRONTEND_PORT=4173"
+set "FRONTEND_PORT=5173"
 set "FRONTEND_WAIT_ATTEMPTS=90"
-set "FRONTEND_BOOT_CMD=npm run build && npm run preview -- --host 0.0.0.0 --port 4173 --strictPort"
-set "FRONTEND_WINDOW_TITLE=Nesh Client (Preview)"
-set "FRONTEND_LOCAL_URL=http://127.0.0.1:4173"
+set "FRONTEND_BOOT_CMD="
+set "FRONTEND_WINDOW_TITLE="
+set "FRONTEND_LOCAL_URL="
 set "FRONTEND_PUBLIC_URL="
 
 :parse_args
@@ -41,18 +41,10 @@ if /I "%~1"=="--auth-debug" (
     set "BACKEND_BOOT_CMD=uv run Nesh.py"
 ) else if /I "%~1"=="--public-preview" (
     set "FRONTEND_MODE=preview"
-    set "FRONTEND_PORT=4173"
-    set "FRONTEND_WAIT_ATTEMPTS=90"
-    set "FRONTEND_BOOT_CMD=npm run build && npm run preview -- --host 0.0.0.0 --port 4173 --strictPort"
-    set "FRONTEND_WINDOW_TITLE=Nesh Client (Preview)"
-    set "FRONTEND_LOCAL_URL=http://127.0.0.1:4173"
+    set "FRONTEND_PORT=5173"
 ) else if /I "%~1"=="--dev-hmr" (
     set "FRONTEND_MODE=dev"
     set "FRONTEND_PORT=5173"
-    set "FRONTEND_WAIT_ATTEMPTS=50"
-    set "FRONTEND_BOOT_CMD=npm run dev"
-    set "FRONTEND_WINDOW_TITLE=Nesh Client (Dev)"
-    set "FRONTEND_LOCAL_URL=http://127.0.0.1:5173"
 ) else (
     echo [WARN] Argumento ignorado: %~1
 )
@@ -61,10 +53,18 @@ goto parse_args
 :args_done
 
 if /I "!FRONTEND_MODE!"=="preview" (
+    set "FRONTEND_WAIT_ATTEMPTS=90"
+    set "FRONTEND_WINDOW_TITLE=Nesh Client (Preview)"
+    set "FRONTEND_BOOT_CMD=npm run build && npm run preview -- --host 0.0.0.0 --port !FRONTEND_PORT! --strictPort"
     set "CHK_FRONTEND_BUILD=PENDENTE"
 ) else (
+    set "FRONTEND_WAIT_ATTEMPTS=50"
+    set "FRONTEND_WINDOW_TITLE=Nesh Client (Dev)"
+    set "FRONTEND_BOOT_CMD=npm run dev -- --host --port !FRONTEND_PORT! --strictPort"
     set "CHK_FRONTEND_BUILD=IGNORADO"
 )
+set "FRONTEND_LOCAL_URL=http://127.0.0.1:!FRONTEND_PORT!"
+set "FRONTEND_PUBLIC_URL="
 
 where node >nul 2>&1
 if errorlevel 1 (

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -82,6 +82,23 @@ async def test_get_chat_response_requires_configured_model(monkeypatch):
         await service.get_chat_response("oi")
     assert exc.value.code == "SERVICE_ERROR"
     assert exc.value.service == "AI"
+    assert "API key ausente" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_get_chat_response_reports_provider_import_failure_reason(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "k-test")
+    monkeypatch.setattr(ai_mod, "genai", None)
+    monkeypatch.setattr(ai_mod, "_genai_import_error", ModuleNotFoundError("requests.exceptions"))
+    monkeypatch.setattr(ai_mod.logger, "error", lambda *_args, **_kwargs: None)
+
+    service = ai_mod.AiService()
+
+    with pytest.raises(ServiceError) as exc:
+        await service.get_chat_response("oi")
+
+    assert "Provider import failed" in str(exc.value)
+    assert "requests.exceptions" in str(exc.value)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -57,10 +57,11 @@ def test_init_with_api_key_sets_model(monkeypatch):
 def test_init_with_api_key_handles_provider_error(monkeypatch):
     monkeypatch.setenv("GOOGLE_API_KEY", "k-test")
     monkeypatch.setattr(ai_mod, "genai", _ProviderModelError)
-    monkeypatch.setattr(ai_mod.logger, "error", lambda _msg: None)
+    monkeypatch.setattr(ai_mod.logger, "exception", lambda *_args, **_kwargs: None)
 
     service = ai_mod.AiService()
     assert service.model is None
+    assert service.ai_disabled_reason == "Provider initialization failed"
 
 
 def test_init_with_api_key_and_missing_provider_dependency(monkeypatch):
@@ -70,6 +71,7 @@ def test_init_with_api_key_and_missing_provider_dependency(monkeypatch):
 
     service = ai_mod.AiService()
     assert service.model is None
+    assert service.ai_disabled_reason == "Provider import failed"
 
 
 @pytest.mark.asyncio
@@ -98,7 +100,7 @@ async def test_get_chat_response_reports_provider_import_failure_reason(monkeypa
         await service.get_chat_response("oi")
 
     assert "Provider import failed" in str(exc.value)
-    assert "requests.exceptions" in str(exc.value)
+    assert "requests.exceptions" not in str(exc.value)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_ai_service.py
+++ b/tests/unit/test_ai_service.py
@@ -17,6 +17,26 @@ class _ErrorModel:
         raise RuntimeError("genai failure")
 
 
+class _ProviderOk:
+    @staticmethod
+    def configure(**_kwargs):
+        return None
+
+    @staticmethod
+    def GenerativeModel(_name: str):
+        return _OkModel()
+
+
+class _ProviderModelError:
+    @staticmethod
+    def configure(**_kwargs):
+        return None
+
+    @staticmethod
+    def GenerativeModel(_name: str):
+        raise RuntimeError("x")
+
+
 def test_init_without_api_key_disables_model(monkeypatch):
     monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
     monkeypatch.setattr(ai_mod.logger, "warning", lambda _msg: None)
@@ -27,8 +47,7 @@ def test_init_without_api_key_disables_model(monkeypatch):
 
 def test_init_with_api_key_sets_model(monkeypatch):
     monkeypatch.setenv("GOOGLE_API_KEY", "k-test")
-    monkeypatch.setattr(ai_mod.genai, "configure", lambda **_kwargs: None)
-    monkeypatch.setattr(ai_mod.genai, "GenerativeModel", lambda _name: _OkModel())
+    monkeypatch.setattr(ai_mod, "genai", _ProviderOk)
     monkeypatch.setattr(ai_mod.logger, "info", lambda _msg: None)
 
     service = ai_mod.AiService()
@@ -37,13 +56,17 @@ def test_init_with_api_key_sets_model(monkeypatch):
 
 def test_init_with_api_key_handles_provider_error(monkeypatch):
     monkeypatch.setenv("GOOGLE_API_KEY", "k-test")
-    monkeypatch.setattr(ai_mod.genai, "configure", lambda **_kwargs: None)
-    monkeypatch.setattr(
-        ai_mod.genai,
-        "GenerativeModel",
-        lambda _name: (_ for _ in ()).throw(RuntimeError("x")),
-    )
+    monkeypatch.setattr(ai_mod, "genai", _ProviderModelError)
     monkeypatch.setattr(ai_mod.logger, "error", lambda _msg: None)
+
+    service = ai_mod.AiService()
+    assert service.model is None
+
+
+def test_init_with_api_key_and_missing_provider_dependency(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "k-test")
+    monkeypatch.setattr(ai_mod, "genai", None)
+    monkeypatch.setattr(ai_mod.logger, "error", lambda *_args, **_kwargs: None)
 
     service = ai_mod.AiService()
     assert service.model is None


### PR DESCRIPTION
## Summary
- make start_nesh_dev.bat run frontend in production preview mode by default (build + preview)
- add dynamic frontend port/url handling and LAN URL resolution in startup script
- make backend startup resilient when optional google.generativeai dependency chain is broken
- add and adjust unit tests for ai_service optional provider behavior

## Validation
- uv run --no-sync pytest tests/unit/test_ai_service.py -q
- uv run --no-sync python -c backend import smoke test

## Notes
- this commit intentionally includes only startup/backend resilience files to avoid mixing unrelated workspace changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI options to control backend startup and frontend mode (dev hot-reload or production-style preview); backend startup behavior is now configurable.
  * Frontend preview supports LAN/public URL resolution and configurable port/URLs.

* **Bug Fixes**
  * AI service now fails gracefully when provider or API key is unavailable and surfaces a clear disabled-reason in error messages.

* **Tests**
  * Expanded tests for AI service to cover dependency import failures and uninitialized-provider scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->