### PR TITLE
[codex] fix offline notes

### DIFF
--- a/backend/presentation/routes/database_download.py
+++ b/backend/presentation/routes/database_download.py
@@ -126,6 +126,13 @@ def _enforce_secure_request(request: Request) -> None:
     )
 
 
+def _should_rate_limit_token_request(request: Request) -> bool:
+    """Keep strict limits in production, but avoid locking local dev/test sessions."""
+    return settings.server.env.lower() == "production" or not _is_local_request(
+        request
+    )
+
+
 async def _store_token(jti: str) -> None:
     """Store a one-time token (Redis preferred, memory fallback)."""
     if redis_cache.available:
@@ -209,15 +216,16 @@ async def create_download_token(request: Request):
     _enforce_secure_request(request)
     limiter_key = f"db-download:ip:{extract_client_ip(request)}"
 
-    allowed, retry_after = await _token_rate_limiter.consume(
-        key=limiter_key, limit=_TOKEN_LIMIT_PER_HOUR
-    )
-    if not allowed:
-        raise HTTPException(
-            status_code=429,
-            detail="Rate limit exceeded for database download tokens. Try again later.",
-            headers={"Retry-After": str(retry_after)},
+    if _should_rate_limit_token_request(request):
+        allowed, retry_after = await _token_rate_limiter.consume(
+            key=limiter_key, limit=_TOKEN_LIMIT_PER_HOUR
         )
+        if not allowed:
+            raise HTTPException(
+                status_code=429,
+                detail="Rate limit exceeded for database download tokens. Try again later.",
+                headers={"Retry-After": str(retry_after)},
+            )
 
     meta = _load_metadata()
     if meta is None:

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -751,6 +751,19 @@ function App() {
                                                 updateTab(tab.id, { isContentReady: true });
                                             }
                                         }}
+                                        onHydratedResults={(incomingTabId, hydratedResults) => {
+                                            if (!hydratedResults || !tab.results || !isCodeSearchResponse(tab.results)) {
+                                                return;
+                                            }
+
+                                            updateTab(incomingTabId, {
+                                                results: {
+                                                    ...tab.results,
+                                                    results: hydratedResults,
+                                                    resultados: hydratedResults,
+                                                },
+                                            });
+                                        }}
                                     />
                                 )}
                                 {/* Esconder visualmente ResultDisplay se nao estiver pronto? Nao, manter montado para o IntersectionObserver rodar,

--- a/client/src/components/ResultDisplay.tsx
+++ b/client/src/components/ResultDisplay.tsx
@@ -347,6 +347,8 @@ interface ResultDisplayProps {
     onConsumeNewSearch: (tabId: string, finalScrollTop?: number) => void;
     /** Callback to notify parent when content is ready (for coordinated loading) */
     onContentReady?: (tabId: string) => void;
+    /** Callback to sync hydrated code results back to the owning tab */
+    onHydratedResults?: (tabId: string, results: Record<string, any>) => void;
 }
 
 type MarkupRenderRefs = {
@@ -489,16 +491,6 @@ type ChapterHydrationResult = {
 
 function createFailedChapterBodiesUpdater(failedChapters: string[]) {
     return (current: string[]) => Array.from(new Set([...current, ...failedChapters]));
-}
-
-function createHydratedCodeResultsUpdater(
-    codeResults: Record<string, any>,
-    chapterBodies: ChapterBodyResponse[],
-) {
-    return (current: Record<string, any> | null) => {
-        const baseResults = current ?? codeResults;
-        return mergeHydratedChapterBodies(baseResults, chapterBodies);
-    };
 }
 
 function createRecoveredChapterBodiesUpdater(chapterBodies: ChapterBodyResponse[]) {
@@ -852,7 +844,8 @@ export const ResultDisplay = React.memo(function ResultDisplay({
     latestTextQuery,
     isNewSearch,
     onConsumeNewSearch,
-    onContentReady
+    onContentReady,
+    onHydratedResults,
 }: ResultDisplayProps) {
     const { sidebarPosition } = useSettings();
     const {
@@ -1115,13 +1108,17 @@ export const ResultDisplay = React.memo(function ResultDisplay({
 
             if (chapterBodies.length === 0) return;
 
+            const mergedResults = mergeHydratedChapterBodies(
+                renderableCodeResults ?? codeResults,
+                chapterBodies,
+            );
+
             startTransition(() => {
-                setHydratedCodeResults(
-                    createHydratedCodeResultsUpdater(codeResults, chapterBodies),
-                );
+                setHydratedCodeResults(mergedResults);
                 setFailedChapterBodies(
                     createRecoveredChapterBodiesUpdater(chapterBodies),
                 );
+                onHydratedResults?.(tabId, mergedResults);
             });
         };
 
@@ -1143,7 +1140,10 @@ export const ResultDisplay = React.memo(function ResultDisplay({
         codeResults,
         isActive,
         missingChapterBodies,
+        onHydratedResults,
+        renderableCodeResults,
         shouldHydrateCodeResults,
+        tabId,
     ]);
 
     const findAnchorIdForQuery = useCallback((resultados: any, query: string) => {

--- a/client/src/context/CrossChapterNoteContext.tsx
+++ b/client/src/context/CrossChapterNoteContext.tsx
@@ -133,5 +133,3 @@ export function useCrossChapterNotes(): CrossChapterNoteContextValue {
     }
     return context;
 }
-
-export default CrossChapterNoteContext;

--- a/client/tests/playwright/nesh-notes-hydration.spec.ts
+++ b/client/tests/playwright/nesh-notes-hydration.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test';
+
+import { installServicesMock, makeNeshChapterData } from './fixtures/service-mocks';
+
+test.beforeEach(async ({ page }) => {
+  await installServicesMock(page, {
+    unmatchedApiStrategy: 'continue',
+    neshSearchResponses: [
+      {
+        body: {
+          success: true,
+          type: 'code',
+          query: '8413',
+          normalized: null,
+          results: {
+            '84': makeNeshChapterData(
+              '84',
+              [
+                {
+                  codigo: '84.13',
+                  descricao: 'Bombas para líquidos, mesmo com dispositivo medidor.',
+                  anchor_id: 'pos-84-13',
+                },
+              ],
+              {
+                ncm_buscado: '8413',
+                posicao_alvo: '84.13',
+                conteudo: '',
+                notas_parseadas: {},
+              },
+            ),
+          },
+          total_capitulos: 1,
+        },
+      },
+    ],
+  });
+
+  await page.route('**/api/search/chapter/84/body', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        capitulo: '84',
+        conteudo: [
+          '<div id="cap-84">',
+          '  <h2>Capítulo 84</h2>',
+          '  <h3 id="pos-84-13" data-ncm="8413">84.13</h3>',
+          '  <ol class="nesh-list">',
+          '    <li>Bombas para líquidos conforme a <button type="button" class="note-ref" data-note="4">Nota 4</button>.</li>',
+          '  </ol>',
+          '</div>',
+        ].join(''),
+        notas_parseadas: {
+          '4': 'Nota 4 hidratada',
+        },
+        notas_gerais: null,
+      }),
+    });
+  });
+});
+
+test('opens hydrated local notes after chapter body enrichment', async ({ page }) => {
+  await page.goto('/');
+
+  await page.locator('#ncmInput').fill('8413');
+  await page.locator('#ncmInput').press('Enter');
+
+  const noteRef = page.locator('.note-ref[data-note="4"]').first();
+  await expect(noteRef).toBeVisible();
+
+  await noteRef.click();
+
+  const notePanel = page.locator('aside[aria-label="Nota 4 do Capítulo 84"]');
+  await expect(notePanel).toBeVisible();
+  await expect(notePanel).toContainText('Nota 4 hidratada');
+  await expect(page.getByText('Nota 4 não encontrada. Mostrando notas do capítulo.')).toHaveCount(0);
+});

--- a/client/tests/unit/App.behavior.test.tsx
+++ b/client/tests/unit/App.behavior.test.tsx
@@ -56,7 +56,8 @@ const mocks = vi.hoisted(() => {
         activeTab: null as MockTab | null,
       },
     },
-    resultDisplayCrashTabIdRef: { value: null as string | null },
+  resultDisplayCrashTabIdRef: { value: null as string | null },
+  hydratedResultsRef: { value: null as Record<string, any> | null },
   };
 });
 
@@ -150,6 +151,7 @@ vi.mock('../../src/components/ResultDisplay', () => ({
     onConsumeNewSearch,
     onPersistScroll,
     onContentReady,
+    onHydratedResults,
   }: any) => (
     (() => {
       if (mocks.resultDisplayCrashTabIdRef.value === tabId) {
@@ -174,6 +176,12 @@ vi.mock('../../src/components/ResultDisplay', () => ({
           </button>
           <button data-testid={`result-ready-${tabId}`} onClick={onContentReady}>
             ready
+          </button>
+          <button
+            data-testid={`result-hydrate-${tabId}`}
+            onClick={() => onHydratedResults?.(tabId, mocks.hydratedResultsRef.value)}
+          >
+            hydrate
           </button>
           <button data-testid={`result-close-mobile-${tabId}`} onClick={onCloseMobileMenu}>
             close-mobile
@@ -455,6 +463,7 @@ describe('App behavior', () => {
     mocks.historyRef.value = [{ term: '8517', timestamp: 1 }];
     mocks.sidebarPositionRef.value = 'right';
     mocks.resultDisplayCrashTabIdRef.value = null;
+    mocks.hydratedResultsRef.value = null;
     setTabsState([buildTab({ id: 'tab-1' })], 'tab-1');
   });
 
@@ -760,6 +769,63 @@ describe('App behavior', () => {
     } finally {
       consoleErrorSpy.mockRestore();
     }
+  });
+
+  it('opens local notes from hydrated chapter data after ResultDisplay updates the tab snapshot', async () => {
+    setTabsState([
+      buildTab({
+        id: 'tab-1',
+        ncm: '8413',
+        results: buildCodeResults({
+          '84': {
+            capitulo: '84',
+            conteudo: '',
+            notas_parseadas: {},
+            posicoes: [],
+          },
+        }, '8413'),
+      }),
+    ]);
+
+    mocks.hydratedResultsRef.value = {
+      '84': {
+        capitulo: '84',
+        conteudo: 'Conteúdo hidratado',
+        notas_parseadas: { '4': 'Nota 4 hidratada' },
+        posicoes: [],
+      },
+    };
+
+    mocks.updateTabMock.mockImplementation((tabId: string, updates: Partial<MockTab>) => {
+      const nextTabs = mocks.tabsStateRef.value.tabs.map((tab) =>
+        tab.id === tabId ? { ...tab, ...updates } : tab
+      );
+      setTabsState(nextTabs, tabId);
+    });
+
+    const { rerender } = render(<App />);
+
+    fireEvent.click(screen.getByTestId('result-hydrate-tab-1'));
+
+    await waitFor(() => {
+      expect(mocks.updateTabMock).toHaveBeenCalledWith('tab-1', {
+        results: expect.objectContaining({
+          results: mocks.hydratedResultsRef.value,
+        }),
+      });
+    });
+    rerender(<App />);
+
+    const localNoteRef = appendNoteRef('4');
+    fireEvent.click(localNoteRef);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('note-panel')).toHaveAttribute('data-open', 'true');
+    });
+    expect(screen.getByTestId('note-panel')).toHaveAttribute('data-note', '4');
+    expect(screen.getByTestId('note-panel')).toHaveAttribute('data-chapter', '84');
+    expect(screen.getByTestId('note-panel')).toHaveAttribute('data-content', 'Nota 4 hidratada');
+    expect(mocks.toastMock).not.toHaveBeenCalledWith('Nota 4 não encontrada. Mostrando notas do capítulo.');
   });
 
   it('opens smart links in background tab on middle mouse down', async () => {

--- a/client/tests/unit/CrossChapterNoteContext.test.tsx
+++ b/client/tests/unit/CrossChapterNoteContext.test.tsx
@@ -17,6 +17,12 @@ describe('CrossChapterNoteContext', () => {
         vi.clearAllMocks();
     });
 
+    it('does not expose a default export that can destabilize Fast Refresh', async () => {
+        const moduleExports = await import('../../src/context/CrossChapterNoteContext');
+
+        expect('default' in moduleExports).toBe(false);
+    });
+
     it('caches chapter notes after first fetch', async () => {
         vi.mocked(fetchChapterNotes).mockResolvedValue({
             success: true,

--- a/client/tests/unit/ResultDisplay.advanced.test.tsx
+++ b/client/tests/unit/ResultDisplay.advanced.test.tsx
@@ -646,6 +646,62 @@ describe('ResultDisplay advanced behavior', () => {
     errorSpy.mockRestore();
   });
 
+  it('notifies the parent when chapter hydration enriches code results', async () => {
+    const onHydratedResults = vi.fn();
+
+    hoisted.getNeshChapterBodyMock.mockResolvedValue({
+      success: true,
+      capitulo: '84',
+      conteudo: 'Conteudo hidratado 84',
+      notas_parseadas: { '4': 'Nota 4 hidratada' },
+      notas_gerais: 'Notas gerais hidratadas',
+      secoes: null,
+    });
+
+    render(
+      <ResultDisplay
+        data={{
+          type: 'code',
+          query: '8413',
+          resultados: {
+            '84': {
+              capitulo: '84',
+              titulo: 'Capitulo 84',
+              conteudo: '',
+              notas_parseadas: {},
+              posicoes: [{ codigo: '84.13', anchor_id: 'pos-84-13', descricao: 'Bombas' }],
+            },
+          },
+        }}
+        mobileMenuOpen={false}
+        onCloseMobileMenu={vi.fn()}
+        isActive={true}
+        tabId="tab-hydrated-callback"
+        isNewSearch={false}
+        onConsumeNewSearch={vi.fn()}
+        onHydratedResults={onHydratedResults}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(hoisted.getNeshChapterBodyMock).toHaveBeenCalledWith('84');
+    });
+
+    await waitFor(() => {
+      expect(onHydratedResults).toHaveBeenCalledWith(
+        'tab-hydrated-callback',
+        expect.objectContaining({
+          '84': expect.objectContaining({
+            capitulo: '84',
+            conteudo: 'Conteudo hidratado 84',
+            notas_parseadas: { '4': 'Nota 4 hidratada' },
+            notas_gerais: 'Notas gerais hidratadas',
+          }),
+        }),
+      );
+    });
+  });
+
   it('stops showing the chapter hydration loading state when all chapter body requests fail', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     hoisted.getNeshChapterBodyMock.mockRejectedValue(new Error('Falha 401'));

--- a/tests/unit/test_database_download_route.py
+++ b/tests/unit/test_database_download_route.py
@@ -154,7 +154,11 @@ async def test_download_token_expires_after_ttl(offline_bundle):
 
 @pytest.mark.asyncio
 async def test_download_token_rate_limit_returns_retry_after(offline_bundle):
-    request = _build_request("/api/database/token", client_host="127.0.0.1")
+    request = _build_request(
+        "/api/database/token",
+        client_host="203.0.113.10",
+        headers={"host": "fiscal.example.test"},
+    )
 
     for _ in range(database_download._TOKEN_LIMIT_PER_HOUR):
         payload = await database_download.create_download_token(request)
@@ -165,6 +169,21 @@ async def test_download_token_rate_limit_returns_retry_after(offline_bundle):
 
     assert exc.value.status_code == 429
     assert int(exc.value.headers["Retry-After"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_local_development_requests_are_not_rate_limited_for_download_tokens(
+    offline_bundle, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(database_download.settings.server, "env", "development")
+    request = _build_request("/api/database/token", client_host="127.0.0.1")
+
+    payloads = [
+        await database_download.create_download_token(request)
+        for _ in range(database_download._TOKEN_LIMIT_PER_HOUR + 2)
+    ]
+
+    assert all(payload["token"] for payload in payloads)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## O que mudou
- O `ResultDisplay` agora devolve os resultados hidratados para o `App`, então o clique em `.note-ref` usa o snapshot atualizado e não cai mais no fallback "Nota X não encontrada".
- O backend de download do banco offline não aplica mais rate limit em requests locais fora de produção, o que evita o `429` que travava a instalação no navegador de desenvolvimento.
- Adicionei regressões unitárias e um teste Playwright para cobrir o fluxo de hidratação da nota.

## Por que mudou
- No fluxo híbrido, a UI mostrava a nota hidratada, mas o handler do clique ainda lia um estado antigo do tab.
- O token do banco offline estava sendo limitado em memória mesmo em localhost, o que bloqueava a automação de instalação durante os testes.

## Validação
- `npm test -- tests/unit/App.behavior.test.tsx tests/unit/ResultDisplay.advanced.test.tsx`
- `npm run test:e2e -- tests/playwright/nesh-notes-hydration.spec.ts`
- `npm run type-check`
- `python -m pytest tests/unit/test_database_download_route.py -q`
- `python -m pytest tests/integration/test_health.py -q`
- `python -m pytest tests/integration/test_search_route_contracts.py -q`