### PR TITLE
refactor(backend): split domain services and routes

### DIFF
--- a/backend/infrastructure/repositories/nbs/__init__.py
+++ b/backend/infrastructure/repositories/nbs/__init__.py
@@ -1,0 +1,14 @@
+from .catalog import (
+    load_nbs_catalog_entries,
+    load_nbs_catalog_item_details,
+    load_nbs_catalog_tree_page,
+)
+from .explanatory import (
+    load_nbs_explanatory_entries,
+    load_nbs_explanatory_entry_details,
+)
+from .snapshot import (
+    snapshot_nbs_catalog_counts,
+    snapshot_nbs_catalog_metadata,
+)
+

--- a/backend/infrastructure/repositories/nbs/__init__.py
+++ b/backend/infrastructure/repositories/nbs/__init__.py
@@ -12,3 +12,12 @@ from .snapshot import (
     snapshot_nbs_catalog_metadata,
 )
 
+__all__ = [
+    "load_nbs_catalog_entries",
+    "load_nbs_catalog_item_details",
+    "load_nbs_catalog_tree_page",
+    "load_nbs_explanatory_entries",
+    "load_nbs_explanatory_entry_details",
+    "snapshot_nbs_catalog_counts",
+    "snapshot_nbs_catalog_metadata",
+]

--- a/backend/infrastructure/repositories/nbs/catalog.py
+++ b/backend/infrastructure/repositories/nbs/catalog.py
@@ -82,8 +82,8 @@ async def load_nbs_catalog_entries(
                 n.level,
                 n.has_nebs,
                 CASE
-                    WHEN n.code = :raw_query THEN 480
-                    WHEN n.code_clean LIKE :clean_prefix THEN 420
+                    WHEN :raw_query <> '' AND n.code = :raw_query THEN 480
+                    WHEN :clean_query <> '' AND n.code_clean LIKE :clean_prefix THEN 420
                     WHEN n.description_normalized = :normalized_query THEN 360
                     WHEN n.description_normalized LIKE :normalized_prefix THEN 320
                     ELSE 280

--- a/backend/infrastructure/repositories/nbs/catalog.py
+++ b/backend/infrastructure/repositories/nbs/catalog.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+from backend.utils.nbs_parser import clean_nbs_code, normalize_nbs_text
+
+from ..postgres_fts import build_postgres_tsquery
+from .common import (
+    load_nbs_catalog_item_ancestors,
+    load_nbs_catalog_item_by_code,
+    load_nbs_catalog_items_by_prefix,
+    load_trusted_nbs_explanatory_entry,
+    public_nbs_explanatory_entry,
+    resolve_nbs_catalog_hierarchy_root,
+    row_to_nbs_catalog_item,
+)
+from .types import (
+    NbsCatalogDetailPayload,
+    NbsCatalogItemPayload,
+    NbsCatalogTreePagePayload,
+)
+
+if TYPE_CHECKING:
+    from backend.infrastructure.repositories.nbs_repository import NbsRepository
+
+
+async def load_nbs_catalog_entries(
+    repo: "NbsRepository", query: str, *, limit: int = 50
+) -> list[NbsCatalogItemPayload]:
+    raw_query = (query or "").strip()
+    normalized_query = normalize_nbs_text(raw_query)
+    clean_query = clean_nbs_code(raw_query)
+
+    if not raw_query:
+        sql = f"""
+            SELECT code, code_clean, description, parent_code, level, has_nebs
+            FROM nbs_items
+            WHERE parent_code IS NULL
+            {" AND " + "nbs_items.tenant_id IS NULL" if repo.tenant_id is None else " AND (nbs_items.tenant_id = :tenant_id OR nbs_items.tenant_id IS NULL)"}
+            ORDER BY source_order ASC
+            LIMIT :limit
+        """
+        params = {"limit": limit}
+        if repo.tenant_id is not None:
+            params["tenant_id"] = repo.tenant_id
+        result = await repo.session.execute(text(sql), params)
+        return [row_to_nbs_catalog_item(row) for row in result]
+
+    if not clean_query and not normalized_query:
+        return []
+
+    tsquery = build_postgres_tsquery(normalized_query or raw_query)
+    tenant_predicate_n = (
+        " AND (n.tenant_id = :tenant_id OR n.tenant_id IS NULL)"
+        if repo.tenant_id is not None
+        else " AND n.tenant_id IS NULL"
+    )
+    fts_predicate = f"(n.search_vector @@ {tsquery.sql})"
+    sql = f"""
+        WITH ranked AS (
+            SELECT
+                n.code,
+                n.code_clean,
+                n.description,
+                n.parent_code,
+                n.level,
+                n.has_nebs,
+                500 AS match_score,
+                0::float AS fts_rank
+            FROM nbs_items AS n
+            WHERE :clean_query <> ''
+              AND n.code_clean = :clean_query
+              {tenant_predicate_n}
+            UNION ALL
+            SELECT
+                n.code,
+                n.code_clean,
+                n.description,
+                n.parent_code,
+                n.level,
+                n.has_nebs,
+                CASE
+                    WHEN n.code = :raw_query THEN 480
+                    WHEN n.code_clean LIKE :clean_prefix THEN 420
+                    WHEN n.description_normalized = :normalized_query THEN 360
+                    WHEN n.description_normalized LIKE :normalized_prefix THEN 320
+                    ELSE 280
+                END AS match_score,
+                0::float AS fts_rank
+            FROM nbs_items AS n
+            WHERE (
+                (:clean_query <> '' AND n.code_clean LIKE :clean_prefix)
+                OR (:raw_query <> '' AND n.code LIKE :raw_prefix)
+                OR (:normalized_query <> '' AND n.description_normalized = :normalized_query)
+                OR (:normalized_query <> '' AND n.description_normalized LIKE :normalized_prefix)
+            )
+            {tenant_predicate_n}
+            UNION ALL
+            SELECT
+                n.code,
+                n.code_clean,
+                n.description,
+                n.parent_code,
+                n.level,
+                n.has_nebs,
+                220 AS match_score,
+                ts_rank(n.search_vector, {tsquery.sql}) AS fts_rank
+            FROM nbs_items AS n
+            WHERE {fts_predicate}
+            {tenant_predicate_n}
+        )
+        SELECT DISTINCT ON (code)
+            code,
+            code_clean,
+            description,
+            parent_code,
+            level,
+            has_nebs,
+            match_score
+        FROM ranked
+        ORDER BY code, match_score DESC, fts_rank DESC
+    """
+    wrapped_sql = f"""
+        SELECT
+            code,
+            code_clean,
+            description,
+            parent_code,
+            level,
+            has_nebs
+        FROM ({sql}) AS deduped
+        ORDER BY match_score DESC, LENGTH(code_clean) ASC, code ASC
+        LIMIT :limit
+    """
+    params = {
+        "clean_query": clean_query,
+        "raw_query": raw_query,
+        "clean_prefix": f"{clean_query}%",
+        "raw_prefix": f"{raw_query}%",
+        "normalized_query": normalized_query,
+        "normalized_prefix": f"{normalized_query}%",
+        "limit": limit,
+        **tsquery.params,
+    }
+    if repo.tenant_id is not None:
+        params["tenant_id"] = repo.tenant_id
+    result = await repo.session.execute(text(wrapped_sql), params)
+    return [row_to_nbs_catalog_item(row) for row in result]
+
+
+async def load_nbs_catalog_item_details(
+    repo: "NbsRepository",
+    code: str,
+    *,
+    include_tree: bool = True,
+    page: int = 1,
+    page_size: int = 50,
+) -> NbsCatalogDetailPayload:
+    item = await load_nbs_catalog_item_by_code(repo, code)
+    ancestors = await load_nbs_catalog_item_ancestors(repo, item)
+    chapter_root = resolve_nbs_catalog_hierarchy_root(item, ancestors)
+
+    children_sql = f"""
+        SELECT code, code_clean, description, parent_code, level, has_nebs
+        FROM nbs_items
+        WHERE parent_code = :code
+        {" AND (nbs_items.tenant_id = :tenant_id OR nbs_items.tenant_id IS NULL)" if repo.tenant_id is not None else " AND nbs_items.tenant_id IS NULL"}
+        ORDER BY source_order ASC
+    """
+    children_params = {"code": item["code"]}
+    if repo.tenant_id is not None:
+        children_params["tenant_id"] = repo.tenant_id
+    child_rows = await repo.session.execute(text(children_sql), children_params)
+    tree_page = (
+        await load_nbs_catalog_tree_page(repo, chapter_root["code"], page=page, page_size=page_size)
+        if include_tree
+        else None
+    )
+    nebs_payload = public_nbs_explanatory_entry(
+        (
+            await load_trusted_nbs_explanatory_entry(
+                repo,
+                item["code"],
+                allow_aliases=False,
+            )
+        )
+    )
+
+    payload: NbsCatalogDetailPayload = {
+        "success": True,
+        "item": item,
+        "ancestors": ancestors,
+        "children": [row_to_nbs_catalog_item(row) for row in child_rows],
+        "chapter_root": chapter_root,
+        "nebs": nebs_payload,
+    }
+    if tree_page is not None:
+        payload["chapter_items"] = tree_page["items"]
+        payload["chapter_page"] = tree_page
+    return payload
+
+
+async def load_nbs_catalog_tree_page(
+    repo: "NbsRepository",
+    code: str,
+    *,
+    page: int = 1,
+    page_size: int = 50,
+) -> NbsCatalogTreePagePayload:
+    normalized_page = max(int(page or 1), 1)
+    normalized_size = min(max(int(page_size or 50), 1), 200)
+    offset = (normalized_page - 1) * normalized_size
+    count_sql = f"""
+        SELECT COUNT(*) AS total
+        FROM nbs_items
+        WHERE (code = :root_code OR code LIKE :root_prefix)
+        {" AND (nbs_items.tenant_id = :tenant_id OR nbs_items.tenant_id IS NULL)" if repo.tenant_id is not None else " AND nbs_items.tenant_id IS NULL"}
+    """
+    params = {
+        "root_code": code,
+        "root_prefix": f"{code}%",
+    }
+    if repo.tenant_id is not None:
+        params["tenant_id"] = repo.tenant_id
+    total_rows = int((await repo.session.execute(text(count_sql), params)).scalar() or 0)
+    items = await load_nbs_catalog_items_by_prefix(
+        repo,
+        code,
+        limit=normalized_size,
+        offset=offset,
+    )
+    return {
+        "items": items,
+        "page": normalized_page,
+        "page_size": normalized_size,
+        "total": total_rows,
+        "has_more": (offset + len(items)) < total_rows,
+    }

--- a/backend/infrastructure/repositories/nbs/catalog.py
+++ b/backend/infrastructure/repositories/nbs/catalog.py
@@ -174,7 +174,9 @@ async def load_nbs_catalog_item_details(
         children_params["tenant_id"] = repo.tenant_id
     child_rows = await repo.session.execute(text(children_sql), children_params)
     tree_page = (
-        await load_nbs_catalog_tree_page(repo, chapter_root["code"], page=page, page_size=page_size)
+        await load_nbs_catalog_tree_page(
+            repo, chapter_root["code"], page=page, page_size=page_size
+        )
         if include_tree
         else None
     )
@@ -224,7 +226,9 @@ async def load_nbs_catalog_tree_page(
     }
     if repo.tenant_id is not None:
         params["tenant_id"] = repo.tenant_id
-    total_rows = int((await repo.session.execute(text(count_sql), params)).scalar() or 0)
+    total_rows = int(
+        (await repo.session.execute(text(count_sql), params)).scalar() or 0
+    )
     items = await load_nbs_catalog_items_by_prefix(
         repo,
         code,

--- a/backend/infrastructure/repositories/nbs/catalog.py
+++ b/backend/infrastructure/repositories/nbs/catalog.py
@@ -81,8 +81,8 @@ async def load_nbs_catalog_entries(
                 CASE
                     WHEN :raw_query <> '' AND n.code = :raw_query THEN 480
                     WHEN :clean_query <> '' AND n.code_clean LIKE :clean_prefix THEN 420
-                    WHEN n.description_normalized = :normalized_query THEN 360
-                    WHEN n.description_normalized LIKE :normalized_prefix THEN 320
+                    WHEN :normalized_query <> '' AND n.description_normalized = :normalized_query THEN 360
+                    WHEN :normalized_query <> '' AND n.description_normalized LIKE :normalized_prefix THEN 320
                     ELSE 280
                 END AS match_score,
                 0::float AS fts_rank

--- a/backend/infrastructure/repositories/nbs/catalog.py
+++ b/backend/infrastructure/repositories/nbs/catalog.py
@@ -8,6 +8,8 @@ from backend.utils.nbs_parser import clean_nbs_code, normalize_nbs_text
 
 from ..postgres_fts import build_postgres_tsquery
 from .common import (
+    build_nbs_tenant_params,
+    build_nbs_tenant_predicate_sql,
     load_nbs_catalog_item_ancestors,
     load_nbs_catalog_item_by_code,
     load_nbs_catalog_items_by_prefix,
@@ -34,17 +36,16 @@ async def load_nbs_catalog_entries(
     clean_query = clean_nbs_code(raw_query)
 
     if not raw_query:
+        tenant_predicate = build_nbs_tenant_predicate_sql(repo.tenant_id, "nbs_items")
         sql = f"""
             SELECT code, code_clean, description, parent_code, level, has_nebs
             FROM nbs_items
             WHERE parent_code IS NULL
-            {" AND " + "nbs_items.tenant_id IS NULL" if repo.tenant_id is None else " AND (nbs_items.tenant_id = :tenant_id OR nbs_items.tenant_id IS NULL)"}
+            {tenant_predicate}
             ORDER BY source_order ASC
             LIMIT :limit
         """
-        params = {"limit": limit}
-        if repo.tenant_id is not None:
-            params["tenant_id"] = repo.tenant_id
+        params = {"limit": limit, **build_nbs_tenant_params(repo.tenant_id)}
         result = await repo.session.execute(text(sql), params)
         return [row_to_nbs_catalog_item(row) for row in result]
 
@@ -52,11 +53,7 @@ async def load_nbs_catalog_entries(
         return []
 
     tsquery = build_postgres_tsquery(normalized_query or raw_query)
-    tenant_predicate_n = (
-        " AND (n.tenant_id = :tenant_id OR n.tenant_id IS NULL)"
-        if repo.tenant_id is not None
-        else " AND n.tenant_id IS NULL"
-    )
+    tenant_predicate_n = build_nbs_tenant_predicate_sql(repo.tenant_id, "n")
     fts_predicate = f"(n.search_vector @@ {tsquery.sql})"
     sql = f"""
         WITH ranked AS (
@@ -142,10 +139,9 @@ async def load_nbs_catalog_entries(
         "normalized_query": normalized_query,
         "normalized_prefix": f"{normalized_query}%",
         "limit": limit,
+        **build_nbs_tenant_params(repo.tenant_id),
         **tsquery.params,
     }
-    if repo.tenant_id is not None:
-        params["tenant_id"] = repo.tenant_id
     result = await repo.session.execute(text(wrapped_sql), params)
     return [row_to_nbs_catalog_item(row) for row in result]
 
@@ -161,17 +157,19 @@ async def load_nbs_catalog_item_details(
     item = await load_nbs_catalog_item_by_code(repo, code)
     ancestors = await load_nbs_catalog_item_ancestors(repo, item)
     chapter_root = resolve_nbs_catalog_hierarchy_root(item, ancestors)
+    tenant_predicate = build_nbs_tenant_predicate_sql(repo.tenant_id, "nbs_items")
 
     children_sql = f"""
         SELECT code, code_clean, description, parent_code, level, has_nebs
         FROM nbs_items
         WHERE parent_code = :code
-        {" AND (nbs_items.tenant_id = :tenant_id OR nbs_items.tenant_id IS NULL)" if repo.tenant_id is not None else " AND nbs_items.tenant_id IS NULL"}
+        {tenant_predicate}
         ORDER BY source_order ASC
     """
-    children_params = {"code": item["code"]}
-    if repo.tenant_id is not None:
-        children_params["tenant_id"] = repo.tenant_id
+    children_params = {
+        "code": item["code"],
+        **build_nbs_tenant_params(repo.tenant_id),
+    }
     child_rows = await repo.session.execute(text(children_sql), children_params)
     tree_page = (
         await load_nbs_catalog_tree_page(
@@ -214,18 +212,18 @@ async def load_nbs_catalog_tree_page(
     normalized_page = max(int(page or 1), 1)
     normalized_size = min(max(int(page_size or 50), 1), 200)
     offset = (normalized_page - 1) * normalized_size
+    tenant_predicate = build_nbs_tenant_predicate_sql(repo.tenant_id, "nbs_items")
     count_sql = f"""
         SELECT COUNT(*) AS total
         FROM nbs_items
         WHERE (code = :root_code OR code LIKE :root_prefix)
-        {" AND (nbs_items.tenant_id = :tenant_id OR nbs_items.tenant_id IS NULL)" if repo.tenant_id is not None else " AND nbs_items.tenant_id IS NULL"}
+        {tenant_predicate}
     """
     params = {
         "root_code": code,
         "root_prefix": f"{code}%",
+        **build_nbs_tenant_params(repo.tenant_id),
     }
-    if repo.tenant_id is not None:
-        params["tenant_id"] = repo.tenant_id
     total_rows = int(
         (await repo.session.execute(text(count_sql), params)).scalar() or 0
     )

--- a/backend/infrastructure/repositories/nbs/common.py
+++ b/backend/infrastructure/repositories/nbs/common.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+from sqlalchemy import text
+
+from backend.config.exceptions import NotFoundError
+from backend.utils.nbs_parser import (
+    build_nbs_code_variants,
+    clean_nbs_code,
+)
+
+from .types import (
+    NBS_EXPLANATORY_PUBLIC_FIELDS,
+    NBS_REPOSITORY_MAX_ANCESTOR_DEPTH,
+    NbsCatalogItemPayload,
+    NbsExplanatoryEntryPayload,
+)
+
+if TYPE_CHECKING:
+    from backend.infrastructure.repositories.nbs_repository import NbsRepository
+
+
+class _NbsCatalogItemRow(Protocol):
+    code: str
+    code_clean: str
+    description: str
+    parent_code: str | None
+    level: int
+    has_nebs: bool | int
+
+
+class _NbsExplanatoryEntryRow(Protocol):
+    code: str
+    code_clean: str
+    title: str
+    title_normalized: str
+    body_text: str
+    body_markdown: str
+    body_normalized: str
+    section_title: str | None
+    page_start: int | None
+    page_end: int | None
+    parser_status: str
+    parse_warnings: str | None
+    source_hash: str
+    updated_at: object
+
+
+def row_to_nbs_catalog_item(row: _NbsCatalogItemRow) -> NbsCatalogItemPayload:
+    return {
+        "code": row.code,
+        "code_clean": row.code_clean,
+        "description": row.description,
+        "parent_code": row.parent_code,
+        "level": row.level,
+        "has_nebs": bool(row.has_nebs),
+    }
+
+
+def row_to_nbs_explanatory_entry(
+    row: _NbsExplanatoryEntryRow,
+) -> NbsExplanatoryEntryPayload:
+    return {
+        "code": row.code,
+        "code_clean": row.code_clean,
+        "title": row.title,
+        "title_normalized": row.title_normalized,
+        "body_text": row.body_text,
+        "body_markdown": row.body_markdown,
+        "body_normalized": row.body_normalized,
+        "section_title": row.section_title,
+        "page_start": row.page_start,
+        "page_end": row.page_end,
+        "parser_status": row.parser_status,
+        "parse_warnings": row.parse_warnings,
+        "source_hash": row.source_hash,
+        "updated_at": row.updated_at,
+    }
+
+
+def public_nbs_explanatory_entry(
+    entry: dict[str, object] | None,
+) -> dict[str, object] | None:
+    if not entry:
+        return None
+    return {field: entry[field] for field in NBS_EXPLANATORY_PUBLIC_FIELDS}
+
+
+def build_nbs_excerpt_snippet(body_text: str, limit: int = 220) -> str:
+    compact = " ".join((body_text or "").split())
+    if len(compact) <= limit:
+        return compact
+    return f"{compact[: limit - 3].rstrip()}..."
+
+
+def resolve_nbs_code_aliases(code: str) -> tuple[list[str], list[str]]:
+    aliases = list(build_nbs_code_variants((code or "").strip()))
+    clean_aliases: list[str] = []
+    for alias in aliases:
+        clean_alias = clean_nbs_code(alias)
+        if clean_alias:
+            clean_aliases.append(clean_alias)
+    return aliases, list(dict.fromkeys(clean_aliases))
+
+
+def build_nbs_tenant_predicate_sql(tenant_id: str | None, alias: str) -> str:
+    if tenant_id:
+        return f" AND ({alias}.tenant_id = :tenant_id OR {alias}.tenant_id IS NULL)"
+    return f" AND {alias}.tenant_id IS NULL"
+
+
+def build_nbs_tenant_params(tenant_id: str | None) -> dict[str, object]:
+    if tenant_id:
+        return {"tenant_id": tenant_id}
+    return {}
+
+
+def append_nbs_sql_in_clause(
+    fragments: list[str],
+    params: dict[str, object],
+    column_sql: str,
+    values: list[str],
+    prefix: str,
+) -> None:
+    if not values:
+        return
+    placeholders: list[str] = []
+    for index, value in enumerate(values):
+        key = f"{prefix}_{index}"
+        placeholders.append(f":{key}")
+        params[key] = value
+    fragments.append(f"{column_sql} IN ({', '.join(placeholders)})")
+
+
+def resolve_nbs_catalog_hierarchy_root(
+    item: NbsCatalogItemPayload, ancestors: list[NbsCatalogItemPayload]
+) -> NbsCatalogItemPayload:
+    if item["level"] <= 1:
+        return item
+
+    for ancestor in ancestors:
+        if ancestor["level"] == 1:
+            return ancestor
+
+    return ancestors[0] if ancestors else item
+
+
+async def load_nbs_catalog_item_by_code(
+    repo: "NbsRepository", code: str
+) -> NbsCatalogItemPayload:
+    raw_code = (code or "").strip()
+    aliases, clean_aliases = resolve_nbs_code_aliases(raw_code)
+    if not aliases and not clean_aliases:
+        raise NotFoundError("Serviço NBS", raw_code)
+
+    where_clauses: list[str] = []
+    params: dict[str, object] = {}
+    append_nbs_sql_in_clause(where_clauses, params, "code", aliases, "code")
+    append_nbs_sql_in_clause(
+        where_clauses, params, "code_clean", clean_aliases, "code_clean"
+    )
+    params.update(build_nbs_tenant_params(repo.tenant_id))
+    sql = f"""
+        SELECT code, code_clean, description, parent_code, level, has_nebs
+        FROM nbs_items
+        WHERE ({" OR ".join(where_clauses)})
+        {build_nbs_tenant_predicate_sql(repo.tenant_id, "nbs_items")}
+        ORDER BY LENGTH(code_clean) DESC, source_order ASC
+        LIMIT 1
+    """
+    row = (await repo.session.execute(text(sql), params)).first()
+    if row is None:
+        raise NotFoundError("Serviço NBS", raw_code)
+    return row_to_nbs_catalog_item(row)
+
+
+async def load_nbs_catalog_item_ancestors(
+    repo: "NbsRepository",
+    item: NbsCatalogItemPayload,
+) -> list[NbsCatalogItemPayload]:
+    ancestors: list[NbsCatalogItemPayload] = []
+    parent_code = item["parent_code"]
+    visited_codes = {item["code"]}
+    depth = 0
+
+    while parent_code:
+        if depth >= NBS_REPOSITORY_MAX_ANCESTOR_DEPTH or parent_code in visited_codes:
+            break
+        params = {"parent_code": parent_code, **build_nbs_tenant_params(repo.tenant_id)}
+        sql = f"""
+            SELECT code, code_clean, description, parent_code, level, has_nebs
+            FROM nbs_items
+            WHERE code = :parent_code
+            {build_nbs_tenant_predicate_sql(repo.tenant_id, "nbs_items")}
+            LIMIT 1
+        """
+        row = (await repo.session.execute(text(sql), params)).first()
+        if row is None:
+            break
+        parent_item = row_to_nbs_catalog_item(row)
+        visited_codes.add(parent_item["code"])
+        ancestors.append(parent_item)
+        parent_code = parent_item["parent_code"]
+        depth += 1
+
+    ancestors.reverse()
+    return ancestors
+
+
+async def load_nbs_catalog_items_by_prefix(
+    repo: "NbsRepository",
+    root_code: str,
+    *,
+    limit: int | None = None,
+    offset: int = 0,
+) -> list[NbsCatalogItemPayload]:
+    sql = f"""
+        SELECT code, code_clean, description, parent_code, level, has_nebs
+        FROM nbs_items
+        WHERE (code = :root_code OR code LIKE :root_prefix)
+        {build_nbs_tenant_predicate_sql(repo.tenant_id, "nbs_items")}
+        ORDER BY source_order ASC
+    """
+    params = {
+        "root_code": root_code,
+        "root_prefix": f"{root_code}%",
+        **build_nbs_tenant_params(repo.tenant_id),
+    }
+    if limit is not None:
+        sql = f"{sql}\n LIMIT :limit OFFSET :offset"
+        params["limit"] = limit
+        params["offset"] = max(offset, 0)
+    result = await repo.session.execute(text(sql), params)
+    return [row_to_nbs_catalog_item(row) for row in result]
+
+
+async def load_trusted_nbs_explanatory_entry(
+    repo: "NbsRepository",
+    code: str,
+    *,
+    allow_aliases: bool,
+) -> NbsExplanatoryEntryPayload | None:
+    where_clauses: list[str] = []
+    params: dict[str, object] = {
+        "parser_status": "trusted",
+        **build_nbs_tenant_params(repo.tenant_id),
+    }
+
+    if allow_aliases:
+        aliases, clean_aliases = resolve_nbs_code_aliases(code)
+        append_nbs_sql_in_clause(where_clauses, params, "code", aliases, "nebs_code")
+        append_nbs_sql_in_clause(
+            where_clauses,
+            params,
+            "code_clean",
+            clean_aliases,
+            "nebs_code_clean",
+        )
+    else:
+        params["code"] = code
+        where_clauses.append("code = :code")
+
+    if not where_clauses:
+        return None
+
+    sql = f"""
+        SELECT
+            code,
+            code_clean,
+            title,
+            title_normalized,
+            body_text,
+            body_markdown,
+            body_normalized,
+            section_title,
+            page_start,
+            page_end,
+            parser_status,
+            parse_warnings,
+            source_hash,
+            updated_at
+        FROM nebs_entries
+        WHERE ({" OR ".join(where_clauses)})
+          AND parser_status = :parser_status
+          {build_nbs_tenant_predicate_sql(repo.tenant_id, "nebs_entries")}
+        ORDER BY LENGTH(code_clean) DESC
+        LIMIT 1
+    """
+    row = (await repo.session.execute(text(sql), params)).first()
+    if row is None:
+        return None
+    return row_to_nbs_explanatory_entry(row)

--- a/backend/infrastructure/repositories/nbs/explanatory.py
+++ b/backend/infrastructure/repositories/nbs/explanatory.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+from backend.config.exceptions import NotFoundError
+from backend.utils.nbs_parser import clean_nbs_code, normalize_nbs_text
+
+from ..postgres_fts import build_postgres_tsquery
+from .common import (
+    load_nbs_catalog_item_ancestors,
+    load_nbs_catalog_item_by_code,
+    load_trusted_nbs_explanatory_entry,
+    public_nbs_explanatory_entry,
+)
+from .types import (
+    NbsExplanatoryDetailPayload,
+    NbsExplanatorySearchResultPayload,
+)
+
+if TYPE_CHECKING:
+    from backend.infrastructure.repositories.nbs_repository import NbsRepository
+
+
+async def load_nbs_explanatory_entries(
+    repo: "NbsRepository", query: str, *, limit: int = 50
+) -> list[NbsExplanatorySearchResultPayload]:
+    raw_query = (query or "").strip()
+    normalized_query = normalize_nbs_text(raw_query)
+    clean_query = clean_nbs_code(raw_query)
+    fts_query = build_postgres_tsquery(normalized_query or raw_query)
+
+    if not raw_query or (not clean_query and not normalized_query):
+        return []
+
+    tenant_predicate_e = (
+        " AND (e.tenant_id = :tenant_id OR e.tenant_id IS NULL)"
+        if repo.tenant_id is not None
+        else " AND e.tenant_id IS NULL"
+    )
+    fts_predicate = f"(e.search_vector @@ {fts_query.sql})"
+    sql = f"""
+        WITH ranked AS (
+            SELECT
+                e.code,
+                e.code_clean,
+                e.title,
+                e.page_start,
+                e.page_end,
+                e.section_title,
+                500 AS match_score,
+                0::float AS fts_rank
+            FROM nebs_entries AS e
+            WHERE e.parser_status = 'trusted'
+              AND :clean_query <> ''
+              AND e.code_clean = :clean_query
+              {tenant_predicate_e}
+            UNION ALL
+            SELECT
+                e.code,
+                e.code_clean,
+                e.title,
+                e.page_start,
+                e.page_end,
+                e.section_title,
+                CASE
+                    WHEN e.code = :raw_query THEN 480
+                    WHEN e.code_clean LIKE :clean_prefix THEN 430
+                    WHEN e.title_normalized = :normalized_query THEN 380
+                    WHEN e.title_normalized LIKE :normalized_prefix THEN 340
+                    ELSE 300
+                END AS match_score,
+                0::float AS fts_rank
+            FROM nebs_entries AS e
+            WHERE e.parser_status = 'trusted'
+              AND (
+                    (:clean_query <> '' AND e.code_clean LIKE :clean_prefix)
+                    OR (:raw_query <> '' AND e.code LIKE :raw_prefix)
+                    OR (:normalized_query <> '' AND e.title_normalized = :normalized_query)
+                    OR (:normalized_query <> '' AND e.title_normalized LIKE :normalized_prefix)
+              )
+              {tenant_predicate_e}
+            UNION ALL
+            SELECT
+                e.code,
+                e.code_clean,
+                e.title,
+                e.page_start,
+                e.page_end,
+                e.section_title,
+                220 AS match_score,
+                ts_rank(e.search_vector, {fts_query.sql}) AS fts_rank
+            FROM nebs_entries AS e
+            WHERE e.parser_status = 'trusted'
+              AND {fts_predicate}
+              {tenant_predicate_e}
+        )
+        SELECT DISTINCT ON (code)
+            code,
+            title,
+            page_start,
+            page_end,
+            section_title,
+            match_score,
+            fts_rank,
+            code_clean
+        FROM ranked
+        ORDER BY code, match_score DESC, fts_rank DESC
+    """
+    wrapped_sql = f"""
+        SELECT
+            code,
+            title,
+            page_start,
+            page_end,
+            section_title
+        FROM ({sql}) AS deduped
+        ORDER BY match_score DESC, fts_rank DESC, LENGTH(code_clean) ASC, page_start ASC
+        LIMIT :limit
+    """
+    params = {
+        "clean_query": clean_query,
+        "raw_query": raw_query,
+        "clean_prefix": f"{clean_query}%",
+        "raw_prefix": f"{raw_query}%",
+        "normalized_query": normalized_query,
+        "normalized_prefix": f"{normalized_query}%",
+        "limit": limit,
+        **fts_query.params,
+    }
+    if repo.tenant_id is not None:
+        params["tenant_id"] = repo.tenant_id
+    result = await repo.session.execute(text(wrapped_sql), params)
+    return [
+        {
+            "code": row.code,
+            "title": row.title,
+            "excerpt": "",
+            "page_start": row.page_start,
+            "page_end": row.page_end,
+            "section_title": row.section_title,
+        }
+        for row in result
+    ]
+
+
+async def load_nbs_explanatory_entry_details(
+    repo: "NbsRepository", code: str
+) -> NbsExplanatoryDetailPayload:
+    normalized_code = (code or "").strip()
+    item = await load_nbs_catalog_item_by_code(repo, normalized_code)
+    ancestors = await load_nbs_catalog_item_ancestors(repo, item)
+    entry = await load_trusted_nbs_explanatory_entry(
+        repo,
+        normalized_code,
+        allow_aliases=True,
+    )
+    if entry is None:
+        raise NotFoundError("Entrada NEBS", normalized_code)
+    return {
+        "success": True,
+        "item": item,
+        "ancestors": ancestors,
+        "entry": public_nbs_explanatory_entry(entry),
+    }

--- a/backend/infrastructure/repositories/nbs/snapshot.py
+++ b/backend/infrastructure/repositories/nbs/snapshot.py
@@ -11,7 +11,10 @@ if TYPE_CHECKING:
     from backend.infrastructure.repositories.nbs_repository import NbsRepository
 
 
-async def snapshot_nbs_catalog_counts(repo: "NbsRepository") -> NbsCatalogCountsSnapshot:
+async def snapshot_nbs_catalog_counts(
+    repo: "NbsRepository",
+) -> NbsCatalogCountsSnapshot:
+    tenant_params = build_nbs_tenant_params(repo.tenant_id)
     nbs_sql = (
         "SELECT COUNT(*) AS total FROM nbs_items WHERE 1=1"
         f"{build_nbs_tenant_predicate_sql(repo.tenant_id, 'nbs_items')}"
@@ -20,12 +23,8 @@ async def snapshot_nbs_catalog_counts(repo: "NbsRepository") -> NbsCatalogCounts
         "SELECT COUNT(*) AS total FROM nebs_entries WHERE parser_status = 'trusted'"
         f"{build_nbs_tenant_predicate_sql(repo.tenant_id, 'nebs_entries')}"
     )
-    nbs_result = await repo.session.execute(
-        text(nbs_sql), build_nbs_tenant_params(repo.tenant_id)
-    )
-    nebs_result = await repo.session.execute(
-        text(nebs_sql), build_nbs_tenant_params(repo.tenant_id)
-    )
+    nbs_result = await repo.session.execute(text(nbs_sql), tenant_params)
+    nebs_result = await repo.session.execute(text(nebs_sql), tenant_params)
     return {
         "nbs_items": int(nbs_result.scalar() or 0),
         "nebs_entries": int(nebs_result.scalar() or 0),
@@ -39,5 +38,7 @@ async def snapshot_nbs_catalog_metadata(
         "SELECT key, value FROM catalog_metadata WHERE 1=1"
         f"{build_nbs_tenant_predicate_sql(repo.tenant_id, 'catalog_metadata')}"
     )
-    result = await repo.session.execute(text(sql), build_nbs_tenant_params(repo.tenant_id))
+    result = await repo.session.execute(
+        text(sql), build_nbs_tenant_params(repo.tenant_id)
+    )
     return {row.key: row.value for row in result}

--- a/backend/infrastructure/repositories/nbs/snapshot.py
+++ b/backend/infrastructure/repositories/nbs/snapshot.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+from .common import build_nbs_tenant_params, build_nbs_tenant_predicate_sql
+from .types import NbsCatalogCountsSnapshot, NbsCatalogMetadataSnapshot
+
+if TYPE_CHECKING:
+    from backend.infrastructure.repositories.nbs_repository import NbsRepository
+
+
+async def snapshot_nbs_catalog_counts(repo: "NbsRepository") -> NbsCatalogCountsSnapshot:
+    nbs_sql = (
+        "SELECT COUNT(*) AS total FROM nbs_items WHERE 1=1"
+        f"{build_nbs_tenant_predicate_sql(repo.tenant_id, 'nbs_items')}"
+    )
+    nebs_sql = (
+        "SELECT COUNT(*) AS total FROM nebs_entries WHERE parser_status = 'trusted'"
+        f"{build_nbs_tenant_predicate_sql(repo.tenant_id, 'nebs_entries')}"
+    )
+    nbs_result = await repo.session.execute(
+        text(nbs_sql), build_nbs_tenant_params(repo.tenant_id)
+    )
+    nebs_result = await repo.session.execute(
+        text(nebs_sql), build_nbs_tenant_params(repo.tenant_id)
+    )
+    return {
+        "nbs_items": int(nbs_result.scalar() or 0),
+        "nebs_entries": int(nebs_result.scalar() or 0),
+    }
+
+
+async def snapshot_nbs_catalog_metadata(
+    repo: "NbsRepository",
+) -> NbsCatalogMetadataSnapshot:
+    sql = (
+        "SELECT key, value FROM catalog_metadata WHERE 1=1"
+        f"{build_nbs_tenant_predicate_sql(repo.tenant_id, 'catalog_metadata')}"
+    )
+    result = await repo.session.execute(text(sql), build_nbs_tenant_params(repo.tenant_id))
+    return {row.key: row.value for row in result}

--- a/backend/infrastructure/repositories/nbs/snapshot.py
+++ b/backend/infrastructure/repositories/nbs/snapshot.py
@@ -37,6 +37,7 @@ async def snapshot_nbs_catalog_metadata(
     sql = (
         "SELECT key, value FROM catalog_metadata WHERE 1=1"
         f"{build_nbs_tenant_predicate_sql(repo.tenant_id, 'catalog_metadata')}"
+        " ORDER BY key ASC, CASE WHEN tenant_id IS NULL THEN 0 ELSE 1 END ASC"
     )
     result = await repo.session.execute(
         text(sql), build_nbs_tenant_params(repo.tenant_id)

--- a/backend/infrastructure/repositories/nbs/types.py
+++ b/backend/infrastructure/repositories/nbs/types.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import TypeAlias, TypedDict
+
+NBS_REPOSITORY_ALLOWED_TABLES = {"nbs_items", "nebs_entries", "catalog_metadata"}
+NBS_REPOSITORY_MAX_ANCESTOR_DEPTH = 64
+NBS_REPOSITORY_DEFAULT_TREE_PAGE_SIZE = 50
+NBS_REPOSITORY_MAX_TREE_PAGE_SIZE = 200
+NBS_EXPLANATORY_PUBLIC_FIELDS = (
+    "code",
+    "code_clean",
+    "title",
+    "title_normalized",
+    "body_text",
+    "body_markdown",
+    "body_normalized",
+    "section_title",
+    "page_start",
+    "page_end",
+)
+
+
+class NbsCatalogItemPayload(TypedDict, total=False):
+    code: str
+    code_clean: str
+    description: str
+    parent_code: str | None
+    level: int
+    has_nebs: bool
+
+
+class NbsCatalogSearchPayload(TypedDict):
+    success: bool
+    query: str
+    normalized: str
+    results: list[NbsCatalogItemPayload]
+    total: int
+
+
+class NbsCatalogTreePagePayload(TypedDict):
+    items: list[NbsCatalogItemPayload]
+    page: int
+    page_size: int
+    total: int
+    has_more: bool
+
+
+class NbsCatalogDetailPayload(TypedDict, total=False):
+    success: bool
+    item: NbsCatalogItemPayload
+    ancestors: list[NbsCatalogItemPayload]
+    children: list[NbsCatalogItemPayload]
+    chapter_root: NbsCatalogItemPayload
+    chapter_items: list[NbsCatalogItemPayload]
+    chapter_page: NbsCatalogTreePagePayload
+    nebs: dict[str, object] | None
+
+
+class NbsExplanatoryEntryPayload(TypedDict, total=False):
+    code: str
+    code_clean: str
+    title: str
+    title_normalized: str
+    body_text: str
+    body_markdown: str
+    body_normalized: str
+    section_title: str
+    page_start: int
+    page_end: int
+    parser_status: str
+    parse_warnings: str | None
+    source_hash: str
+    updated_at: str
+
+
+class NbsExplanatorySearchResultPayload(TypedDict):
+    code: str
+    title: str
+    excerpt: str
+    page_start: int
+    page_end: int
+    section_title: str
+
+
+class NbsExplanatorySearchPayload(TypedDict):
+    success: bool
+    query: str
+    normalized: str
+    results: list[NbsExplanatorySearchResultPayload]
+    total: int
+
+
+class NbsExplanatoryDetailPayload(TypedDict, total=False):
+    success: bool
+    item: NbsCatalogItemPayload
+    ancestors: list[NbsCatalogItemPayload]
+    entry: NbsExplanatoryEntryPayload | None
+
+
+class NbsCatalogCountsSnapshot(TypedDict):
+    nbs_items: int
+    nebs_entries: int
+
+
+NbsCatalogMetadataSnapshot: TypeAlias = dict[str, str]

--- a/backend/infrastructure/repositories/nbs/types.py
+++ b/backend/infrastructure/repositories/nbs/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TypeAlias, TypedDict
+from typing import TypedDict
 
 NBS_REPOSITORY_ALLOWED_TABLES = {"nbs_items", "nebs_entries", "catalog_metadata"}
 NBS_REPOSITORY_MAX_ANCESTOR_DEPTH = 64
@@ -102,4 +102,4 @@ class NbsCatalogCountsSnapshot(TypedDict):
     nebs_entries: int
 
 
-NbsCatalogMetadataSnapshot: TypeAlias = dict[str, str]
+type NbsCatalogMetadataSnapshot = dict[str, str]

--- a/backend/infrastructure/repositories/nbs_repository.py
+++ b/backend/infrastructure/repositories/nbs_repository.py
@@ -1,42 +1,44 @@
-"""
-Repository para operações do catálogo NBS / NEBS em PostgreSQL.
+"""Facade do repositório NBS / NEBS.
 
-Mantém o contrato usado pelo serviço legado, mas executa consultas usando
-AsyncSession e FTS do PostgreSQL.
+A implementação concreta foi dividida em ``backend.infrastructure.repositories.nbs``
+para manter esta classe fina, com nomes canônicos claros e aliases de migração.
 """
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ...config.exceptions import NotFoundError
-from ...config.settings import settings
-from ...infrastructure.db_engine import tenant_context
-from ...utils.nbs_parser import (
-    build_nbs_code_variants,
-    clean_nbs_code,
-    normalize_nbs_text,
-)
-from .postgres_fts import build_postgres_tsquery
+from backend.config.settings import settings
+from backend.infrastructure.db_engine import tenant_context
 
-MAX_ANCESTOR_DEPTH = 64
-NEBS_PUBLIC_FIELDS = (
-    "code",
-    "code_clean",
-    "title",
-    "title_normalized",
-    "body_text",
-    "body_markdown",
-    "body_normalized",
-    "section_title",
-    "page_start",
-    "page_end",
+from .nbs.catalog import (
+    load_nbs_catalog_entries,
+    load_nbs_catalog_item_details,
+    load_nbs_catalog_tree_page,
 )
-DEFAULT_TREE_PAGE_SIZE = 50
-MAX_TREE_PAGE_SIZE = 200
+from .nbs.explanatory import (
+    load_nbs_explanatory_entries,
+    load_nbs_explanatory_entry_details,
+)
+from .nbs.snapshot import (
+    snapshot_nbs_catalog_counts,
+    snapshot_nbs_catalog_metadata,
+)
+from .nbs.types import (
+    NBS_EXPLANATORY_PUBLIC_FIELDS,
+    NBS_REPOSITORY_ALLOWED_TABLES,
+    NBS_REPOSITORY_DEFAULT_TREE_PAGE_SIZE,
+    NBS_REPOSITORY_MAX_ANCESTOR_DEPTH,
+    NBS_REPOSITORY_MAX_TREE_PAGE_SIZE,
+)
+
+MAX_ANCESTOR_DEPTH = NBS_REPOSITORY_MAX_ANCESTOR_DEPTH
+DEFAULT_TREE_PAGE_SIZE = NBS_REPOSITORY_DEFAULT_TREE_PAGE_SIZE
+MAX_TREE_PAGE_SIZE = NBS_REPOSITORY_MAX_TREE_PAGE_SIZE
+NEBS_PUBLIC_FIELDS = NBS_EXPLANATORY_PUBLIC_FIELDS
+NBS_ALLOWED_TABLES = NBS_REPOSITORY_ALLOWED_TABLES
 
 
 class NbsRepository:
@@ -47,403 +49,29 @@ class NbsRepository:
         self.is_postgres = settings.database.is_postgres
         self.tenant_id = tenant_id or tenant_context.get() or None
 
-    @staticmethod
-    def _row_to_item(row: Any) -> dict[str, Any]:
-        return {
-            "code": row.code,
-            "code_clean": row.code_clean,
-            "description": row.description,
-            "parent_code": row.parent_code,
-            "level": row.level,
-            "has_nebs": bool(row.has_nebs),
-        }
+    async def load_nbs_catalog_entries(
+        self, query: str, limit: int = 50
+    ) -> list[dict[str, object]]:
+        return await load_nbs_catalog_entries(self, query, limit=limit)
 
-    @staticmethod
-    def _row_to_nebs_entry_internal(row: Any) -> dict[str, Any]:
-        return {
-            "code": row.code,
-            "code_clean": row.code_clean,
-            "title": row.title,
-            "title_normalized": row.title_normalized,
-            "body_text": row.body_text,
-            "body_markdown": row.body_markdown,
-            "body_normalized": row.body_normalized,
-            "section_title": row.section_title,
-            "page_start": row.page_start,
-            "page_end": row.page_end,
-            "parser_status": row.parser_status,
-            "parse_warnings": row.parse_warnings,
-            "source_hash": row.source_hash,
-            "updated_at": row.updated_at,
-        }
+    async def search(self, query: str, limit: int = 50) -> list[dict[str, object]]:
+        return await self.load_nbs_catalog_entries(query, limit=limit)
 
-    @staticmethod
-    def _to_public_nebs_entry(entry: dict[str, Any] | None) -> dict[str, Any] | None:
-        if not entry:
-            return None
-        return {field: entry[field] for field in NEBS_PUBLIC_FIELDS}
-
-    @staticmethod
-    def _build_excerpt(body_text: str, limit: int = 220) -> str:
-        compact = " ".join((body_text or "").split())
-        if len(compact) <= limit:
-            return compact
-        return f"{compact[: limit - 3].rstrip()}..."
-
-    @staticmethod
-    def _resolve_code_aliases(code: str) -> tuple[list[str], list[str]]:
-        aliases = list(build_nbs_code_variants((code or "").strip()))
-        clean_aliases = [
-            clean_nbs_code(alias) for alias in aliases if clean_nbs_code(alias)
-        ]
-        return aliases, list(dict.fromkeys(clean_aliases))
-
-    def _tenant_predicate_sql(self, alias: str) -> str:
-        if self.tenant_id:
-            return f" AND ({alias}.tenant_id = :tenant_id OR {alias}.tenant_id IS NULL)"
-        return f" AND {alias}.tenant_id IS NULL"
-
-    def _tenant_params(self) -> dict[str, Any]:
-        if self.tenant_id:
-            return {"tenant_id": self.tenant_id}
-        return {}
-
-    @staticmethod
-    def _append_in_clause(
-        fragments: list[str],
-        params: dict[str, Any],
-        column_sql: str,
-        values: list[str],
-        prefix: str,
-    ) -> None:
-        if not values:
-            return
-        placeholders: list[str] = []
-        for index, value in enumerate(values):
-            key = f"{prefix}_{index}"
-            placeholders.append(f":{key}")
-            params[key] = value
-        fragments.append(f"{column_sql} IN ({', '.join(placeholders)})")
-
-    async def get_catalog_metadata(self) -> dict[str, str]:
-        sql = (
-            "SELECT key, value FROM catalog_metadata WHERE 1=1"
-            f"{self._tenant_predicate_sql('catalog_metadata')}"
+    async def load_nbs_catalog_item_details(
+        self,
+        code: str,
+        *,
+        include_tree: bool = True,
+        page: int = 1,
+        page_size: int = DEFAULT_TREE_PAGE_SIZE,
+    ) -> dict[str, object]:
+        return await load_nbs_catalog_item_details(
+            self,
+            code,
+            include_tree=include_tree,
+            page=page,
+            page_size=page_size,
         )
-        result = await self.session.execute(text(sql), self._tenant_params())
-        return {row.key: row.value for row in result}
-
-    async def get_catalog_counts(self) -> dict[str, int]:
-        nbs_sql = (
-            "SELECT COUNT(*) AS total FROM nbs_items WHERE 1=1"
-            f"{self._tenant_predicate_sql('nbs_items')}"
-        )
-        nebs_sql = (
-            "SELECT COUNT(*) AS total FROM nebs_entries WHERE parser_status = 'trusted'"
-            f"{self._tenant_predicate_sql('nebs_entries')}"
-        )
-        nbs_result = await self.session.execute(text(nbs_sql), self._tenant_params())
-        nebs_result = await self.session.execute(text(nebs_sql), self._tenant_params())
-        return {
-            "nbs_items": int(nbs_result.scalar() or 0),
-            "nebs_entries": int(nebs_result.scalar() or 0),
-        }
-
-    async def search(self, query: str, limit: int = 50) -> list[dict[str, Any]]:
-        raw_query = (query or "").strip()
-        normalized_query = normalize_nbs_text(raw_query)
-        clean_query = clean_nbs_code(raw_query)
-
-        if not raw_query:
-            sql = f"""
-                SELECT code, code_clean, description, parent_code, level, has_nebs
-                FROM nbs_items
-                WHERE parent_code IS NULL
-                {self._tenant_predicate_sql("nbs_items")}
-                ORDER BY source_order ASC
-                LIMIT :limit
-            """
-            result = await self.session.execute(
-                text(sql), {"limit": limit, **self._tenant_params()}
-            )
-            return [self._row_to_item(row) for row in result]
-
-        if not clean_query and not normalized_query:
-            return []
-
-        tsquery = build_postgres_tsquery(normalized_query or raw_query)
-        fts_predicate = f"(n.search_vector @@ {tsquery.sql})"
-        sql = f"""
-            WITH ranked AS (
-                SELECT
-                    n.code,
-                    n.code_clean,
-                    n.description,
-                    n.parent_code,
-                    n.level,
-                    n.has_nebs,
-                    500 AS match_score,
-                    0::float AS fts_rank
-                FROM nbs_items AS n
-                WHERE :clean_query <> ''
-                  AND n.code_clean = :clean_query
-                  {self._tenant_predicate_sql("n")}
-                UNION ALL
-                SELECT
-                    n.code,
-                    n.code_clean,
-                    n.description,
-                    n.parent_code,
-                    n.level,
-                    n.has_nebs,
-                    CASE
-                        WHEN n.code = :raw_query THEN 480
-                        WHEN n.code_clean LIKE :clean_prefix THEN 420
-                        WHEN n.description_normalized = :normalized_query THEN 360
-                        WHEN n.description_normalized LIKE :normalized_prefix THEN 320
-                        ELSE 280
-                    END AS match_score,
-                    0::float AS fts_rank
-                FROM nbs_items AS n
-                WHERE (
-                    (:clean_query <> '' AND n.code_clean LIKE :clean_prefix)
-                    OR (:raw_query <> '' AND n.code LIKE :raw_prefix)
-                    OR (:normalized_query <> '' AND n.description_normalized = :normalized_query)
-                    OR (:normalized_query <> '' AND n.description_normalized LIKE :normalized_prefix)
-                )
-                {self._tenant_predicate_sql("n")}
-                UNION ALL
-                SELECT
-                    n.code,
-                    n.code_clean,
-                    n.description,
-                    n.parent_code,
-                    n.level,
-                    n.has_nebs,
-                    220 AS match_score,
-                    ts_rank(n.search_vector, {tsquery.sql}) AS fts_rank
-                FROM nbs_items AS n
-                WHERE {fts_predicate}
-                {self._tenant_predicate_sql("n")}
-            )
-            SELECT DISTINCT ON (code)
-                code,
-                code_clean,
-                description,
-                parent_code,
-                level,
-                has_nebs,
-                match_score
-            FROM ranked
-            ORDER BY code, match_score DESC, fts_rank DESC
-        """
-        wrapped_sql = f"""
-            SELECT
-                code,
-                code_clean,
-                description,
-                parent_code,
-                level,
-                has_nebs
-            FROM ({sql}) AS deduped
-            ORDER BY match_score DESC, LENGTH(code_clean) ASC, code ASC
-            LIMIT :limit
-        """
-        params = {
-            "clean_query": clean_query,
-            "raw_query": raw_query,
-            "clean_prefix": f"{clean_query}%",
-            "raw_prefix": f"{raw_query}%",
-            "normalized_query": normalized_query,
-            "normalized_prefix": f"{normalized_query}%",
-            "normalized_like": f"%{normalized_query}%",
-            "limit": limit,
-            **tsquery.params,
-            **self._tenant_params(),
-        }
-        result = await self.session.execute(text(wrapped_sql), params)
-        return [self._row_to_item(row) for row in result]
-
-    async def _fetch_item_by_code(self, code: str) -> dict[str, Any]:
-        raw_code = (code or "").strip()
-        aliases, clean_aliases = self._resolve_code_aliases(raw_code)
-        if not aliases and not clean_aliases:
-            raise NotFoundError("Serviço NBS", raw_code)
-
-        where_clauses: list[str] = []
-        params: dict[str, Any] = {}
-        self._append_in_clause(where_clauses, params, "code", aliases, "code")
-        self._append_in_clause(
-            where_clauses, params, "code_clean", clean_aliases, "code_clean"
-        )
-        params.update(self._tenant_params())
-        sql = f"""
-            SELECT code, code_clean, description, parent_code, level, has_nebs
-            FROM nbs_items
-            WHERE ({" OR ".join(where_clauses)})
-            {self._tenant_predicate_sql("nbs_items")}
-            ORDER BY LENGTH(code_clean) DESC, source_order ASC
-            LIMIT 1
-        """
-        row = (await self.session.execute(text(sql), params)).first()
-        if row is None:
-            raise NotFoundError("Serviço NBS", raw_code)
-        return self._row_to_item(row)
-
-    async def _fetch_ancestors(self, item: dict[str, Any]) -> list[dict[str, Any]]:
-        ancestors: list[dict[str, Any]] = []
-        parent_code = item["parent_code"]
-        visited_codes = {item["code"]}
-        depth = 0
-
-        while parent_code:
-            if depth >= MAX_ANCESTOR_DEPTH or parent_code in visited_codes:
-                break
-            params = {"parent_code": parent_code, **self._tenant_params()}
-            sql = f"""
-                SELECT code, code_clean, description, parent_code, level, has_nebs
-                FROM nbs_items
-                WHERE code = :parent_code
-                {self._tenant_predicate_sql("nbs_items")}
-                LIMIT 1
-            """
-            row = (await self.session.execute(text(sql), params)).first()
-            if row is None:
-                break
-            parent_item = self._row_to_item(row)
-            visited_codes.add(parent_item["code"])
-            ancestors.append(parent_item)
-            parent_code = parent_item["parent_code"]
-            depth += 1
-
-        ancestors.reverse()
-        return ancestors
-
-    async def _fetch_items_by_prefix(
-        self, root_code: str, *, limit: int | None = None, offset: int = 0
-    ) -> list[dict[str, Any]]:
-        sql = f"""
-            SELECT code, code_clean, description, parent_code, level, has_nebs
-            FROM nbs_items
-            WHERE (code = :root_code OR code LIKE :root_prefix)
-            {self._tenant_predicate_sql("nbs_items")}
-            ORDER BY source_order ASC
-        """
-        params = {
-            "root_code": root_code,
-            "root_prefix": f"{root_code}%",
-            **self._tenant_params(),
-        }
-        if limit is not None:
-            sql = f"{sql}\n LIMIT :limit OFFSET :offset"
-            params["limit"] = limit
-            params["offset"] = max(offset, 0)
-        result = await self.session.execute(text(sql), params)
-        return [self._row_to_item(row) for row in result]
-
-    async def get_tree_page(
-        self, root_code: str, *, page: int = 1, page_size: int = DEFAULT_TREE_PAGE_SIZE
-    ) -> dict[str, Any]:
-        normalized_page = max(page, 1)
-        normalized_size = min(max(page_size, 1), MAX_TREE_PAGE_SIZE)
-        offset = (normalized_page - 1) * normalized_size
-
-        count_sql = f"""
-            SELECT COUNT(*) AS total
-            FROM nbs_items
-            WHERE (code = :root_code OR code LIKE :root_prefix)
-            {self._tenant_predicate_sql("nbs_items")}
-        """
-        params = {
-            "root_code": root_code,
-            "root_prefix": f"{root_code}%",
-            **self._tenant_params(),
-        }
-        total_rows = int(
-            (
-                await self.session.execute(
-                    text(count_sql),
-                    params,
-                )
-            ).scalar()
-            or 0
-        )
-        items = await self._fetch_items_by_prefix(
-            root_code,
-            limit=normalized_size,
-            offset=offset,
-        )
-        return {
-            "items": items,
-            "page": normalized_page,
-            "page_size": normalized_size,
-            "total": total_rows,
-            "has_more": (offset + len(items)) < total_rows,
-        }
-
-    @staticmethod
-    def _resolve_hierarchy_root(
-        item: dict[str, Any], ancestors: list[dict[str, Any]]
-    ) -> dict[str, Any]:
-        if item["level"] <= 1:
-            return item
-
-        for ancestor in ancestors:
-            if ancestor["level"] == 1:
-                return ancestor
-
-        return ancestors[0] if ancestors else item
-
-    async def _fetch_trusted_nebs_entry(
-        self, code: str, *, allow_aliases: bool
-    ) -> dict[str, Any] | None:
-        where_clauses: list[str] = []
-        params: dict[str, Any] = {"parser_status": "trusted", **self._tenant_params()}
-
-        if allow_aliases:
-            aliases, clean_aliases = self._resolve_code_aliases(code)
-            self._append_in_clause(where_clauses, params, "code", aliases, "nebs_code")
-            self._append_in_clause(
-                where_clauses,
-                params,
-                "code_clean",
-                clean_aliases,
-                "nebs_code_clean",
-            )
-        else:
-            params["code"] = code
-            where_clauses.append("code = :code")
-
-        if not where_clauses:
-            return None
-
-        sql = f"""
-            SELECT
-                code,
-                code_clean,
-                title,
-                title_normalized,
-                body_text,
-                body_markdown,
-                body_normalized,
-                section_title,
-                page_start,
-                page_end,
-                parser_status,
-                parse_warnings,
-                source_hash,
-                updated_at
-            FROM nebs_entries
-            WHERE ({" OR ".join(where_clauses)})
-              AND parser_status = :parser_status
-              {self._tenant_predicate_sql("nebs_entries")}
-            ORDER BY LENGTH(code_clean) DESC
-            LIMIT 1
-        """
-        row = (await self.session.execute(text(sql), params)).first()
-        if row is None:
-            return None
-        return self._row_to_nebs_entry_internal(row)
 
     async def get_item_details(
         self,
@@ -452,169 +80,73 @@ class NbsRepository:
         include_tree: bool = True,
         page: int = 1,
         page_size: int = DEFAULT_TREE_PAGE_SIZE,
-    ) -> dict[str, Any]:
-        item = await self._fetch_item_by_code(code)
-        ancestors = await self._fetch_ancestors(item)
-        chapter_root = self._resolve_hierarchy_root(item, ancestors)
-
-        children_sql = f"""
-            SELECT code, code_clean, description, parent_code, level, has_nebs
-            FROM nbs_items
-            WHERE parent_code = :code
-            {self._tenant_predicate_sql("nbs_items")}
-            ORDER BY source_order ASC
-        """
-        child_rows = await self.session.execute(
-            text(children_sql), {"code": item["code"], **self._tenant_params()}
-        )
-        tree_page = (
-            await self.get_tree_page(
-                chapter_root["code"],
-                page=page,
-                page_size=page_size,
-            )
-            if include_tree
-            else None
-        )
-        nebs_payload = self._to_public_nebs_entry(
-            await self._fetch_trusted_nebs_entry(item["code"], allow_aliases=False)
+    ) -> dict[str, object]:
+        return await self.load_nbs_catalog_item_details(
+            code,
+            include_tree=include_tree,
+            page=page,
+            page_size=page_size,
         )
 
-        payload = {
-            "success": True,
-            "item": item,
-            "ancestors": ancestors,
-            "children": [self._row_to_item(row) for row in child_rows],
-            "chapter_root": chapter_root,
-            "nebs": nebs_payload,
-        }
-        if tree_page is not None:
-            payload["chapter_items"] = tree_page["items"]
-            payload["chapter_page"] = tree_page
-        return payload
+    async def load_nbs_catalog_tree_page(
+        self,
+        code: str,
+        *,
+        page: int = 1,
+        page_size: int = DEFAULT_TREE_PAGE_SIZE,
+    ) -> dict[str, object]:
+        return await load_nbs_catalog_tree_page(
+            self,
+            code,
+            page=page,
+            page_size=page_size,
+        )
 
-    async def search_nebs(self, query: str, limit: int = 50) -> list[dict[str, Any]]:
-        raw_query = (query or "").strip()
-        normalized_query = normalize_nbs_text(raw_query)
-        clean_query = clean_nbs_code(raw_query)
-        if not raw_query or (not clean_query and not normalized_query):
-            return []
+    async def get_tree_page(
+        self,
+        code: str,
+        *,
+        page: int = 1,
+        page_size: int = DEFAULT_TREE_PAGE_SIZE,
+    ) -> dict[str, object]:
+        return await self.load_nbs_catalog_tree_page(
+            code,
+            page=page,
+            page_size=page_size,
+        )
 
-        tsquery = build_postgres_tsquery(normalized_query or raw_query)
-        fts_predicate = f"(e.search_vector @@ {tsquery.sql})"
-        sql = f"""
-            WITH ranked AS (
-                SELECT
-                    e.code,
-                    e.code_clean,
-                    e.title,
-                    e.page_start,
-                    e.page_end,
-                    e.section_title,
-                    500 AS match_score,
-                    0::float AS fts_rank
-                FROM nebs_entries AS e
-                WHERE e.parser_status = 'trusted'
-                  AND :clean_query <> ''
-                  AND e.code_clean = :clean_query
-                  {self._tenant_predicate_sql("e")}
-                UNION ALL
-                SELECT
-                    e.code,
-                    e.code_clean,
-                    e.title,
-                    e.page_start,
-                    e.page_end,
-                    e.section_title,
-                    CASE
-                        WHEN e.code = :raw_query THEN 480
-                        WHEN e.code_clean LIKE :clean_prefix THEN 430
-                        WHEN e.title_normalized = :normalized_query THEN 380
-                        WHEN e.title_normalized LIKE :normalized_prefix THEN 340
-                        ELSE 300
-                    END AS match_score,
-                    0::float AS fts_rank
-                FROM nebs_entries AS e
-                WHERE e.parser_status = 'trusted'
-                  AND (
-                        (:clean_query <> '' AND e.code_clean LIKE :clean_prefix)
-                        OR (:raw_query <> '' AND e.code LIKE :raw_prefix)
-                        OR (:normalized_query <> '' AND e.title_normalized = :normalized_query)
-                        OR (:normalized_query <> '' AND e.title_normalized LIKE :normalized_prefix)
-                  )
-                  {self._tenant_predicate_sql("e")}
-                UNION ALL
-                SELECT
-                    e.code,
-                    e.code_clean,
-                    e.title,
-                    e.page_start,
-                    e.page_end,
-                    e.section_title,
-                    220 AS match_score,
-                    ts_rank(e.search_vector, {tsquery.sql}) AS fts_rank
-                FROM nebs_entries AS e
-                WHERE e.parser_status = 'trusted'
-                  AND {fts_predicate}
-                  {self._tenant_predicate_sql("e")}
-            )
-            SELECT DISTINCT ON (code)
-                code,
-                title,
-                page_start,
-                page_end,
-                section_title,
-                match_score,
-                fts_rank,
-                code_clean
-            FROM ranked
-            ORDER BY code, match_score DESC, fts_rank DESC
-        """
-        wrapped_sql = f"""
-            SELECT
-                code,
-                title,
-                page_start,
-                page_end,
-                section_title
-            FROM ({sql}) AS deduped
-            ORDER BY match_score DESC, fts_rank DESC, LENGTH(code_clean) ASC, page_start ASC
-            LIMIT :limit
-        """
-        params = {
-            "clean_query": clean_query,
-            "raw_query": raw_query,
-            "clean_prefix": f"{clean_query}%",
-            "raw_prefix": f"{raw_query}%",
-            "normalized_query": normalized_query,
-            "normalized_prefix": f"{normalized_query}%",
-            "limit": limit,
-            **tsquery.params,
-            **self._tenant_params(),
-        }
-        result = await self.session.execute(text(wrapped_sql), params)
-        return [
-            {
-                "code": row.code,
-                "title": row.title,
-                "excerpt": "",
-                "page_start": row.page_start,
-                "page_end": row.page_end,
-                "section_title": row.section_title,
-            }
-            for row in result
-        ]
+    async def load_nbs_explanatory_entries(
+        self, query: str, limit: int = 50
+    ) -> list[dict[str, object]]:
+        return await load_nbs_explanatory_entries(self, query, limit=limit)
 
-    async def get_nebs_details(self, code: str) -> dict[str, Any]:
-        item = await self._fetch_item_by_code(code)
-        ancestors = await self._fetch_ancestors(item)
-        entry = await self._fetch_trusted_nebs_entry(code, allow_aliases=True)
-        if entry is None:
-            raise NotFoundError("Entrada NEBS", (code or "").strip())
+    async def search_nebs(self, query: str, limit: int = 50) -> list[dict[str, object]]:
+        return await self.load_nbs_explanatory_entries(query, limit=limit)
 
-        return {
-            "success": True,
-            "item": item,
-            "ancestors": ancestors,
-            "entry": self._to_public_nebs_entry(entry),
-        }
+    async def load_nbs_explanatory_entry_details(self, code: str) -> dict[str, object]:
+        return await load_nbs_explanatory_entry_details(self, code)
+
+    async def get_nebs_details(self, code: str) -> dict[str, object]:
+        return await self.load_nbs_explanatory_entry_details(code)
+
+    async def snapshot_nbs_catalog_counts(self) -> dict[str, int]:
+        return await snapshot_nbs_catalog_counts(self)
+
+    async def snapshot_nbs_catalog_metadata(self) -> dict[str, str]:
+        return await snapshot_nbs_catalog_metadata(self)
+
+    async def get_catalog_counts(self) -> dict[str, int]:
+        return await self.snapshot_nbs_catalog_counts()
+
+    async def get_catalog_metadata(self) -> dict[str, str]:
+        return await self.snapshot_nbs_catalog_metadata()
+
+
+__all__ = [
+    "DEFAULT_TREE_PAGE_SIZE",
+    "MAX_ANCESTOR_DEPTH",
+    "MAX_TREE_PAGE_SIZE",
+    "NBS_ALLOWED_TABLES",
+    "NEBS_PUBLIC_FIELDS",
+    "NbsRepository",
+]

--- a/backend/presentation/routes/search.py
+++ b/backend/presentation/routes/search.py
@@ -447,9 +447,7 @@ async def handle_global_fiscal_search_request(
     # - pre-renderizar HTML no backend (campo `markdown` mantido por compatibilidade)
     # - remover campos brutos pesados da serialização
     if response_data.get("type") == "code":
-        response_data = _apply_code_search_response_contract(
-            response_data, shape=shape
-        )
+        response_data = _apply_code_search_response_contract(response_data, shape=shape)
         return _build_code_search_response(
             request,
             response_data,

--- a/backend/presentation/routes/search.py
+++ b/backend/presentation/routes/search.py
@@ -1,6 +1,7 @@
 import gzip
 import threading
 from collections import OrderedDict
+from dataclasses import dataclass
 from time import perf_counter
 from typing import Annotated, Any, Mapping, cast
 
@@ -30,22 +31,18 @@ _code_payload_cache: OrderedDict[str, tuple[bytes, bytes]] = OrderedDict()
 _code_payload_cache_lock = threading.Lock()
 
 
-class SearchCacheRequestContext:
-    def __init__(
-        self,
-        *,
-        is_code_query: bool,
-        normalized_query: str,
-        payload_cache_key: str | None,
-        cache_headers: dict[str, str],
-    ):
-        self.is_code_query = is_code_query
-        self.normalized_query = normalized_query
-        self.payload_cache_key = payload_cache_key
-        self.cache_headers = cache_headers
+@dataclass(slots=True)
+class SearchPayloadCacheContext:
+    is_code_query: bool
+    normalized_query: str
+    payload_scope_key: str
+    cache_headers: dict[str, str]
+
+    def build_code_payload_cache_key(self, *, shape: str) -> str:
+        return f"{self.payload_scope_key}:{self.normalized_query}:{shape}"
 
 
-def _normalize_query_for_cache(ncm: str, *, is_code_query: bool) -> str:
+def _normalize_search_query_for_cache_key(ncm: str, *, is_code_query: bool) -> str:
     """Normalize query while preserving multi-code intent for cache keys."""
     raw_query = (ncm or "").strip()
     if is_code_query:
@@ -61,17 +58,6 @@ def _normalize_query_for_cache(ncm: str, *, is_code_query: bool) -> str:
             return ",".join(normalized_parts)
         return ncm_utils.clean_ncm(raw_query)
     return raw_query.lower()
-
-
-def _orjson_response(
-    content: Mapping[str, Any], headers: dict[str, str] | None = None
-) -> Response:
-    """Build a Response pre-serialized with orjson (5-10x faster than stdlib json)."""
-    body = _orjson.dumps(content)
-    resp = Response(content=body, media_type=JSON_MEDIA_TYPE)
-    if headers:
-        resp.headers.update(headers)
-    return resp
 
 
 def _code_payload_cache_get(key: str) -> tuple[bytes, bytes] | None:
@@ -120,7 +106,7 @@ def _parse_accept_encoding_token(token: str) -> tuple[str, float] | None:
     return encoding, quality
 
 
-def _accepts_gzip(request: Request) -> bool:
+def _request_accepts_gzip_encoding(request: Request) -> bool:
     accept_encoding = request.headers.get("Accept-Encoding") or ""
     gzip_q: float | None = None
     wildcard_q: float | None = None
@@ -140,7 +126,7 @@ def _accepts_gzip(request: Request) -> bool:
     return wildcard_q is not None and wildcard_q > 0
 
 
-def get_payload_cache_metrics() -> dict[str, str | float | int]:
+def snapshotSearchCodePayloadCacheMetrics() -> dict[str, str | float | int]:
     with _code_payload_cache_lock:
         current_size = len(_code_payload_cache)
     snapshot = search_payload_cache_metrics.snapshot(
@@ -161,10 +147,12 @@ def get_payload_cache_metrics() -> dict[str, str | float | int]:
     }
 
 
-def _build_cache_headers(cache_key: str, ncm_normalized: str) -> dict[str, str]:
+def _build_search_payload_cache_headers(
+    payload_scope_key: str, normalized_query: str
+) -> dict[str, str]:
     return {
         "Cache-Control": "private, max-age=3600, stale-while-revalidate=86400",
-        "ETag": weak_etag("nesh", cache_key, ncm_normalized),
+        "ETag": weak_etag("nesh", payload_scope_key, normalized_query),
         "Vary": "Authorization, X-Tenant-Id, Accept-Encoding",
     }
 
@@ -180,30 +168,28 @@ def _validate_public_search_query_input(ncm: str) -> None:
         )
 
 
-def _build_search_cache_request_context(
+def _build_search_payload_cache_context(
     request: Request,
     *,
     ncm: str,
-    shape: str,
-) -> SearchCacheRequestContext:
+) -> SearchPayloadCacheContext:
     is_code_query = ncm_utils.is_code_query(ncm)
-    ncm_normalized = _normalize_query_for_cache(ncm, is_code_query=is_code_query)
-
-    cache_key = cache_scope_key(request)
-    headers = _build_cache_headers(cache_key, ncm_normalized)
-
-    payload_key = (
-        f"{cache_key}:{ncm_normalized}:{shape}" if is_code_query else None
+    ncm_normalized = _normalize_search_query_for_cache_key(
+        ncm, is_code_query=is_code_query
     )
-    return SearchCacheRequestContext(
+
+    payload_scope_key = cache_scope_key(request)
+    headers = _build_search_payload_cache_headers(payload_scope_key, ncm_normalized)
+
+    return SearchPayloadCacheContext(
         is_code_query=is_code_query,
         normalized_query=ncm_normalized,
-        payload_cache_key=payload_key,
+        payload_scope_key=payload_scope_key,
         cache_headers=headers,
     )
 
 
-def _extract_code_results(response_data: Mapping[str, Any]) -> dict[str, Any]:
+def _extract_code_search_results(response_data: Mapping[str, Any]) -> dict[str, Any]:
     if "results" in response_data:
         raw_results = response_data.get("results")
     elif "resultados" in response_data:
@@ -213,7 +199,7 @@ def _extract_code_results(response_data: Mapping[str, Any]) -> dict[str, Any]:
     return raw_results if isinstance(raw_results, dict) else {}
 
 
-def _build_payload_response(
+def _build_search_payload_response(
     request: Request,
     payload: tuple[bytes, bytes],
     *,
@@ -222,7 +208,7 @@ def _build_payload_response(
 ) -> Response:
     raw_body, gzip_body = payload
     common_headers = {**headers, "X-Payload-Cache": cache_status}
-    if _accepts_gzip(request):
+    if _request_accepts_gzip_encoding(request):
         search_payload_cache_metrics.record_served(gzip=True)
         return Response(
             content=gzip_body,
@@ -238,13 +224,13 @@ def _build_payload_response(
 router = APIRouter()
 
 
-def _public_search_limiter_key(request: Request) -> str:
+def _build_public_search_rate_limit_key(request: Request) -> str:
     return f"search:ip:{extract_client_ip(request)}"
 
 
-async def _apply_search_rate_limit(request: Request) -> None:
+async def _enforce_public_search_rate_limit(request: Request) -> None:
     allowed, retry_after = await public_search_rate_limiter.consume(
-        key=_public_search_limiter_key(request),
+        key=_build_public_search_rate_limit_key(request),
         limit=settings.security.public_search_requests_per_minute,
     )
     if allowed:
@@ -253,6 +239,112 @@ async def _apply_search_rate_limit(request: Request) -> None:
         status_code=429,
         detail="Rate limit exceeded for public search. Try again later.",
         headers={"Retry-After": str(retry_after)},
+    )
+
+
+def _apply_code_search_response_contract(
+    response_data: dict[str, Any], *, shape: str
+) -> dict[str, Any]:
+    results = _extract_code_search_results(response_data)
+    if shape == "full":
+        response_data["markdown"] = HtmlRenderer.render_full_response(results)
+    for chapter_data in results.values():
+        if isinstance(chapter_data, dict):
+            chapter_data.pop("conteudo", None)
+    response_data["results"] = results
+    response_data["resultados"] = results  # legacy alias for backward compatibility
+    response_data["total_capitulos"] = response_data.get("total_capitulos") or len(
+        results
+    )
+    return response_data
+
+
+def _serialize_search_response_body(
+    response_data: Mapping[str, Any],
+) -> tuple[bytes, float]:
+    serialization_started = perf_counter()
+    raw_body = _orjson.dumps(response_data)
+    return raw_body, round((perf_counter() - serialization_started) * 1000, 2)
+
+
+def _compress_search_response_body(raw_body: bytes) -> tuple[bytes, float]:
+    gzip_started = perf_counter()
+    gzip_body = gzip.compress(raw_body, compresslevel=1, mtime=0)
+    return gzip_body, round((perf_counter() - gzip_started) * 1000, 2)
+
+
+def _build_code_search_response(
+    request: Request,
+    response_data: Mapping[str, Any],
+    *,
+    headers: Mapping[str, str],
+    payload_key: str,
+    shape: str,
+    request_id: str,
+) -> Response:
+    cached_payload = _code_payload_cache_get(payload_key)
+    cache_status = "HIT" if cached_payload is not None else "MISS"
+    serialization_ms = 0.0
+    gzip_ms = 0.0
+    response_bytes = 0
+    compressed_bytes = 0
+
+    if cached_payload is None:
+        raw_body, serialization_ms = _serialize_search_response_body(response_data)
+        gzip_body, gzip_ms = _compress_search_response_body(raw_body)
+        response_bytes = len(raw_body)
+        compressed_bytes = len(gzip_body)
+        cached_payload = (raw_body, gzip_body)
+        _code_payload_cache_set(payload_key, cached_payload)
+    else:
+        response_bytes = len(cached_payload[0])
+        compressed_bytes = len(cached_payload[1])
+
+    metric_headers = {
+        "X-Response-Bytes": str(response_bytes),
+        "X-Compressed-Bytes": str(compressed_bytes),
+        "X-Serialize-Ms": str(serialization_ms),
+        "X-Gzip-Ms": str(gzip_ms),
+        "X-Response-Shape": shape,
+    }
+
+    logger.info(
+        "search_request_finished request_id=%s path=%s outcome=success type=code cache_status=%s",
+        request_id,
+        request.url.path,
+        cache_status,
+    )
+    return _build_search_payload_response(
+        request,
+        cached_payload,
+        headers={**headers, **metric_headers},
+        cache_status=cache_status,
+    )
+
+
+def _build_text_search_response(
+    request: Request,
+    response_data: Mapping[str, Any],
+    *,
+    headers: Mapping[str, str],
+    shape: str,
+    request_id: str,
+) -> Response:
+    raw_body, serialization_ms = _serialize_search_response_body(response_data)
+    logger.info(
+        "search_request_finished request_id=%s path=%s outcome=success type=non_code",
+        request_id,
+        request.url.path,
+    )
+    return Response(
+        content=raw_body,
+        media_type=JSON_MEDIA_TYPE,
+        headers={
+            **headers,
+            "X-Response-Bytes": str(len(raw_body)),
+            "X-Serialize-Ms": str(serialization_ms),
+            "X-Response-Shape": shape,
+        },
     )
 
 
@@ -301,32 +393,29 @@ async def handleGlobalFiscalSearchRequest(
         ncm,
     )
 
-    await _apply_search_rate_limit(request)
+    await _enforce_public_search_rate_limit(request)
     _validate_public_search_query_input(ncm)
 
     safe_ncm = ncm.replace("\r", "\\r").replace("\n", "\\n")
     logger.debug("Busca: '%s'", safe_ncm)
 
-    context = _build_search_cache_request_context(request, ncm=ncm, shape=shape)
+    context = _build_search_payload_cache_context(request, ncm=ncm)
     is_code_query = context.is_code_query
     headers = context.cache_headers
+    code_payload_cache_key = context.build_code_payload_cache_key(shape=shape)
 
     # Hot-path short-circuit:
     # for code queries, return cached payload before running service/renderer.
-    payload_key: str | None = None
     cached_payload: tuple[bytes, bytes] | None = None
-    cache_checked = False
     if is_code_query:
-        payload_key = context.payload_cache_key
-        cached_payload = _code_payload_cache_get(payload_key)
-        cache_checked = True
+        cached_payload = _code_payload_cache_get(code_payload_cache_key)
         if cached_payload is not None:
             logger.info(
                 "search_request_finished request_id=%s path=%s outcome=cache_hit type=code",
                 request_id,
                 request.url.path,
             )
-            return _build_payload_response(
+            return _build_search_payload_response(
                 request,
                 cached_payload,
                 headers=headers,
@@ -347,104 +436,35 @@ async def handleGlobalFiscalSearchRequest(
             status_code=500, detail="Formato de resposta inválido do serviço"
         )
     response_data = cast(dict[str, Any], result)
-    serialization_ms = 0.0
-    gzip_ms = 0.0
-    response_bytes = 0
-    compressed_bytes = 0
 
     # Compatibilidade de contrato / performance:
     # - manter 'results' como chave canônica e alias legado 'resultados'
     # - pre-renderizar HTML no backend (campo `markdown` mantido por compatibilidade)
     # - remover campos brutos pesados da serialização
     if response_data.get("type") == "code":
-        results = _extract_code_results(response_data)
-        if shape == "full":
-            response_data["markdown"] = HtmlRenderer.render_full_response(results)
-        for chapter_data in results.values():
-            if isinstance(chapter_data, dict):
-                chapter_data.pop("conteudo", None)
-        response_data["results"] = results
-        response_data["resultados"] = (
-            results  # @deprecated: legacy alias, planned removal v2.0
+        response_data = _apply_code_search_response_contract(
+            response_data, shape=shape
         )
-        response_data["total_capitulos"] = response_data.get("total_capitulos") or len(
-            results
-        )
-
-    # Hot path optimization:
-    # code lookups are frequently repeated with very large payloads (~860KB+).
-    # Cache both raw and gzip bodies to avoid serializing/compressing each request.
-    # Secondary cache lookup: if `is_code_query` was False but service returned
-    # `type="code"`, we still try `_code_payload_cache_get` once using
-    # `payload_key=f"{cache_key}:{ncm_normalized}"` and guard with `cache_checked`.
-    if response_data.get("type") == "code":
-        if not cache_checked:
-            payload_key = context.payload_cache_key
-            cached_payload = _code_payload_cache_get(payload_key)
-            cache_checked = True
-
-        cache_status = "HIT" if cached_payload is not None else "MISS"
-        if cached_payload is None:
-            serialization_started = perf_counter()
-            raw_body = _orjson.dumps(response_data)
-            serialization_ms = round((perf_counter() - serialization_started) * 1000, 2)
-            gzip_started = perf_counter()
-            gzip_body = gzip.compress(raw_body, compresslevel=1, mtime=0)
-            gzip_ms = round((perf_counter() - gzip_started) * 1000, 2)
-            response_bytes = len(raw_body)
-            compressed_bytes = len(gzip_body)
-            cached_payload = (raw_body, gzip_body)
-            if payload_key is not None:
-                _code_payload_cache_set(payload_key, cached_payload)
-        else:
-            response_bytes = len(cached_payload[0])
-            compressed_bytes = len(cached_payload[1])
-        metric_headers = {
-            "X-Response-Bytes": str(response_bytes),
-            "X-Compressed-Bytes": str(compressed_bytes),
-            "X-Serialize-Ms": str(serialization_ms),
-            "X-Gzip-Ms": str(gzip_ms),
-            "X-Response-Shape": shape,
-        }
-
-        logger.info(
-            "search_request_finished request_id=%s path=%s outcome=success type=code cache_status=%s",
-            request_id,
-            request.url.path,
-            cache_status,
-        )
-        return _build_payload_response(
+        return _build_code_search_response(
             request,
-            cached_payload,
-            headers={**headers, **metric_headers},
-            cache_status=cache_status,
+            response_data,
+            headers=headers,
+            payload_key=code_payload_cache_key,
+            shape=shape,
+            request_id=request_id,
         )
 
-    logger.info(
-        "search_request_finished request_id=%s path=%s outcome=success type=non_code",
-        request_id,
-        request.url.path,
+    return _build_text_search_response(
+        request,
+        response_data,
+        headers=headers,
+        shape=shape,
+        request_id=request_id,
     )
-    serialization_started = perf_counter()
-    raw_body = _orjson.dumps(response_data)
-    serialization_ms = round((perf_counter() - serialization_started) * 1000, 2)
-    return Response(
-        content=raw_body,
-        media_type=JSON_MEDIA_TYPE,
-        headers={
-            **headers,
-            "X-Response-Bytes": str(len(raw_body)),
-            "X-Serialize-Ms": str(serialization_ms),
-            "X-Response-Shape": shape,
-        },
-    )
-
-
-search = handleGlobalFiscalSearchRequest
 
 
 @router.get("/chapters")
-async def get_chapters(request: Request):
+async def listNeshChapters(request: Request):
     """
     Lista todos os capítulos do sistema Harmonizado (NESH).
 
@@ -473,7 +493,7 @@ async def get_chapters(request: Request):
     "/nesh/chapter/{chapter}/notes",
     responses={404: {"description": "Capítulo não encontrado"}},
 )
-async def get_chapter_notes(
+async def fetchNeshChapterNotes(
     chapter: str, service: Annotated[NeshService, Depends(get_nesh_service)]
 ):
     """
@@ -494,7 +514,7 @@ async def get_chapter_notes(
     logger.info("Buscando notas do capítulo: %s", chapter)
 
     # Usa o método existente de fetch com cache
-    data = await service.fetch_chapter_data(chapter)
+    data = await service.fetchNeshChapterData(chapter)
 
     if not data:
         raise HTTPException(
@@ -513,11 +533,11 @@ async def get_chapter_notes(
     "/search/chapter/{chapter}/body",
     responses={404: {"description": "Capítulo não encontrado"}},
 )
-async def get_chapter_body(
+async def fetchNeshChapterBody(
     chapter: str,
     service: Annotated[NeshService, Depends(get_nesh_service)],
 ):
-    data = await service.fetch_chapter_data(chapter)
+    data = await service.fetchNeshChapterData(chapter)
     if not data:
         raise HTTPException(
             status_code=404, detail=f"Capítulo {chapter} não encontrado"
@@ -527,7 +547,7 @@ async def get_chapter_body(
     has_sections = any((sections.get(key) or "").strip() for key in sections)
     raw_content = data.get("content", "")
     content = (
-        service.strip_chapter_preamble(raw_content) if has_sections else raw_content
+        service.stripNeshChapterPreamble(raw_content) if has_sections else raw_content
     )
 
     return {
@@ -541,7 +561,7 @@ async def get_chapter_body(
 
 
 @router.get("/glossary")
-async def get_glossary(
+async def lookupGlossaryDefinition(
     term: Annotated[str, Query(..., description="Termo para consultar no glossário")],
 ):
     """

--- a/backend/presentation/routes/search.py
+++ b/backend/presentation/routes/search.py
@@ -126,7 +126,7 @@ def _request_accepts_gzip_encoding(request: Request) -> bool:
     return wildcard_q is not None and wildcard_q > 0
 
 
-def snapshotSearchCodePayloadCacheMetrics() -> dict[str, str | float | int]:
+def snapshot_search_code_payload_cache_metrics() -> dict[str, str | float | int]:
     with _code_payload_cache_lock:
         current_size = len(_code_payload_cache)
     snapshot = search_payload_cache_metrics.snapshot(
@@ -149,7 +149,7 @@ def snapshotSearchCodePayloadCacheMetrics() -> dict[str, str | float | int]:
 
 def get_payload_cache_metrics() -> dict[str, str | float | int]:
     """Alias compatível com a API anterior do módulo."""
-    return snapshotSearchCodePayloadCacheMetrics()
+    return snapshot_search_code_payload_cache_metrics()
 
 
 def _build_search_payload_cache_headers(
@@ -360,7 +360,7 @@ def _build_text_search_response(
         500: {"description": "Formato de resposta inválido do serviço"},
     },
 )
-async def handleGlobalFiscalSearchRequest(
+async def handle_global_fiscal_search_request(
     request: Request,
     service: Annotated[NeshService, Depends(get_nesh_service)],
     ncm: Annotated[
@@ -469,7 +469,7 @@ async def handleGlobalFiscalSearchRequest(
 
 
 @router.get("/chapters")
-async def listNeshChapters(request: Request):
+async def list_nesh_chapters(request: Request):
     """
     Lista todos os capítulos do sistema Harmonizado (NESH).
 
@@ -498,7 +498,7 @@ async def listNeshChapters(request: Request):
     "/nesh/chapter/{chapter}/notes",
     responses={404: {"description": "Capítulo não encontrado"}},
 )
-async def fetchNeshChapterNotes(
+async def fetch_nesh_chapter_notes(
     chapter: str, service: Annotated[NeshService, Depends(get_nesh_service)]
 ):
     """
@@ -538,7 +538,7 @@ async def fetchNeshChapterNotes(
     "/search/chapter/{chapter}/body",
     responses={404: {"description": "Capítulo não encontrado"}},
 )
-async def fetchNeshChapterBody(
+async def fetch_nesh_chapter_body(
     chapter: str,
     service: Annotated[NeshService, Depends(get_nesh_service)],
 ):
@@ -566,7 +566,7 @@ async def fetchNeshChapterBody(
 
 
 @router.get("/glossary")
-async def lookupGlossaryDefinition(
+async def lookup_glossary_definition(
     term: Annotated[str, Query(..., description="Termo para consultar no glossário")],
 ):
     """
@@ -579,3 +579,12 @@ async def lookupGlossaryDefinition(
         return {"found": True, "term": term, "data": definition}
     else:
         return {"found": False, "term": term}
+
+
+snapshotSearchCodePayloadCacheMetrics = snapshot_search_code_payload_cache_metrics
+handleGlobalFiscalSearchRequest = handle_global_fiscal_search_request
+handle_global_fiscal_search_request.__name__ = "handleGlobalFiscalSearchRequest"
+listNeshChapters = list_nesh_chapters
+fetchNeshChapterNotes = fetch_nesh_chapter_notes
+fetchNeshChapterBody = fetch_nesh_chapter_body
+lookupGlossaryDefinition = lookup_glossary_definition

--- a/backend/presentation/routes/search.py
+++ b/backend/presentation/routes/search.py
@@ -147,6 +147,11 @@ def snapshotSearchCodePayloadCacheMetrics() -> dict[str, str | float | int]:
     }
 
 
+def get_payload_cache_metrics() -> dict[str, str | float | int]:
+    """Alias compatível com a API anterior do módulo."""
+    return snapshotSearchCodePayloadCacheMetrics()
+
+
 def _build_search_payload_cache_headers(
     payload_scope_key: str, normalized_query: str
 ) -> dict[str, str]:

--- a/backend/presentation/routes/services.py
+++ b/backend/presentation/routes/services.py
@@ -33,18 +33,20 @@ SERVICE_DETAIL_RESPONSES = {
 }
 
 
-def _services_limiter_key(request: Request, payload: dict | None = None) -> str:
+def build_nbs_services_rate_limit_key(
+    request: Request, payload: dict | None = None
+) -> str:
     user_id = (payload or {}).get("sub")
     if isinstance(user_id, str) and user_id.strip():
         return f"services:user:{user_id.strip()}"
     return f"services:ip:{extract_client_ip(request)}"
 
 
-async def _apply_search_rate_limit(
+async def apply_nbs_services_search_rate_limit(
     request: Request, payload: dict | None = None
 ) -> None:
     allowed, retry_after = await services_search_rate_limiter.consume(
-        key=_services_limiter_key(request, payload),
+        key=build_nbs_services_rate_limit_key(request, payload),
         limit=settings.security.services_search_requests_per_minute,
     )
     if allowed:
@@ -56,11 +58,11 @@ async def _apply_search_rate_limit(
     )
 
 
-async def _apply_detail_rate_limit(
+async def apply_nbs_services_detail_rate_limit(
     request: Request, payload: dict | None = None
 ) -> None:
     allowed, retry_after = await services_detail_rate_limiter.consume(
-        key=_services_limiter_key(request, payload),
+        key=build_nbs_services_rate_limit_key(request, payload),
         limit=settings.security.services_detail_requests_per_minute,
     )
     if allowed:
@@ -72,7 +74,7 @@ async def _apply_detail_rate_limit(
     )
 
 
-def _validate_service_code(code: str) -> str:
+def normalize_nbs_service_code(code: str) -> str:
     normalized = code.strip()
     if not normalized:
         raise ValidationError("Parâmetro 'code' é obrigatório", field="code")
@@ -85,22 +87,22 @@ def _validate_service_code(code: str) -> str:
 
 
 @router.get("/nbs/search", responses=SERVICE_SEARCH_RESPONSES)
-async def search_nbs(
+async def search_nbs_catalog_entries_route(
     request: Request,
     service: Annotated[NbsService, Depends(get_nbs_service)],
     q: Annotated[str, Query(description="Código NBS ou descrição")] = "",
 ):
-    await _apply_search_rate_limit(request)
+    await apply_nbs_services_search_rate_limit(request)
     if len(q) > SearchConfig.MAX_QUERY_LENGTH:
         raise ValidationError(
             f"Query muito longa (máximo {SearchConfig.MAX_QUERY_LENGTH} caracteres)",
             field="q",
         )
-    return await service.search(q)
+    return await service.searchNbsCatalogEntries(q)
 
 
 @router.get("/nbs/{code}", responses=SERVICE_DETAIL_RESPONSES)
-async def get_nbs_detail(
+async def fetch_nbs_catalog_item_details_route(
     request: Request,
     code: str,
     service: Annotated[NbsService, Depends(get_nbs_service)],
@@ -119,9 +121,9 @@ async def get_nbs_detail(
         ),
     ] = DEFAULT_TREE_PAGE_SIZE,
 ):
-    await _apply_detail_rate_limit(request)
-    normalized_code = _validate_service_code(code)
-    return await service.get_item_details(
+    await apply_nbs_services_detail_rate_limit(request)
+    normalized_code = normalize_nbs_service_code(code)
+    return await service.fetchNbsCatalogItemDetails(
         normalized_code,
         include_tree=include_tree,
         page=page,
@@ -130,7 +132,7 @@ async def get_nbs_detail(
 
 
 @router.get("/nbs/{code}/tree", responses=SERVICE_DETAIL_RESPONSES)
-async def get_nbs_detail_tree(
+async def fetch_nbs_catalog_tree_page_route(
     request: Request,
     code: str,
     service: Annotated[NbsService, Depends(get_nbs_service)],
@@ -146,9 +148,9 @@ async def get_nbs_detail_tree(
         ),
     ] = DEFAULT_TREE_PAGE_SIZE,
 ):
-    await _apply_detail_rate_limit(request)
-    normalized_code = _validate_service_code(code)
-    return await service.get_item_tree_page(
+    await apply_nbs_services_detail_rate_limit(request)
+    normalized_code = normalize_nbs_service_code(code)
+    return await service.fetchNbsCatalogTreePage(
         normalized_code,
         page=page,
         page_size=page_size,
@@ -156,26 +158,26 @@ async def get_nbs_detail_tree(
 
 
 @router.get("/nebs/search", responses=SERVICE_SEARCH_RESPONSES)
-async def search_nebs(
+async def search_nbs_explanatory_entries_route(
     request: Request,
     service: Annotated[NbsService, Depends(get_nbs_service)],
     q: Annotated[str, Query(description="Código NEBS ou termo textual")] = "",
 ):
-    await _apply_search_rate_limit(request)
+    await apply_nbs_services_search_rate_limit(request)
     if len(q) > SearchConfig.MAX_QUERY_LENGTH:
         raise ValidationError(
             f"Query muito longa (máximo {SearchConfig.MAX_QUERY_LENGTH} caracteres)",
             field="q",
         )
-    return await service.search_nebs(q)
+    return await service.searchNbsExplanatoryEntries(q)
 
 
 @router.get("/nebs/{code}", responses=SERVICE_DETAIL_RESPONSES)
-async def get_nebs_detail(
+async def fetch_nbs_explanatory_entry_details_route(
     request: Request,
     code: str,
     service: Annotated[NbsService, Depends(get_nbs_service)],
 ):
-    await _apply_detail_rate_limit(request)
-    normalized_code = _validate_service_code(code)
-    return await service.get_nebs_details(normalized_code)
+    await apply_nbs_services_detail_rate_limit(request)
+    normalized_code = normalize_nbs_service_code(code)
+    return await service.fetchNbsExplanatoryEntryDetails(normalized_code)

--- a/backend/presentation/routes/tipi.py
+++ b/backend/presentation/routes/tipi.py
@@ -201,13 +201,27 @@ def _build_tipi_payload_cache_context(
 def _extract_tipi_code_search_results(
     response_data: Mapping[str, Any],
 ) -> dict[str, Any]:
-    if "results" in response_data:
-        raw_results = response_data.get("results")
-    elif "resultados" in response_data:
-        raw_results = response_data.get("resultados")
-    else:
-        raw_results = {}
-    return raw_results if isinstance(raw_results, dict) else {}
+    canonical_results = response_data.get("results")
+    if isinstance(canonical_results, dict):
+        return canonical_results
+
+    legacy_results = response_data.get("resultados")
+    if isinstance(legacy_results, dict):
+        return legacy_results
+
+    return {}
+
+
+def _calculate_tipi_result_total(results: Any) -> int:
+    if isinstance(results, list):
+        return len(results)
+    if isinstance(results, dict):
+        return sum(
+            len(cap_data.get("posicoes") or [])
+            for cap_data in results.values()
+            if isinstance(cap_data, dict)
+        )
+    return 0
 
 
 def _build_tipi_payload_response(
@@ -303,13 +317,9 @@ def _apply_tipi_description_highlights(result: dict[str, Any]) -> None:
 def _apply_tipi_code_search_contract(response_data: dict[str, Any]) -> dict[str, Any]:
     results = _extract_tipi_code_search_results(response_data)
     response_data["results"] = results
-    response_data["resultados"] = results
+    response_data["resultados"] = dict(results)
     if response_data.get("total") is None:
-        response_data["total"] = sum(
-            len(cap_data.get("posicoes") or [])
-            for cap_data in results.values()
-            if isinstance(cap_data, dict)
-        )
+        response_data["total"] = _calculate_tipi_result_total(results)
     if response_data.get("total_capitulos") is None:
         response_data["total_capitulos"] = len(results)
     return response_data
@@ -484,7 +494,7 @@ async def handle_tipi_search_request(
     result.setdefault("normalized", result.get("query", ""))
     result.setdefault("warning", None)
     result.setdefault("match_type", "text")
-    result.setdefault("total", len(result.get("results") or []))
+    result.setdefault("total", _calculate_tipi_result_total(result.get("results")))
     _apply_tipi_description_highlights(result)
     return _build_tipi_text_search_response(
         request,

--- a/backend/presentation/routes/tipi.py
+++ b/backend/presentation/routes/tipi.py
@@ -1,9 +1,14 @@
 import gzip
 import threading
 from collections import OrderedDict
+from dataclasses import dataclass
+from time import perf_counter
 from typing import Annotated, Any, Mapping
 
 import orjson as _orjson  # pyright: ignore[reportMissingImports]
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from starlette.responses import Response
+
 from backend.config.constants import SearchConfig, ViewMode
 from backend.config.exceptions import ValidationError
 from backend.config.logging_config import server_logger as logger
@@ -12,11 +17,10 @@ from backend.presentation.renderer import HtmlRenderer
 from backend.server.dependencies import get_tipi_service
 from backend.server.rate_limit import public_search_rate_limiter
 from backend.services.tipi_service import TipiService
+from backend.utils import ncm_utils
 from backend.utils.auth import extract_client_ip
 from backend.utils.cache import cache_scope_key, weak_etag
 from backend.utils.payload_cache_metrics import tipi_payload_cache_metrics
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from starlette.responses import Response
 
 JSON_MEDIA_TYPE = "application/json"
 _TIPI_CODE_PAYLOAD_CACHE_MAX = 16
@@ -24,14 +28,33 @@ _tipi_code_payload_cache: OrderedDict[str, tuple[bytes, bytes]] = OrderedDict()
 _tipi_code_payload_cache_lock = threading.Lock()
 
 
-def _orjson_response(
-    content: Mapping[str, Any], headers: dict[str, str] | None = None
-) -> Response:
-    body = _orjson.dumps(content)
-    resp = Response(content=body, media_type=JSON_MEDIA_TYPE)
-    if headers:
-        resp.headers.update(headers)
-    return resp
+@dataclass(slots=True)
+class TipiPayloadCacheContext:
+    is_code_query: bool
+    normalized_query: str
+    payload_scope_key: str
+    view_mode: str
+    cache_headers: dict[str, str]
+
+    def build_code_payload_cache_key(self) -> str:
+        return f"{self.payload_scope_key}:{self.view_mode}:{self.normalized_query}"
+
+
+def _normalize_tipi_query_for_cache_key(query: str, *, is_code_query: bool) -> str:
+    raw_query = (query or "").strip()
+    if is_code_query:
+        normalized_parts: list[str] = []
+        seen_parts: set[str] = set()
+        for raw_part in ncm_utils.split_ncm_query(raw_query):
+            normalized_part = ncm_utils.clean_ncm(raw_part)
+            if not normalized_part or normalized_part in seen_parts:
+                continue
+            normalized_parts.append(normalized_part)
+            seen_parts.add(normalized_part)
+        if normalized_parts:
+            return ",".join(normalized_parts)
+        return ncm_utils.clean_ncm(raw_query)
+    return raw_query.lower()
 
 
 def _tipi_payload_cache_get(key: str) -> tuple[bytes, bytes] | None:
@@ -55,52 +78,52 @@ def _tipi_payload_cache_set(key: str, payload: tuple[bytes, bytes]) -> None:
             tipi_payload_cache_metrics.record_eviction()
 
 
-def _accepts_gzip(request: Request) -> bool:
-    accept_encoding = (request.headers.get("Accept-Encoding") or "").lower()
-    return "gzip" in accept_encoding
+def _parse_tipi_accept_encoding_quality_value(raw_value: str) -> float:
+    try:
+        return float(raw_value)
+    except ValueError:
+        return 0.0
 
 
-def _apply_highlights_code_search(results: dict[str, Any]) -> None:
-    for cap_data in results.values():
-        if not isinstance(cap_data, dict):
+def _parse_tipi_accept_encoding_token(token: str) -> tuple[str, float] | None:
+    part = token.strip()
+    if not part:
+        return None
+
+    pieces = [p.strip() for p in part.split(";")]
+    encoding = pieces[0].lower()
+    quality = 1.0
+    for param in pieces[1:]:
+        key, separator, value = param.partition("=")
+        if not separator or key.strip().lower() != "q":
             continue
-        for pos in cap_data.get("posicoes") or []:
-            desc = pos.get("descricao", "")
-            if desc:
-                desc = HtmlRenderer.inject_exclusion_highlights(desc)
-                desc = HtmlRenderer.inject_unit_highlights(desc)
-                pos["descricao"] = desc
+        quality = _parse_tipi_accept_encoding_quality_value(value.strip())
+        break
+
+    return encoding, quality
 
 
-def _apply_highlights_text_search(results: list) -> None:
-    for item in results:
-        desc = item.get("descricao", "")
-        if desc:
-            desc = HtmlRenderer.inject_exclusion_highlights(desc)
-            desc = HtmlRenderer.inject_unit_highlights(desc)
-            item["descricao"] = desc
+def _request_accepts_tipi_gzip_encoding(request: Request) -> bool:
+    accept_encoding = request.headers.get("Accept-Encoding") or ""
+    gzip_q: float | None = None
+    wildcard_q: float | None = None
+
+    for token in accept_encoding.split(","):
+        parsed = _parse_tipi_accept_encoding_token(token)
+        if parsed is None:
+            continue
+        encoding, q_value = parsed
+        if encoding == "gzip":
+            gzip_q = q_value
+        elif encoding == "*":
+            wildcard_q = q_value
+
+    if gzip_q is not None:
+        return gzip_q > 0
+    return wildcard_q is not None and wildcard_q > 0
 
 
-def _apply_highlights_to_descriptions(result: dict[str, Any]) -> None:
-    """Aplica highlights de unidades e exclusões antes de serializar.
-
-    Percorre as duas estruturas possíveis de resposta:
-    - code search: result["results"][cap]["posicoes"][i]["descricao"]
-    - text search: result["results"][i]["descricao"]
-    """
-    results = result.get("results") or result.get("resultados")
-    if not results:
-        return
-
-    if isinstance(results, dict):
-        # Code search: results é {cap: {posicoes: [...]}}
-        _apply_highlights_code_search(results)
-    elif isinstance(results, list):
-        # Text search: results é [{descricao: ...}, ...]
-        _apply_highlights_text_search(results)
-
-
-def get_payload_cache_metrics() -> dict[str, str | float | int]:
+def snapshotTipiCodePayloadCacheMetrics() -> dict[str, str | float | int]:
     snapshot = tipi_payload_cache_metrics.snapshot(
         current_size=len(_tipi_code_payload_cache),
         max_size=_TIPI_CODE_PAYLOAD_CACHE_MAX,
@@ -119,19 +142,98 @@ def get_payload_cache_metrics() -> dict[str, str | float | int]:
     }
 
 
+def _build_tipi_payload_cache_headers(
+    payload_scope_key: str, normalized_query: str, view_mode: str
+) -> dict[str, str]:
+    return {
+        "Cache-Control": "private, max-age=3600, stale-while-revalidate=86400",
+        "ETag": weak_etag("tipi", payload_scope_key, normalized_query, view_mode),
+        "Vary": "Authorization, X-Tenant-Id, Accept-Encoding",
+    }
+
+
+def _validate_tipi_search_query_input(ncm: str) -> None:
+    if not ncm:
+        raise ValidationError("Parâmetro 'ncm' é obrigatório", field="ncm")
+
+    if len(ncm) > SearchConfig.MAX_QUERY_LENGTH:
+        raise ValidationError(
+            f"Query muito longa (máximo {SearchConfig.MAX_QUERY_LENGTH} caracteres)",
+            field="ncm",
+        )
+
+
+def _build_tipi_payload_cache_context(
+    request: Request,
+    *,
+    ncm: str,
+    view_mode: ViewMode,
+) -> TipiPayloadCacheContext:
+    is_code_query = ncm_utils.is_code_query(ncm)
+    normalized_query = _normalize_tipi_query_for_cache_key(
+        ncm, is_code_query=is_code_query
+    )
+    payload_scope_key = cache_scope_key(request)
+    headers = _build_tipi_payload_cache_headers(
+        payload_scope_key, normalized_query, view_mode.value
+    )
+    return TipiPayloadCacheContext(
+        is_code_query=is_code_query,
+        normalized_query=normalized_query,
+        payload_scope_key=payload_scope_key,
+        view_mode=view_mode.value,
+        cache_headers=headers,
+    )
+
+
+def _extract_tipi_code_search_results(response_data: Mapping[str, Any]) -> dict[str, Any]:
+    if "results" in response_data:
+        raw_results = response_data.get("results")
+    elif "resultados" in response_data:
+        raw_results = response_data.get("resultados")
+    else:
+        raw_results = {}
+    return raw_results if isinstance(raw_results, dict) else {}
+
+
+def _build_tipi_payload_response(
+    request: Request,
+    payload: tuple[bytes, bytes],
+    *,
+    headers: Mapping[str, str],
+    cache_status: str,
+) -> Response:
+    raw_body, gzip_body = payload
+    common_headers = {**headers, "X-Payload-Cache": cache_status}
+    if _request_accepts_tipi_gzip_encoding(request):
+        tipi_payload_cache_metrics.record_served(gzip=True)
+        return Response(
+            content=gzip_body,
+            media_type=JSON_MEDIA_TYPE,
+            headers={**common_headers, "Content-Encoding": "gzip"},
+        )
+    tipi_payload_cache_metrics.record_served(gzip=False)
+    return Response(
+        content=raw_body,
+        media_type=JSON_MEDIA_TYPE,
+        headers=common_headers,
+    )
+
+
 router = APIRouter()
 TIPI_SEARCH_RESPONSES = {
     429: {"description": "Limite de requisições para busca pública excedido."},
+    500: {"description": "Formato de resposta inválido do serviço"},
 }
 
 
-def _public_search_limiter_key(request: Request) -> str:
-    return f"search:ip:{extract_client_ip(request)}"
+def _build_public_tipi_search_rate_limit_key(request: Request) -> str:
+    return f"tipi:ip:{extract_client_ip(request)}"
 
 
-async def _apply_search_rate_limit(request: Request) -> None:
+async def _enforce_public_tipi_search_rate_limit(request: Request) -> None:
     allowed, retry_after = await public_search_rate_limiter.consume(
-        key=_public_search_limiter_key(request),
+        key=_build_public_tipi_search_rate_limit_key(request),
         limit=settings.security.public_search_requests_per_minute,
     )
     if allowed:
@@ -143,8 +245,132 @@ async def _apply_search_rate_limit(request: Request) -> None:
     )
 
 
+def _apply_tipi_code_description_highlights(results: dict[str, Any]) -> None:
+    for cap_data in results.values():
+        if not isinstance(cap_data, dict):
+            continue
+        for pos in cap_data.get("posicoes") or []:
+            desc = pos.get("descricao", "")
+            if desc:
+                desc = HtmlRenderer.inject_exclusion_highlights(desc)
+                desc = HtmlRenderer.inject_unit_highlights(desc)
+                pos["descricao"] = desc
+
+
+def _apply_tipi_text_description_highlights(results: list) -> None:
+    for item in results:
+        desc = item.get("descricao", "")
+        if desc:
+            desc = HtmlRenderer.inject_exclusion_highlights(desc)
+            desc = HtmlRenderer.inject_unit_highlights(desc)
+            item["descricao"] = desc
+
+
+def _apply_tipi_description_highlights(result: dict[str, Any]) -> None:
+    """Aplica highlights de unidades e exclusões antes de serializar.
+
+    Percorre as duas estruturas possíveis de resposta:
+    - code search: result["results"][cap]["posicoes"][i]["descricao"]
+    - text search: result["results"][i]["descricao"]
+    """
+    results = result.get("results") or result.get("resultados")
+    if not results:
+        return
+
+    if isinstance(results, dict):
+        _apply_tipi_code_description_highlights(results)
+    elif isinstance(results, list):
+        _apply_tipi_text_description_highlights(results)
+
+
+def _apply_tipi_code_search_contract(
+    response_data: dict[str, Any]
+) -> dict[str, Any]:
+    results = _extract_tipi_code_search_results(response_data)
+    response_data["results"] = results
+    response_data["resultados"] = results
+    response_data["total"] = response_data.get("total") or len(results)
+    response_data["total_capitulos"] = response_data.get("total_capitulos") or len(
+        results
+    )
+    return response_data
+
+
+def _serialize_tipi_response_body(
+    response_data: Mapping[str, Any],
+) -> tuple[bytes, float]:
+    serialization_started = perf_counter()
+    raw_body = _orjson.dumps(response_data)
+    return raw_body, round((perf_counter() - serialization_started) * 1000, 2)
+
+
+def _compress_tipi_response_body(raw_body: bytes) -> tuple[bytes, float]:
+    gzip_started = perf_counter()
+    gzip_body = gzip.compress(raw_body, compresslevel=1, mtime=0)
+    return gzip_body, round((perf_counter() - gzip_started) * 1000, 2)
+
+
+def _build_tipi_code_search_response(
+    request: Request,
+    response_data: Mapping[str, Any],
+    *,
+    headers: Mapping[str, str],
+    payload_key: str,
+    request_id: str,
+) -> Response:
+    raw_body, serialization_ms = _serialize_tipi_response_body(response_data)
+    gzip_body, gzip_ms = _compress_tipi_response_body(raw_body)
+    response_bytes = len(raw_body)
+    compressed_bytes = len(gzip_body)
+    cached_payload = (raw_body, gzip_body)
+    _tipi_payload_cache_set(payload_key, cached_payload)
+
+    metric_headers = {
+        "X-Response-Bytes": str(response_bytes),
+        "X-Compressed-Bytes": str(compressed_bytes),
+        "X-Serialize-Ms": str(serialization_ms),
+        "X-Gzip-Ms": str(gzip_ms),
+    }
+
+    logger.info(
+        "tipi_request_finished request_id=%s path=%s outcome=success type=code cache_status=MISS",
+        request_id,
+        request.url.path,
+    )
+    return _build_tipi_payload_response(
+        request,
+        cached_payload,
+        headers={**headers, **metric_headers},
+        cache_status="MISS",
+    )
+
+
+def _build_tipi_text_search_response(
+    request: Request,
+    response_data: Mapping[str, Any],
+    *,
+    headers: Mapping[str, str],
+    request_id: str,
+) -> Response:
+    raw_body, serialization_ms = _serialize_tipi_response_body(response_data)
+    logger.info(
+        "tipi_request_finished request_id=%s path=%s outcome=success type=non_code",
+        request_id,
+        request.url.path,
+    )
+    return Response(
+        content=raw_body,
+        media_type=JSON_MEDIA_TYPE,
+        headers={
+            **headers,
+            "X-Response-Bytes": str(len(raw_body)),
+            "X-Serialize-Ms": str(serialization_ms),
+        },
+    )
+
+
 @router.get("/search", responses=TIPI_SEARCH_RESPONSES)
-async def tipi_search(
+async def handleTipiSearchRequest(
     request: Request,
     tipi_service: Annotated[TipiService, Depends(get_tipi_service)],
     ncm: Annotated[
@@ -174,79 +400,87 @@ async def tipi_search(
     Raises:
         ValidationError: Se a query estiver vazia ou for muito longa.
     """
-    if not ncm:
-        raise ValidationError("Parâmetro 'ncm' é obrigatório", field="ncm")
+    _validate_tipi_search_query_input(ncm)
+    await _enforce_public_tipi_search_rate_limit(request)
 
-    if len(ncm) > SearchConfig.MAX_QUERY_LENGTH:
-        raise ValidationError(
-            f"Query muito longa (máximo {SearchConfig.MAX_QUERY_LENGTH} caracteres)",
-            field="ncm",
-        )
-
-    await _apply_search_rate_limit(request)
-
+    request_id = request.headers.get("x-request-id") or "unknown"
     safe_ncm = ncm.replace("\r", "\\r").replace("\n", "\\n")
     logger.debug("TIPI Busca: '%s' (mode=%s)", safe_ncm, view_mode)
 
-    # Detectar tipo de busca - Exceções propagam para o handler global
-    if tipi_service.is_code_query(ncm):
-        result = await tipi_service.search_by_code(ncm, view_mode=view_mode.value)
+    context = _build_tipi_payload_cache_context(
+        request,
+        ncm=ncm,
+        view_mode=view_mode,
+    )
+    headers = context.cache_headers
 
-        # Compatibilidade de contrato:
-        # manter 'results' como canônica e preservar alias legado 'resultados'.
-        results = result.get("results") or result.get("resultados") or {}
-        result["results"] = results
-        result["resultados"] = results
-        result["total_capitulos"] = result.get("total_capitulos") or len(results)
-    else:
-        result = await tipi_service.search_text(ncm)
-        result.setdefault("normalized", result.get("query", ""))
-        result.setdefault("warning", None)
-        result.setdefault("match_type", "text")
-
-    # Aplicar highlights de unidades e exclusões nas descrições antes de serializar
-    _apply_highlights_to_descriptions(result)
-
-    cache_key = cache_scope_key(request)
-    headers = {
-        "Cache-Control": "private, max-age=3600, stale-while-revalidate=86400",
-        "ETag": weak_etag("tipi", cache_key, ncm, view_mode.value),
-        "Vary": "Authorization, X-Tenant-Id, Accept-Encoding",
-    }
-
-    # Same strategy used in /api/search:
-    # keep pre-serialized payloads for hot TIPI code lookups.
-    if result.get("type") == "code":
-        payload_key = f"{cache_key}:{view_mode.value}:{ncm}"
-        cache_status = "MISS"
+    if context.is_code_query:
+        payload_key = context.build_code_payload_cache_key()
         cached_payload = _tipi_payload_cache_get(payload_key)
-        if cached_payload is None:
-            raw_body = _orjson.dumps(result)
-            gzip_body = gzip.compress(raw_body, compresslevel=1, mtime=0)
-            cached_payload = (raw_body, gzip_body)
-            _tipi_payload_cache_set(payload_key, cached_payload)
-        else:
-            cache_status = "HIT"
-
-        raw_body, gzip_body = cached_payload
-        common_headers = {**headers, "X-Payload-Cache": cache_status}
-        if _accepts_gzip(request):
-            tipi_payload_cache_metrics.record_served(gzip=True)
-            return Response(
-                content=gzip_body,
-                media_type=JSON_MEDIA_TYPE,
-                headers={**common_headers, "Content-Encoding": "gzip"},
+        if cached_payload is not None:
+            logger.info(
+                "tipi_request_finished request_id=%s path=%s outcome=cache_hit type=code",
+                request_id,
+                request.url.path,
             )
-        tipi_payload_cache_metrics.record_served(gzip=False)
-        return Response(
-            content=raw_body, media_type=JSON_MEDIA_TYPE, headers=common_headers
+            return _build_tipi_payload_response(
+                request,
+                cached_payload,
+                headers=headers,
+                cache_status="HIT",
+            )
+
+        result = await tipi_service.searchTipiByNcmCode(
+            ncm, view_mode=view_mode.value
+        )
+        if not isinstance(result, dict):
+            logger.error(
+                "tipi_request_failed request_id=%s path=%s reason=invalid_service_response ncm=%s type=%s",
+                request_id,
+                request.url.path,
+                safe_ncm,
+                type(result).__name__,
+            )
+            raise HTTPException(
+                status_code=500, detail="Formato de resposta inválido do serviço"
+            )
+
+        result = _apply_tipi_code_search_contract(result)
+        _apply_tipi_description_highlights(result)
+        return _build_tipi_code_search_response(
+            request,
+            result,
+            headers=headers,
+            payload_key=payload_key,
+            request_id=request_id,
         )
 
-    return _orjson_response(result, headers=headers)
+    result = await tipi_service.searchTipiByTextQuery(ncm)
+    if not isinstance(result, dict):
+        logger.error(
+            "tipi_request_failed request_id=%s path=%s reason=invalid_service_response ncm=%s type=%s",
+            request_id,
+            request.url.path,
+            safe_ncm,
+            type(result).__name__,
+        )
+        raise HTTPException(status_code=500, detail="Formato de resposta inválido do serviço")
+
+    result.setdefault("normalized", result.get("query", ""))
+    result.setdefault("warning", None)
+    result.setdefault("match_type", "text")
+    result.setdefault("total", len(result.get("results") or []))
+    _apply_tipi_description_highlights(result)
+    return _build_tipi_text_search_response(
+        request,
+        result,
+        headers=headers,
+        request_id=request_id,
+    )
 
 
 @router.get("/chapters")
-async def get_tipi_chapters(
+async def listTipiChapters(
     tipi_service: Annotated[TipiService, Depends(get_tipi_service)],
 ):
     """
@@ -254,6 +488,5 @@ async def get_tipi_chapters(
 
     Útil para navegação hierárquica no frontend.
     """
-    # Exceções propagam para o handler global
-    chapters = await tipi_service.get_all_chapters()
+    chapters = await tipi_service.fetchTipiChapterCatalog()
     return {"success": True, "capitulos": chapters}

--- a/backend/presentation/routes/tipi.py
+++ b/backend/presentation/routes/tipi.py
@@ -142,6 +142,11 @@ def snapshotTipiCodePayloadCacheMetrics() -> dict[str, str | float | int]:
     }
 
 
+def get_payload_cache_metrics() -> dict[str, str | float | int]:
+    """Alias compatível com a API anterior do módulo."""
+    return snapshotTipiCodePayloadCacheMetrics()
+
+
 def _build_tipi_payload_cache_headers(
     payload_scope_key: str, normalized_query: str, view_mode: str
 ) -> dict[str, str]:

--- a/backend/presentation/routes/tipi.py
+++ b/backend/presentation/routes/tipi.py
@@ -191,7 +191,9 @@ def _build_tipi_payload_cache_context(
     )
 
 
-def _extract_tipi_code_search_results(response_data: Mapping[str, Any]) -> dict[str, Any]:
+def _extract_tipi_code_search_results(
+    response_data: Mapping[str, Any],
+) -> dict[str, Any]:
     if "results" in response_data:
         raw_results = response_data.get("results")
     elif "resultados" in response_data:
@@ -289,9 +291,7 @@ def _apply_tipi_description_highlights(result: dict[str, Any]) -> None:
         _apply_tipi_text_description_highlights(results)
 
 
-def _apply_tipi_code_search_contract(
-    response_data: dict[str, Any]
-) -> dict[str, Any]:
+def _apply_tipi_code_search_contract(response_data: dict[str, Any]) -> dict[str, Any]:
     results = _extract_tipi_code_search_results(response_data)
     response_data["results"] = results
     response_data["resultados"] = results
@@ -436,9 +436,7 @@ async def handle_tipi_search_request(
                 cache_status="HIT",
             )
 
-        result = await tipi_service.searchTipiByNcmCode(
-            ncm, view_mode=view_mode.value
-        )
+        result = await tipi_service.searchTipiByNcmCode(ncm, view_mode=view_mode.value)
         if not isinstance(result, dict):
             logger.error(
                 "tipi_request_failed request_id=%s path=%s reason=invalid_service_response ncm=%s type=%s",
@@ -447,9 +445,7 @@ async def handle_tipi_search_request(
                 safe_ncm,
                 type(result).__name__,
             )
-            raise HTTPException(
-                status_code=500, detail=INVALID_TIPI_RESPONSE_DETAIL
-            )
+            raise HTTPException(status_code=500, detail=INVALID_TIPI_RESPONSE_DETAIL)
 
         result = _apply_tipi_code_search_contract(result)
         _apply_tipi_description_highlights(result)

--- a/backend/presentation/routes/tipi.py
+++ b/backend/presentation/routes/tipi.py
@@ -274,6 +274,8 @@ def _apply_tipi_code_description_highlights(results: dict[str, Any]) -> None:
 
 def _apply_tipi_text_description_highlights(results: list) -> None:
     for item in results:
+        if not isinstance(item, dict):
+            continue
         desc = item.get("descricao", "")
         if desc:
             desc = HtmlRenderer.inject_exclusion_highlights(desc)
@@ -302,10 +304,14 @@ def _apply_tipi_code_search_contract(response_data: dict[str, Any]) -> dict[str,
     results = _extract_tipi_code_search_results(response_data)
     response_data["results"] = results
     response_data["resultados"] = results
-    response_data["total"] = response_data.get("total") or len(results)
-    response_data["total_capitulos"] = response_data.get("total_capitulos") or len(
-        results
-    )
+    if response_data.get("total") is None:
+        response_data["total"] = sum(
+            len(cap_data.get("posicoes") or [])
+            for cap_data in results.values()
+            if isinstance(cap_data, dict)
+        )
+    if response_data.get("total_capitulos") is None:
+        response_data["total_capitulos"] = len(results)
     return response_data
 
 

--- a/backend/presentation/routes/tipi.py
+++ b/backend/presentation/routes/tipi.py
@@ -123,7 +123,7 @@ def _request_accepts_tipi_gzip_encoding(request: Request) -> bool:
     return wildcard_q is not None and wildcard_q > 0
 
 
-def snapshotTipiCodePayloadCacheMetrics() -> dict[str, str | float | int]:
+def snapshot_tipi_code_payload_cache_metrics() -> dict[str, str | float | int]:
     snapshot = tipi_payload_cache_metrics.snapshot(
         current_size=len(_tipi_code_payload_cache),
         max_size=_TIPI_CODE_PAYLOAD_CACHE_MAX,
@@ -144,7 +144,7 @@ def snapshotTipiCodePayloadCacheMetrics() -> dict[str, str | float | int]:
 
 def get_payload_cache_metrics() -> dict[str, str | float | int]:
     """Alias compatível com a API anterior do módulo."""
-    return snapshotTipiCodePayloadCacheMetrics()
+    return snapshot_tipi_code_payload_cache_metrics()
 
 
 def _build_tipi_payload_cache_headers(
@@ -226,9 +226,10 @@ def _build_tipi_payload_response(
 
 
 router = APIRouter()
+INVALID_TIPI_RESPONSE_DETAIL = "Formato de resposta inválido do serviço"
 TIPI_SEARCH_RESPONSES = {
     429: {"description": "Limite de requisições para busca pública excedido."},
-    500: {"description": "Formato de resposta inválido do serviço"},
+    500: {"description": INVALID_TIPI_RESPONSE_DETAIL},
 }
 
 
@@ -375,7 +376,7 @@ def _build_tipi_text_search_response(
 
 
 @router.get("/search", responses=TIPI_SEARCH_RESPONSES)
-async def handleTipiSearchRequest(
+async def handle_tipi_search_request(
     request: Request,
     tipi_service: Annotated[TipiService, Depends(get_tipi_service)],
     ncm: Annotated[
@@ -447,7 +448,7 @@ async def handleTipiSearchRequest(
                 type(result).__name__,
             )
             raise HTTPException(
-                status_code=500, detail="Formato de resposta inválido do serviço"
+                status_code=500, detail=INVALID_TIPI_RESPONSE_DETAIL
             )
 
         result = _apply_tipi_code_search_contract(result)
@@ -469,7 +470,7 @@ async def handleTipiSearchRequest(
             safe_ncm,
             type(result).__name__,
         )
-        raise HTTPException(status_code=500, detail="Formato de resposta inválido do serviço")
+        raise HTTPException(status_code=500, detail=INVALID_TIPI_RESPONSE_DETAIL)
 
     result.setdefault("normalized", result.get("query", ""))
     result.setdefault("warning", None)
@@ -485,7 +486,7 @@ async def handleTipiSearchRequest(
 
 
 @router.get("/chapters")
-async def listTipiChapters(
+async def list_tipi_chapters(
     tipi_service: Annotated[TipiService, Depends(get_tipi_service)],
 ):
     """
@@ -495,3 +496,8 @@ async def listTipiChapters(
     """
     chapters = await tipi_service.fetchTipiChapterCatalog()
     return {"success": True, "capitulos": chapters}
+
+
+snapshotTipiCodePayloadCacheMetrics = snapshot_tipi_code_payload_cache_metrics
+handleTipiSearchRequest = handle_tipi_search_request
+listTipiChapters = list_tipi_chapters

--- a/backend/presentation/routes/webhooks.py
+++ b/backend/presentation/routes/webhooks.py
@@ -3,18 +3,63 @@ import logging
 import re
 import secrets
 from datetime import date, datetime, timezone
-from typing import Any, Dict, Optional, cast
+from typing import Protocol, TypedDict, Unpack, cast
 
 from backend.config.settings import settings
 from backend.domain.sqlmodels import Subscription, Tenant
 from backend.infrastructure.db_engine import get_session
 from fastapi import APIRouter, HTTPException, Request
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 router = APIRouter()
 logger = logging.getLogger("routes.webhooks")
 _TENANT_ID_RE = re.compile(r"^[A-Za-z0-9_-]{3,128}$")
 _asaas_token_warning_logged = False
+
+
+class AsaasPaymentPayload(TypedDict, total=False):
+    externalReference: str
+    plan: str
+    description: str
+    value: str | int | float
+    billingType: str
+    status: str
+    dueDate: str
+    paymentDate: str
+    customer: str
+    subscription: str
+    id: str
+
+
+class AsaasWebhookPayload(TypedDict, total=False):
+    event: str
+    externalReference: str
+    plan: str
+    payment: AsaasPaymentPayload
+
+
+class _SubscriptionUpsertPayload(TypedDict):
+    tenant_id: str
+    provider_customer_id: str | None
+    provider_subscription_id: str | None
+    provider_payment_id: str | None
+    plan_name: str
+    payment_status: str
+    amount: float | None
+    billing_cycle: str | None
+    next_due_date: date | None
+    last_payment_date: datetime | None
+    raw_payload: str
+    now: datetime
+
+
+class _SubscriptionTableColumns(Protocol):
+    provider: object
+    provider_payment_id: object
+    provider_subscription_id: object
+    tenant_id: object
+    updated_at: object
 
 
 def _extract_asaas_token(request: Request) -> str | None:
@@ -41,16 +86,28 @@ def _is_valid_asaas_webhook(request: Request) -> bool:
     return secrets.compare_digest(token, configured)
 
 
-def _parse_date(value: Any) -> Optional[date]:
+def _normalize_optional_text(
+    value: object | None, *, max_length: int | None = None
+) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text[:max_length] if max_length is not None else text
+
+
+def _parse_date(value: object | None) -> date | None:
     if not value:
         return None
     try:
         return date.fromisoformat(str(value)[:10])
-    except Exception:
+    except (ValueError, TypeError) as exc:
+        logger.debug("Failed to parse date value %r: %s", value, exc)
         return None
 
 
-def _parse_datetime(value: Any) -> Optional[datetime]:
+def _parse_datetime(value: object | None) -> datetime | None:
     if not value:
         return None
     raw = str(value).strip()
@@ -64,12 +121,14 @@ def _parse_datetime(value: Any) -> Optional[datetime]:
             # Persistimos como UTC naive para compatibilidade com DateTime sem timezone.
             parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
         return parsed
-    except Exception:
-        logger.warning("Invalid datetime format in Asaas payload: %s", raw)
+    except ValueError as exc:
+        logger.warning("Invalid datetime format in Asaas payload %r: %s", raw, exc)
         return None
 
 
-async def _get_or_update_tenant(session: Any, tenant_id: str, plan_name: str) -> None:
+async def _get_or_update_tenant(
+    session: AsyncSession, tenant_id: str, plan_name: str
+) -> None:
     tenant = await session.get(Tenant, tenant_id)
     if not tenant:
         tenant = Tenant(
@@ -85,12 +144,12 @@ async def _get_or_update_tenant(session: Any, tenant_id: str, plan_name: str) ->
 
 
 async def _find_asaas_subscription(
-    session: Any,
+    session: AsyncSession,
     tenant_id: str,
-    provider_payment_id: Optional[str],
-    provider_subscription_id: Optional[str],
-):
-    table = cast(Any, Subscription).__table__.c
+    provider_payment_id: str | None,
+    provider_subscription_id: str | None,
+) -> Subscription | None:
+    table = cast(_SubscriptionTableColumns, Subscription.__table__.c)
     if provider_payment_id:
         result = await session.execute(
             select(Subscription).where(
@@ -126,9 +185,9 @@ async def _find_asaas_subscription(
 
 
 def _upsert_subscription(
-    session: Any,
-    subscription: Optional[Subscription],
-    **data: Any,
+    session: AsyncSession,
+    subscription: Subscription | None,
+    **data: Unpack[_SubscriptionUpsertPayload],
 ) -> None:
     if not subscription:
         subscription = Subscription(
@@ -166,17 +225,21 @@ def _upsert_subscription(
         subscription.updated_at = data["now"]
 
 
-async def process_asaas_payment_confirmed(payload: Dict[str, Any]) -> Dict[str, Any]:
+async def process_asaas_payment_confirmed(
+    payload: AsaasWebhookPayload,
+) -> dict[str, object]:
     """
     Provisiona ou atualiza assinatura/tenant após PAYMENT_CONFIRMED.
     """
     raw_payment = payload.get("payment")
-    payment: Dict[str, Any] = raw_payment if isinstance(raw_payment, dict) else {}
-
-    external_reference = payment.get("externalReference") or payload.get(
-        "externalReference"
+    payment: AsaasPaymentPayload = (
+        cast(AsaasPaymentPayload, raw_payment) if isinstance(raw_payment, dict) else {}
     )
-    tenant_id = str(external_reference or "").strip()
+
+    external_reference = _normalize_optional_text(
+        payment.get("externalReference") or payload.get("externalReference")
+    )
+    tenant_id = external_reference or ""
     if not tenant_id:
         return {"processed": False, "reason": "missing_external_reference"}
     if not _TENANT_ID_RE.fullmatch(tenant_id):
@@ -197,14 +260,16 @@ async def process_asaas_payment_confirmed(payload: Dict[str, Any]) -> Dict[str, 
     if amount is not None and amount <= 0:
         return {"processed": False, "reason": "invalid_amount"}
 
-    billing_cycle = payment.get("billingType")
-    payment_status = str(payment.get("status") or "CONFIRMED")[:64]
+    billing_cycle = _normalize_optional_text(payment.get("billingType"), max_length=64)
+    payment_status = (
+        _normalize_optional_text(payment.get("status"), max_length=64) or "CONFIRMED"
+    )
     next_due_date = _parse_date(payment.get("dueDate"))
     last_payment_date = _parse_datetime(payment.get("paymentDate"))
 
-    provider_customer_id = payment.get("customer")
-    provider_subscription_id = payment.get("subscription")
-    provider_payment_id = payment.get("id")
+    provider_customer_id = _normalize_optional_text(payment.get("customer"))
+    provider_subscription_id = _normalize_optional_text(payment.get("subscription"))
+    provider_payment_id = _normalize_optional_text(payment.get("id"))
 
     async with get_session() as session:
         await _get_or_update_tenant(session, tenant_id, plan_name)
@@ -269,17 +334,18 @@ async def asaas_webhook(request: Request):
 
     try:
         payload = json.loads(raw_body)
-    except Exception:
+    except (json.JSONDecodeError, ValueError):
         raise HTTPException(status_code=400, detail="Invalid JSON payload")
     if not isinstance(payload, dict):
         raise HTTPException(status_code=400, detail="Invalid webhook payload")
+    typed_payload = cast(AsaasWebhookPayload, payload)
 
-    event = str(payload.get("event") or "").strip()
+    event = _normalize_optional_text(typed_payload.get("event")) or ""
     if not event:
         raise HTTPException(status_code=400, detail="Missing event in payload")
 
     if event != "PAYMENT_CONFIRMED":
         return {"success": True, "processed": False, "ignored_event": event}
 
-    result = await process_asaas_payment_confirmed(payload)
+    result = await process_asaas_payment_confirmed(typed_payload)
     return {"success": True, **result}

--- a/backend/presentation/tipi_renderer.py
+++ b/backend/presentation/tipi_renderer.py
@@ -55,10 +55,10 @@ class TipiRenderer:
 
     # Tooltip labels for aliquota types
     ALIQUOT_TOOLTIPS = {
-        "0": "Isento de IPI",
-        "NT": "Não Tributável",
+        "zero": "Isento de IPI",
+        "nt": "Não Tributável",
         "low": "Alíquota Reduzida (1-5%)",
-        "medium": "Alíquota Média (6-10%)",
+        "med": "Alíquota Média (6-10%)",
         "high": "Alíquota Elevada (>10%)",
     }
 

--- a/backend/server/app_lifecycle.py
+++ b/backend/server/app_lifecycle.py
@@ -239,7 +239,7 @@ async def _init_tipi_service(app: FastAPI) -> None:
 
     if await _postgres_tipi_has_data():
         app.state.tipi_service = (
-            await TipiService.initializeTipiServiceWithRepositoryFactory()
+            TipiService.initializeTipiServiceWithRepositoryFactory()
         )
         logger.info("TipiService initialized in Repository mode (Postgres)")
         return

--- a/backend/services/nbs/__init__.py
+++ b/backend/services/nbs/__init__.py
@@ -1,0 +1,2 @@
+"""NBS service support modules."""
+

--- a/backend/services/nbs/__init__.py
+++ b/backend/services/nbs/__init__.py
@@ -1,2 +1,1 @@
 """NBS service support modules."""
-

--- a/backend/services/nbs/bootstrap.py
+++ b/backend/services/nbs/bootstrap.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import AsyncContextManager, AsyncIterator, Callable
+
+from .types import NbsRepositoryProtocol, NbsServiceState
+
+
+def build_nbs_repository_factory() -> Callable[
+    [], AsyncContextManager[NbsRepositoryProtocol]
+]:
+    try:
+        from backend.infrastructure.db_engine import get_session
+        from backend.infrastructure.repositories.nbs_repository import NbsRepository
+    except ImportError as exc:
+        raise RuntimeError("Repository não disponível. Instale sqlmodel.") from exc
+
+    @asynccontextmanager
+    async def repo_factory() -> AsyncIterator[NbsRepositoryProtocol]:
+        async with get_session() as session:
+            yield NbsRepository(session)
+
+    return repo_factory
+
+
+@asynccontextmanager
+async def acquire_nbs_repository(
+    service: NbsServiceState,
+) -> AsyncIterator[NbsRepositoryProtocol | None]:
+    if service._repository is not None:
+        yield service._repository
+        return
+    if service._repository_factory is not None:
+        async with service._repository_factory() as repo:
+            yield repo
+        return
+    yield None

--- a/backend/services/nbs/cache.py
+++ b/backend/services/nbs/cache.py
@@ -148,4 +148,3 @@ async def write_nbs_detail_cache_payload(
     )
     if redis_cache.available:
         await redis_cache.set_services_detail(namespace, scope, key, payload)
-

--- a/backend/services/nbs/cache.py
+++ b/backend/services/nbs/cache.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from collections import OrderedDict
+
+import orjson
+
+from backend.infrastructure.redis_client import redis_cache
+
+from .types import (
+    NBS_DETAIL_CACHE_SIZE,
+    NBS_SEARCH_CACHE_SIZE,
+    NbsRepositoryProtocol,
+    NbsServiceState,
+)
+
+try:
+    from backend.infrastructure.db_engine import tenant_context
+except ImportError:  # pragma: no cover - optional dependency
+    tenant_context = None
+
+
+def get_nbs_cache_lock(service: NbsServiceState) -> asyncio.Lock:
+    if service._cache_lock is None:
+        service._cache_lock = asyncio.Lock()
+    return service._cache_lock
+
+
+def build_nbs_cache_key(*parts: object) -> str:
+    serialized = "|".join(str(part) for part in parts)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def resolve_nbs_cache_scope(repo: NbsRepositoryProtocol | None = None) -> str:
+    tenant_id = getattr(repo, "tenant_id", None)
+    if not tenant_id and tenant_context is not None:
+        tenant_id = tenant_context.get() or None
+    return str(tenant_id or "public")
+
+
+async def read_nbs_l1_cache_payload(
+    service: NbsServiceState,
+    cache: OrderedDict[str, bytes],
+    key: str,
+) -> dict[str, object] | None:
+    async with get_nbs_cache_lock(service):
+        cached = cache.get(key)
+        if cached is None:
+            return None
+        cache.move_to_end(key)
+    return orjson.loads(cached)
+
+
+async def write_nbs_l1_cache_payload(
+    service: NbsServiceState,
+    cache: OrderedDict[str, bytes],
+    key: str,
+    payload: dict[str, object],
+    *,
+    max_size: int,
+) -> None:
+    encoded = orjson.dumps(payload)
+    async with get_nbs_cache_lock(service):
+        cache[key] = encoded
+        cache.move_to_end(key)
+        while len(cache) > max_size:
+            cache.popitem(last=False)
+
+
+async def read_nbs_search_cache_payload(
+    service: NbsServiceState, namespace: str, scope: str, key: str
+) -> dict[str, object] | None:
+    cache_key = f"{namespace}:{scope}:{key}"
+    cached = await read_nbs_l1_cache_payload(service, service._search_cache, cache_key)
+    if cached is not None:
+        return cached
+    if not redis_cache.available:
+        return None
+    cached = await redis_cache.get_services_search(namespace, scope, key)
+    if cached is None:
+        return None
+    await write_nbs_l1_cache_payload(
+        service,
+        service._search_cache,
+        cache_key,
+        cached,
+        max_size=NBS_SEARCH_CACHE_SIZE,
+    )
+    return cached
+
+
+async def write_nbs_search_cache_payload(
+    service: NbsServiceState,
+    namespace: str,
+    scope: str,
+    key: str,
+    payload: dict[str, object],
+) -> None:
+    cache_key = f"{namespace}:{scope}:{key}"
+    await write_nbs_l1_cache_payload(
+        service,
+        service._search_cache,
+        cache_key,
+        payload,
+        max_size=NBS_SEARCH_CACHE_SIZE,
+    )
+    if redis_cache.available:
+        await redis_cache.set_services_search(namespace, scope, key, payload)
+
+
+async def read_nbs_detail_cache_payload(
+    service: NbsServiceState, namespace: str, scope: str, key: str
+) -> dict[str, object] | None:
+    cache_key = f"{namespace}:{scope}:{key}"
+    cached = await read_nbs_l1_cache_payload(service, service._detail_cache, cache_key)
+    if cached is not None:
+        return cached
+    if not redis_cache.available:
+        return None
+    cached = await redis_cache.get_services_detail(namespace, scope, key)
+    if cached is None:
+        return None
+    await write_nbs_l1_cache_payload(
+        service,
+        service._detail_cache,
+        cache_key,
+        cached,
+        max_size=NBS_DETAIL_CACHE_SIZE,
+    )
+    return cached
+
+
+async def write_nbs_detail_cache_payload(
+    service: NbsServiceState,
+    namespace: str,
+    scope: str,
+    key: str,
+    payload: dict[str, object],
+) -> None:
+    cache_key = f"{namespace}:{scope}:{key}"
+    await write_nbs_l1_cache_payload(
+        service,
+        service._detail_cache,
+        cache_key,
+        payload,
+        max_size=NBS_DETAIL_CACHE_SIZE,
+    )
+    if redis_cache.available:
+        await redis_cache.set_services_detail(namespace, scope, key, payload)
+

--- a/backend/services/nbs/details.py
+++ b/backend/services/nbs/details.py
@@ -29,7 +29,9 @@ from .types import (
 )
 
 
-def public_nbs_explanatory_entry(entry: dict[str, object] | None) -> dict[str, object] | None:
+def public_nbs_explanatory_entry(
+    entry: dict[str, object] | None,
+) -> dict[str, object] | None:
     if not entry:
         return None
     public_entry = {field: entry.get(field) for field in NEBS_PUBLIC_FIELDS}
@@ -137,9 +139,7 @@ async def fetch_nbs_catalog_item_details(
         nebs_payload = (
             None
             if nebs_row is None
-            else public_nbs_explanatory_entry(
-                row_to_nbs_explanatory_entry(nebs_row)
-            )
+            else public_nbs_explanatory_entry(row_to_nbs_explanatory_entry(nebs_row))
         )
 
         payload = {
@@ -230,9 +230,7 @@ async def fetch_nbs_explanatory_entry_details(
         entry_where_clauses: list[str] = []
         entry_params: list[str] = []
         if aliases:
-            entry_where_clauses.append(
-                f"code IN ({', '.join(['?'] * len(aliases))})"
-            )
+            entry_where_clauses.append(f"code IN ({', '.join(['?'] * len(aliases))})")
             entry_params.extend(aliases)
         if clean_aliases:
             entry_where_clauses.append(

--- a/backend/services/nbs/details.py
+++ b/backend/services/nbs/details.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from backend.config.exceptions import NotFoundError
+
+from .bootstrap import acquire_nbs_repository
+from .cache import (
+    build_nbs_cache_key,
+    read_nbs_detail_cache_payload,
+    resolve_nbs_cache_scope,
+    write_nbs_detail_cache_payload,
+)
+from .sqlite_common import (
+    acquire_nbs_sqlite_connection,
+    fetch_nbs_ancestors,
+    fetch_nbs_item_by_code,
+    fetch_nbs_tree_page_sqlite,
+    release_nbs_sqlite_connection,
+    resolve_nbs_hierarchy_root,
+    sanitize_nbs_detail_payload,
+    sanitize_nbs_html_fields,
+    row_to_nbs_item,
+    row_to_nbs_explanatory_entry,
+)
+from .types import (
+    DEFAULT_TREE_PAGE_SIZE,
+    MAX_TREE_PAGE_SIZE,
+    NEBS_PUBLIC_FIELDS,
+    NbsServiceState,
+)
+
+
+def public_nbs_explanatory_entry(entry: dict[str, object] | None) -> dict[str, object] | None:
+    if not entry:
+        return None
+    public_entry = {field: entry.get(field) for field in NEBS_PUBLIC_FIELDS}
+    return sanitize_nbs_html_fields(public_entry)
+
+
+async def fetch_nbs_catalog_item_details(
+    service: NbsServiceState,
+    code: str,
+    *,
+    include_tree: bool = True,
+    page: int = 1,
+    page_size: int = DEFAULT_TREE_PAGE_SIZE,
+) -> dict[str, object]:
+    normalized_code = (code or "").strip()
+    normalized_page = max(int(page or 1), 1)
+    normalized_page_size = min(
+        max(int(page_size or DEFAULT_TREE_PAGE_SIZE), 1), MAX_TREE_PAGE_SIZE
+    )
+    cache_key = build_nbs_cache_key(
+        "nbs-detail",
+        normalized_code,
+        include_tree,
+        normalized_page,
+        normalized_page_size,
+    )
+    scope = resolve_nbs_cache_scope(service._repository)
+    cached = await read_nbs_detail_cache_payload(service, "nbs", scope, cache_key)
+    if cached is not None:
+        return cached
+
+    if service._use_repository:
+        async with acquire_nbs_repository(service) as repo:
+            if repo is None:
+                raise RuntimeError("NBS repository unavailable")
+            scoped_key = resolve_nbs_cache_scope(repo)
+            if scoped_key != scope:
+                cached = await read_nbs_detail_cache_payload(
+                    service, "nbs", scoped_key, cache_key
+                )
+                if cached is not None:
+                    return cached
+            scope = scoped_key
+            payload = await repo.load_nbs_catalog_item_details(
+                normalized_code,
+                include_tree=include_tree,
+                page=normalized_page,
+                page_size=normalized_page_size,
+            )
+        payload = sanitize_nbs_detail_payload(payload)
+        await write_nbs_detail_cache_payload(service, "nbs", scope, cache_key, payload)
+        return payload
+
+    conn = await acquire_nbs_sqlite_connection(service)
+    try:
+        item = await fetch_nbs_item_by_code(conn, normalized_code)
+        ancestors = await fetch_nbs_ancestors(conn, item)
+        chapter_root = resolve_nbs_hierarchy_root(item, ancestors)
+
+        children_cursor = await conn.execute(
+            """
+            SELECT code, code_clean, description, parent_code, level, has_nebs
+            FROM nbs_items
+            WHERE parent_code = ?
+            ORDER BY source_order ASC
+            """,
+            (item["code"],),
+        )
+        child_rows = await children_cursor.fetchall()
+        tree_page = (
+            await fetch_nbs_tree_page_sqlite(
+                conn,
+                chapter_root["code"],
+                page=normalized_page,
+                page_size=normalized_page_size,
+            )
+            if include_tree
+            else None
+        )
+
+        nebs_cursor = await conn.execute(
+            """
+            SELECT
+                code,
+                code_clean,
+                title,
+                title_normalized,
+                body_text,
+                body_markdown,
+                body_normalized,
+                section_title,
+                page_start,
+                page_end,
+                parser_status,
+                parse_warnings,
+                source_hash,
+                updated_at
+            FROM nebs_entries
+            WHERE code = ? AND parser_status = 'trusted'
+            LIMIT 1
+            """,
+            (item["code"],),
+        )
+        nebs_row = await nebs_cursor.fetchone()
+        nebs_payload = (
+            None
+            if nebs_row is None
+            else public_nbs_explanatory_entry(
+                row_to_nbs_explanatory_entry(nebs_row)
+            )
+        )
+
+        payload = {
+            "success": True,
+            "item": item,
+            "ancestors": ancestors,
+            "children": [row_to_nbs_item(row) for row in child_rows],
+            "chapter_root": chapter_root,
+            "nebs": nebs_payload,
+        }
+        if tree_page is not None:
+            payload["chapter_items"] = tree_page["items"]
+            payload["chapter_page"] = tree_page
+        payload = sanitize_nbs_detail_payload(payload)
+        await write_nbs_detail_cache_payload(service, "nbs", scope, cache_key, payload)
+        return payload
+    finally:
+        await release_nbs_sqlite_connection(service, conn)
+
+
+async def fetch_nbs_catalog_tree_page(
+    service: NbsServiceState,
+    code: str,
+    *,
+    page: int = 1,
+    page_size: int = DEFAULT_TREE_PAGE_SIZE,
+) -> dict[str, object]:
+    detail = await fetch_nbs_catalog_item_details(
+        service,
+        code,
+        include_tree=True,
+        page=page,
+        page_size=page_size,
+    )
+    normalized_page = max(int(page or 1), 1)
+    normalized_page_size = min(
+        max(int(page_size or DEFAULT_TREE_PAGE_SIZE), 1), MAX_TREE_PAGE_SIZE
+    )
+    return {
+        "success": True,
+        "item": detail["item"],
+        "chapter_root": detail.get("chapter_root"),
+        "chapter_page": detail.get("chapter_page")
+        or {
+            "items": detail.get("chapter_items", []),
+            "page": normalized_page,
+            "page_size": normalized_page_size,
+            "total": len(detail.get("chapter_items", [])),
+            "has_more": False,
+        },
+    }
+
+
+async def fetch_nbs_explanatory_entry_details(
+    service: NbsServiceState, code: str
+) -> dict[str, object]:
+    normalized_code = (code or "").strip()
+    cache_key = build_nbs_cache_key("nebs-detail", normalized_code)
+    scope = resolve_nbs_cache_scope(service._repository)
+    cached = await read_nbs_detail_cache_payload(service, "nebs", scope, cache_key)
+    if cached is not None:
+        return cached
+
+    if service._use_repository:
+        async with acquire_nbs_repository(service) as repo:
+            if repo is None:
+                raise RuntimeError("NBS repository unavailable")
+            scoped_key = resolve_nbs_cache_scope(repo)
+            if scoped_key != scope:
+                cached = await read_nbs_detail_cache_payload(
+                    service, "nebs", scoped_key, cache_key
+                )
+                if cached is not None:
+                    return cached
+            scope = scoped_key
+            payload = await repo.load_nbs_explanatory_entry_details(normalized_code)
+        payload = sanitize_nbs_detail_payload(payload)
+        await write_nbs_detail_cache_payload(service, "nebs", scope, cache_key, payload)
+        return payload
+
+    conn = await acquire_nbs_sqlite_connection(service)
+    try:
+        item = await fetch_nbs_item_by_code(conn, normalized_code)
+        ancestors = await fetch_nbs_ancestors(conn, item)
+        from .sqlite_common import resolve_nbs_code_aliases
+
+        aliases, clean_aliases = resolve_nbs_code_aliases(normalized_code)
+        entry_where_clauses: list[str] = []
+        entry_params: list[str] = []
+        if aliases:
+            entry_where_clauses.append(
+                f"code IN ({', '.join(['?'] * len(aliases))})"
+            )
+            entry_params.extend(aliases)
+        if clean_aliases:
+            entry_where_clauses.append(
+                f"code_clean IN ({', '.join(['?'] * len(clean_aliases))})"
+            )
+            entry_params.extend(clean_aliases)
+        entry_params.append("trusted")
+        entry_cursor = await conn.execute(
+            f"""
+            SELECT
+                code,
+                code_clean,
+                title,
+                title_normalized,
+                body_text,
+                body_markdown,
+                body_normalized,
+                section_title,
+                page_start,
+                page_end,
+                parser_status,
+                parse_warnings,
+                source_hash,
+                updated_at
+            FROM nebs_entries
+            WHERE ({" OR ".join(entry_where_clauses)}) AND parser_status = ?
+            ORDER BY LENGTH(code_clean) DESC
+            LIMIT 1
+            """,
+            entry_params,
+        )
+        entry_row = await entry_cursor.fetchone()
+        if entry_row is None:
+            raise NotFoundError("Entrada NEBS", normalized_code)
+
+        payload = {
+            "success": True,
+            "item": item,
+            "ancestors": ancestors,
+            "entry": public_nbs_explanatory_entry(
+                row_to_nbs_explanatory_entry(entry_row)
+            ),
+        }
+        payload = sanitize_nbs_detail_payload(payload)
+        await write_nbs_detail_cache_payload(service, "nebs", scope, cache_key, payload)
+        return payload
+    finally:
+        await release_nbs_sqlite_connection(service, conn)

--- a/backend/services/nbs/health.py
+++ b/backend/services/nbs/health.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from backend.config.logging_config import service_logger as logger
+
+from .bootstrap import acquire_nbs_repository
+from .sqlite_common import (
+    acquire_nbs_sqlite_connection,
+    nbs_table_exists,
+)
+from .types import NbsServiceState
+
+
+def build_nbs_health_payload(
+    nbs_items: int,
+    nebs_entries: int,
+    metadata: dict[str, str],
+) -> dict[str, object]:
+    status = "online" if nbs_items > 0 and nebs_entries > 0 else "error"
+    return {
+        "status": status,
+        "nbs_items": nbs_items,
+        "nebs_entries": nebs_entries,
+        "metadata": metadata,
+    }
+
+
+async def probe_nbs_repository_health(service: NbsServiceState) -> dict[str, object]:
+    async with acquire_nbs_repository(service) as repo:
+        if repo is None:
+            raise RuntimeError("NBS repository unavailable")
+        counts = await repo.snapshot_nbs_catalog_counts()
+        metadata = await repo.snapshot_nbs_catalog_metadata()
+    return build_nbs_health_payload(
+        int(counts.get("nbs_items", 0)),
+        int(counts.get("nebs_entries", 0)),
+        metadata,
+    )
+
+
+async def count_nbs_sqlite_rows(conn, table: str, query: str) -> int:
+    if not await nbs_table_exists(conn, table):
+        return 0
+    cursor = await conn.execute(query)
+    row = await cursor.fetchone()
+    return int(row[0] if row else 0)
+
+
+async def read_nbs_sqlite_catalog_metadata(conn) -> dict[str, str]:
+    if not await nbs_table_exists(conn, "catalog_metadata"):
+        return {}
+    cursor = await conn.execute("SELECT key, value FROM catalog_metadata")
+    return {row["key"]: row["value"] for row in await cursor.fetchall()}
+
+
+async def probe_nbs_sqlite_health(service: NbsServiceState) -> dict[str, object]:
+    if not service.db_path.exists():
+        return {
+            "status": "error",
+            "error": f"Banco NBS não encontrado: {service.db_path}",
+        }
+
+    conn = await acquire_nbs_sqlite_connection(service)
+    try:
+        nbs_count = await count_nbs_sqlite_rows(
+            conn,
+            "nbs_items",
+            "SELECT COUNT(*) FROM nbs_items",
+        )
+        nebs_count = await count_nbs_sqlite_rows(
+            conn,
+            "nebs_entries",
+            "SELECT COUNT(*) FROM nebs_entries WHERE parser_status = 'trusted'",
+        )
+        metadata = await read_nbs_sqlite_catalog_metadata(conn)
+        return build_nbs_health_payload(nbs_count, nebs_count, metadata)
+    except Exception as exc:
+        logger.error("NBS SQLite healthcheck failed: %s", exc)
+        return {"status": "error", "error": str(exc)}
+    finally:
+        from .sqlite_common import release_nbs_sqlite_connection
+
+        await release_nbs_sqlite_connection(service, conn)
+
+
+async def probe_nbs_catalog_health(service: NbsServiceState) -> dict[str, object]:
+    if service._use_repository:
+        try:
+            return await probe_nbs_repository_health(service)
+        except Exception as exc:
+            logger.error("NBS repository healthcheck failed: %s", exc)
+            return {"status": "error", "error": str(exc)}
+    return await probe_nbs_sqlite_health(service)

--- a/backend/services/nbs/search.py
+++ b/backend/services/nbs/search.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+from backend.utils.nbs_parser import clean_nbs_code, normalize_nbs_text
+
+from .bootstrap import acquire_nbs_repository
+from .cache import (
+    build_nbs_cache_key,
+    read_nbs_search_cache_payload,
+    resolve_nbs_cache_scope,
+    write_nbs_search_cache_payload,
+)
+from .sqlite_common import (
+    acquire_nbs_sqlite_connection,
+    build_nbs_fts_query,
+    load_nbs_table_columns,
+    nbs_table_exists,
+    row_to_nbs_item,
+)
+from .types import NbsServiceState
+
+
+async def search_nbs_catalog_entries(
+    service: NbsServiceState, query: str, *, limit: int = 50
+) -> dict[str, object]:
+    raw_query = (query or "").strip()
+    normalized_query = normalize_nbs_text(raw_query)
+    clean_query = clean_nbs_code(raw_query)
+    cache_key = build_nbs_cache_key("nbs", raw_query, normalized_query, limit)
+    scope = resolve_nbs_cache_scope(service._repository)
+    cached = await read_nbs_search_cache_payload(service, "nbs", scope, cache_key)
+    if cached is not None:
+        return cached
+
+    if service._use_repository:
+        async with acquire_nbs_repository(service) as repo:
+            if repo is None:
+                raise RuntimeError("NBS repository unavailable")
+            scoped_key = resolve_nbs_cache_scope(repo)
+            if scoped_key != scope:
+                cached = await read_nbs_search_cache_payload(
+                    service, "nbs", scoped_key, cache_key
+                )
+                if cached is not None:
+                    return cached
+            scope = scoped_key
+            results = await repo.load_nbs_catalog_entries(raw_query, limit=limit)
+        payload = {
+            "success": True,
+            "query": raw_query,
+            "normalized": normalized_query,
+            "results": results,
+            "total": len(results),
+        }
+        await write_nbs_search_cache_payload(service, "nbs", scope, cache_key, payload)
+        return payload
+
+    conn = await acquire_nbs_sqlite_connection(service)
+    try:
+        await load_nbs_table_columns(service, conn, "nbs_items")
+        if not raw_query:
+            cursor = await conn.execute(
+                """
+                SELECT code, code_clean, description, parent_code, level, has_nebs
+                FROM nbs_items
+                WHERE parent_code IS NULL
+                ORDER BY source_order ASC
+                LIMIT ?
+                """,
+                (limit,),
+            )
+            rows = await cursor.fetchall()
+        elif not clean_query and not normalized_query:
+            rows = []
+        else:
+            cursor = await conn.execute(
+                """
+                SELECT
+                    code,
+                    code_clean,
+                    description,
+                    parent_code,
+                    level,
+                    has_nebs,
+                    CASE
+                        WHEN code_clean = ? THEN 500
+                        WHEN code = ? THEN 480
+                        WHEN code_clean LIKE ? THEN 420
+                        WHEN description_normalized = ? THEN 360
+                        WHEN description_normalized LIKE ? THEN 320
+                        ELSE 200
+                    END AS match_score
+                FROM nbs_items
+                WHERE
+                    (? <> '' AND code_clean = ?)
+                    OR (? <> '' AND code_clean LIKE ?)
+                    OR (? <> '' AND code LIKE ?)
+                    OR (? <> '' AND description_normalized LIKE ?)
+                ORDER BY match_score DESC, LENGTH(code_clean) ASC, source_order ASC
+                LIMIT ?
+                """,
+                (
+                    clean_query,
+                    raw_query,
+                    f"{clean_query}%",
+                    normalized_query,
+                    f"{normalized_query}%",
+                    clean_query,
+                    clean_query,
+                    clean_query,
+                    f"{clean_query}%",
+                    raw_query,
+                    f"{raw_query}%",
+                    normalized_query,
+                    f"%{normalized_query}%",
+                    limit,
+                ),
+            )
+            rows = await cursor.fetchall()
+
+        payload = {
+            "success": True,
+            "query": raw_query,
+            "normalized": normalized_query,
+            "results": [row_to_nbs_item(row) for row in rows],
+            "total": len(rows),
+        }
+        await write_nbs_search_cache_payload(service, "nbs", scope, cache_key, payload)
+        return payload
+    finally:
+        from .sqlite_common import release_nbs_sqlite_connection
+
+        await release_nbs_sqlite_connection(service, conn)
+
+
+async def search_nbs_explanatory_entries(
+    service: NbsServiceState, query: str, *, limit: int = 50
+) -> dict[str, object]:
+    raw_query = (query or "").strip()
+    normalized_query = normalize_nbs_text(raw_query)
+    clean_query = clean_nbs_code(raw_query)
+    fts_query = build_nbs_fts_query(normalized_query)
+    cache_key = build_nbs_cache_key("nebs", raw_query, normalized_query, limit)
+    scope = resolve_nbs_cache_scope(service._repository)
+    cached = await read_nbs_search_cache_payload(service, "nebs", scope, cache_key)
+    if cached is not None:
+        return cached
+
+    if service._use_repository:
+        async with acquire_nbs_repository(service) as repo:
+            if repo is None:
+                raise RuntimeError("NBS repository unavailable")
+            scoped_key = resolve_nbs_cache_scope(repo)
+            if scoped_key != scope:
+                cached = await read_nbs_search_cache_payload(
+                    service, "nebs", scoped_key, cache_key
+                )
+                if cached is not None:
+                    return cached
+            scope = scoped_key
+            results = await repo.load_nbs_explanatory_entries(raw_query, limit=limit)
+        payload = {
+            "success": True,
+            "query": raw_query,
+            "normalized": normalized_query,
+            "results": results,
+            "total": len(results),
+        }
+        await write_nbs_search_cache_payload(service, "nebs", scope, cache_key, payload)
+        return payload
+
+    conn = await acquire_nbs_sqlite_connection(service)
+    try:
+        await load_nbs_table_columns(service, conn, "nebs_entries")
+        has_fts = await nbs_table_exists(conn, "nebs_entries_fts")
+        if not raw_query or (not clean_query and not normalized_query):
+            rows = []
+        elif not has_fts:
+            cursor = await conn.execute(
+                """
+                SELECT
+                    code,
+                    code_clean,
+                    title,
+                    section_title,
+                    page_start,
+                    page_end,
+                    CASE
+                        WHEN code_clean = ? THEN 500
+                        WHEN code = ? THEN 480
+                        WHEN code_clean LIKE ? THEN 430
+                        WHEN title_normalized = ? THEN 380
+                        WHEN title_normalized LIKE ? THEN 340
+                        WHEN body_normalized LIKE ? THEN 220
+                        ELSE 180
+                    END AS match_score
+                FROM nebs_entries
+                WHERE parser_status = 'trusted'
+                  AND (
+                    (? <> '' AND code_clean = ?)
+                    OR (? <> '' AND code_clean LIKE ?)
+                    OR (? <> '' AND code LIKE ?)
+                    OR (? <> '' AND title_normalized LIKE ?)
+                    OR (? <> '' AND body_normalized LIKE ?)
+                  )
+                ORDER BY match_score DESC, LENGTH(code_clean) ASC, page_start ASC
+                LIMIT ?
+                """,
+                (
+                    clean_query,
+                    raw_query,
+                    f"{clean_query}%",
+                    normalized_query,
+                    f"{normalized_query}%",
+                    f"%{normalized_query}%",
+                    clean_query,
+                    clean_query,
+                    clean_query,
+                    f"{clean_query}%",
+                    raw_query,
+                    f"{raw_query}%",
+                    normalized_query,
+                    f"{normalized_query}%",
+                    normalized_query,
+                    f"%{normalized_query}%",
+                    limit,
+                ),
+            )
+            rows = await cursor.fetchall()
+        else:
+            cursor = await conn.execute(
+                """
+                WITH fts_hits AS (
+                    SELECT
+                        code,
+                        bm25(nebs_entries_fts, 8.0, 4.0, 1.0, 0.5) AS fts_rank
+                    FROM nebs_entries_fts
+                    WHERE ? <> '' AND nebs_entries_fts MATCH ?
+                )
+                SELECT
+                    e.code,
+                    e.code_clean,
+                    e.title,
+                    e.section_title,
+                    e.page_start,
+                    e.page_end,
+                    CASE
+                        WHEN e.code_clean = ? THEN 500
+                        WHEN e.code = ? THEN 480
+                        WHEN e.code_clean LIKE ? THEN 430
+                        WHEN e.title_normalized = ? THEN 380
+                        WHEN e.title_normalized LIKE ? THEN 340
+                        WHEN fts_hits.code IS NOT NULL THEN 220
+                        ELSE 180
+                    END AS match_score,
+                    COALESCE(fts_hits.fts_rank, 999999.0) AS fts_rank
+                FROM nebs_entries AS e
+                LEFT JOIN fts_hits ON fts_hits.code = e.code
+                WHERE e.parser_status = 'trusted'
+                  AND (
+                    (? <> '' AND e.code_clean = ?)
+                    OR (? <> '' AND e.code_clean LIKE ?)
+                    OR (? <> '' AND e.code LIKE ?)
+                    OR (? <> '' AND e.title_normalized LIKE ?)
+                    OR fts_hits.code IS NOT NULL
+                  )
+                ORDER BY match_score DESC, fts_rank ASC, LENGTH(e.code_clean) ASC, e.page_start ASC
+                LIMIT ?
+                """,
+                (
+                    fts_query,
+                    fts_query,
+                    clean_query,
+                    raw_query,
+                    f"{clean_query}%",
+                    normalized_query,
+                    f"{normalized_query}%",
+                    clean_query,
+                    clean_query,
+                    clean_query,
+                    f"{clean_query}%",
+                    raw_query,
+                    f"{raw_query}%",
+                    normalized_query,
+                    f"{normalized_query}%",
+                    limit,
+                ),
+            )
+            rows = await cursor.fetchall()
+
+        results = [
+            {
+                "code": row["code"],
+                "title": row["title"],
+                "excerpt": "",
+                "page_start": row["page_start"],
+                "page_end": row["page_end"],
+                "section_title": row["section_title"],
+            }
+            for row in rows
+        ]
+        payload = {
+            "success": True,
+            "query": raw_query,
+            "normalized": normalized_query,
+            "results": results,
+            "total": len(results),
+        }
+        await write_nbs_search_cache_payload(service, "nebs", scope, cache_key, payload)
+        return payload
+    finally:
+        from .sqlite_common import release_nbs_sqlite_connection
+
+        await release_nbs_sqlite_connection(service, conn)

--- a/backend/services/nbs/sqlite_common.py
+++ b/backend/services/nbs/sqlite_common.py
@@ -7,7 +7,11 @@ from typing import cast
 import aiosqlite
 import orjson
 
-from backend.config.exceptions import DatabaseError, DatabaseNotFoundError, NotFoundError
+from backend.config.exceptions import (
+    DatabaseError,
+    DatabaseNotFoundError,
+    NotFoundError,
+)
 from backend.config.logging_config import service_logger as logger
 from backend.utils.nbs_parser import (
     build_nbs_code_variants,
@@ -32,7 +36,9 @@ def normalize_nbs_page_size(page_size: int) -> int:
     return min(max(normalized, 1), MAX_TREE_PAGE_SIZE)
 
 
-async def acquire_nbs_sqlite_connection(service: NbsServiceState) -> aiosqlite.Connection:
+async def acquire_nbs_sqlite_connection(
+    service: NbsServiceState,
+) -> aiosqlite.Connection:
     if not service.db_path.exists():
         raise DatabaseNotFoundError(str(service.db_path))
 
@@ -164,7 +170,9 @@ def build_nbs_excerpt(body_text: str, limit: int = 220) -> str:
 
 def resolve_nbs_code_aliases(code: str) -> tuple[list[str], list[str]]:
     aliases = list(build_nbs_code_variants((code or "").strip()))
-    clean_aliases = [clean_nbs_code(alias) for alias in aliases if clean_nbs_code(alias)]
+    clean_aliases = [
+        clean_nbs_code(alias) for alias in aliases if clean_nbs_code(alias)
+    ]
     return aliases, list(dict.fromkeys(clean_aliases))
 
 
@@ -253,9 +261,7 @@ async def fetch_nbs_item_by_code(
         where_clauses.append(f"code IN ({', '.join(['?'] * len(aliases))})")
         params.extend(aliases)
     if clean_aliases:
-        where_clauses.append(
-            f"code_clean IN ({', '.join(['?'] * len(clean_aliases))})"
-        )
+        where_clauses.append(f"code_clean IN ({', '.join(['?'] * len(clean_aliases))})")
         params.extend(clean_aliases)
 
     cursor = await conn.execute(

--- a/backend/services/nbs/sqlite_common.py
+++ b/backend/services/nbs/sqlite_common.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import re
+from html import escape, unescape
+from typing import cast
+
+import aiosqlite
+import orjson
+
+from backend.config.exceptions import DatabaseError, DatabaseNotFoundError, NotFoundError
+from backend.config.logging_config import service_logger as logger
+from backend.utils.nbs_parser import (
+    build_nbs_code_variants,
+    clean_nbs_code,
+)
+
+from .types import (
+    MAX_ANCESTOR_DEPTH,
+    MAX_TREE_PAGE_SIZE,
+    NBS_ALLOWED_TABLES,
+    DEFAULT_TREE_PAGE_SIZE,
+    NbsServiceState,
+)
+
+
+def normalize_nbs_page(page: int) -> int:
+    return max(int(page or 1), 1)
+
+
+def normalize_nbs_page_size(page_size: int) -> int:
+    normalized = int(page_size or DEFAULT_TREE_PAGE_SIZE)
+    return min(max(normalized, 1), MAX_TREE_PAGE_SIZE)
+
+
+async def acquire_nbs_sqlite_connection(service: NbsServiceState) -> aiosqlite.Connection:
+    if not service.db_path.exists():
+        raise DatabaseNotFoundError(str(service.db_path))
+
+    async with service._pool_lock:
+        if service._pool:
+            return service._pool.pop()
+
+    try:
+        conn = await aiosqlite.connect(service.db_path)
+        conn.row_factory = aiosqlite.Row
+        return conn
+    except Exception as exc:
+        logger.error("Failed to connect to services DB: %s", exc)
+        raise DatabaseError(f"Services DB connection failed: {exc}") from exc
+
+
+async def release_nbs_sqlite_connection(
+    service: NbsServiceState, conn: aiosqlite.Connection
+) -> None:
+    async with service._pool_lock:
+        if len(service._pool) < service._pool_max_size:
+            service._pool.append(conn)
+            return
+    await conn.close()
+
+
+async def load_nbs_table_columns(
+    service: NbsServiceState, conn: aiosqlite.Connection, table: str
+) -> set[str]:
+    if table not in NBS_ALLOWED_TABLES:
+        raise ValueError(f"Tabela não permitida para inspeção de schema: {table}")
+    if table in service._schema_columns_cache:
+        return service._schema_columns_cache[table]
+
+    cursor = await conn.execute(f"PRAGMA table_info({table})")
+    rows = await cursor.fetchall()
+    cols = {row["name"] for row in rows}
+    service._schema_columns_cache[table] = cols
+    return cols
+
+
+async def nbs_table_exists(conn: aiosqlite.Connection, table: str) -> bool:
+    cursor = await conn.execute(
+        """
+        SELECT 1
+        FROM sqlite_master
+        WHERE type IN ('table', 'view') AND name = ?
+        LIMIT 1
+        """,
+        (table,),
+    )
+    row = await cursor.fetchone()
+    return row is not None
+
+
+def row_to_nbs_item(row: aiosqlite.Row) -> dict[str, object]:
+    return {
+        "code": row["code"],
+        "code_clean": row["code_clean"],
+        "description": row["description"],
+        "parent_code": row["parent_code"],
+        "level": row["level"],
+        "has_nebs": bool(row["has_nebs"]),
+    }
+
+
+def row_to_nbs_explanatory_entry(row: aiosqlite.Row) -> dict[str, object]:
+    return {
+        "code": row["code"],
+        "code_clean": row["code_clean"],
+        "title": row["title"],
+        "title_normalized": row["title_normalized"],
+        "body_text": row["body_text"],
+        "body_markdown": row["body_markdown"],
+        "body_normalized": row["body_normalized"],
+        "section_title": row["section_title"],
+        "page_start": row["page_start"],
+        "page_end": row["page_end"],
+        "parser_status": row["parser_status"],
+        "parse_warnings": row["parse_warnings"],
+        "source_hash": row["source_hash"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def sanitize_nbs_html_fields(
+    entry: dict[str, object] | None,
+) -> dict[str, object] | None:
+    if not entry:
+        return None
+
+    sanitized = dict(entry)
+    for field in ("body_text", "body_markdown"):
+        value = sanitized.get(field)
+        if isinstance(value, str):
+            sanitized[field] = escape(unescape(value))
+
+    return sanitized
+
+
+def sanitize_nbs_detail_payload(
+    payload: dict[str, object],
+) -> dict[str, object]:
+    sanitized_payload = orjson.loads(orjson.dumps(payload))
+    if isinstance(sanitized_payload.get("nebs"), dict):
+        sanitized_payload["nebs"] = sanitize_nbs_html_fields(
+            cast(dict[str, object], sanitized_payload.get("nebs"))
+        )
+    if isinstance(sanitized_payload.get("entry"), dict):
+        sanitized_payload["entry"] = sanitize_nbs_html_fields(
+            cast(dict[str, object], sanitized_payload.get("entry"))
+        )
+    return sanitized_payload
+
+
+def build_nbs_fts_query(normalized_query: str) -> str:
+    tokens = re.findall(r"[0-9a-z]+", normalized_query or "")
+    if not tokens:
+        return ""
+    return " AND ".join(f"{token}*" for token in tokens)
+
+
+def build_nbs_excerpt(body_text: str, limit: int = 220) -> str:
+    compact = " ".join((body_text or "").split())
+    if len(compact) <= limit:
+        return compact
+    return f"{compact[: limit - 3].rstrip()}..."
+
+
+def resolve_nbs_code_aliases(code: str) -> tuple[list[str], list[str]]:
+    aliases = list(build_nbs_code_variants((code or "").strip()))
+    clean_aliases = [clean_nbs_code(alias) for alias in aliases if clean_nbs_code(alias)]
+    return aliases, list(dict.fromkeys(clean_aliases))
+
+
+def resolve_nbs_hierarchy_root(
+    item: dict[str, object], ancestors: list[dict[str, object]]
+) -> dict[str, object]:
+    if int(item["level"]) <= 1:
+        return item
+
+    for ancestor in ancestors:
+        if int(ancestor["level"]) == 1:
+            return ancestor
+
+    return ancestors[0] if ancestors else item
+
+
+async def fetch_nbs_items_by_prefix(
+    conn: aiosqlite.Connection,
+    root_code: str,
+    *,
+    limit: int | None = None,
+    offset: int = 0,
+) -> list[dict[str, object]]:
+    sql = """
+        SELECT code, code_clean, description, parent_code, level, has_nebs
+        FROM nbs_items
+        WHERE code = ? OR code LIKE ?
+        ORDER BY source_order ASC
+        """
+    params: list[object] = [root_code, f"{root_code}%"]
+    if limit is not None:
+        sql = f"{sql}\n LIMIT ? OFFSET ?"
+        params.extend([limit, max(offset, 0)])
+    cursor = await conn.execute(sql, params)
+    rows = await cursor.fetchall()
+    return [row_to_nbs_item(row) for row in rows]
+
+
+async def fetch_nbs_tree_page_sqlite(
+    conn: aiosqlite.Connection,
+    root_code: str,
+    *,
+    page: int,
+    page_size: int,
+) -> dict[str, object]:
+    normalized_page = normalize_nbs_page(page)
+    normalized_page_size = normalize_nbs_page_size(page_size)
+    offset = (normalized_page - 1) * normalized_page_size
+
+    count_cursor = await conn.execute(
+        """
+        SELECT COUNT(*) AS total
+        FROM nbs_items
+        WHERE code = ? OR code LIKE ?
+        """,
+        (root_code, f"{root_code}%"),
+    )
+    count_row = await count_cursor.fetchone()
+    total = int(count_row[0] if count_row else 0)
+    items = await fetch_nbs_items_by_prefix(
+        conn,
+        root_code,
+        limit=normalized_page_size,
+        offset=offset,
+    )
+    return {
+        "items": items,
+        "page": normalized_page,
+        "page_size": normalized_page_size,
+        "total": total,
+        "has_more": (offset + len(items)) < total,
+    }
+
+
+async def fetch_nbs_item_by_code(
+    conn: aiosqlite.Connection, code: str
+) -> dict[str, object]:
+    raw_code = (code or "").strip()
+    aliases, clean_aliases = resolve_nbs_code_aliases(raw_code)
+    if not aliases and not clean_aliases:
+        raise NotFoundError("Serviço NBS", raw_code)
+
+    where_clauses: list[str] = []
+    params: list[str] = []
+    if aliases:
+        where_clauses.append(f"code IN ({', '.join(['?'] * len(aliases))})")
+        params.extend(aliases)
+    if clean_aliases:
+        where_clauses.append(
+            f"code_clean IN ({', '.join(['?'] * len(clean_aliases))})"
+        )
+        params.extend(clean_aliases)
+
+    cursor = await conn.execute(
+        f"""
+        SELECT code, code_clean, description, parent_code, level, has_nebs
+        FROM nbs_items
+        WHERE {" OR ".join(where_clauses)}
+        ORDER BY LENGTH(code_clean) DESC, source_order ASC
+        LIMIT 1
+        """,
+        params,
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        raise NotFoundError("Serviço NBS", raw_code)
+    return row_to_nbs_item(row)
+
+
+async def fetch_nbs_ancestors(
+    conn: aiosqlite.Connection, item: dict[str, object]
+) -> list[dict[str, object]]:
+    ancestors: list[dict[str, object]] = []
+    parent_code = item["parent_code"]
+    visited_codes = {item["code"]}
+    depth = 0
+
+    while parent_code:
+        if depth >= MAX_ANCESTOR_DEPTH:
+            logger.warning(
+                "Stopping ancestor traversal at max depth for NBS code %s",
+                item["code"],
+            )
+            break
+        if parent_code in visited_codes:
+            logger.warning(
+                "Detected cyclic NBS ancestor chain for code %s via parent %s",
+                item["code"],
+                parent_code,
+            )
+            break
+        parent_cursor = await conn.execute(
+            """
+            SELECT code, code_clean, description, parent_code, level, has_nebs
+            FROM nbs_items
+            WHERE code = ?
+            LIMIT 1
+            """,
+            (parent_code,),
+        )
+        parent_row = await parent_cursor.fetchone()
+        if parent_row is None:
+            break
+        parent_item = row_to_nbs_item(parent_row)
+        visited_codes.add(parent_item["code"])
+        ancestors.append(parent_item)
+        parent_code = parent_item["parent_code"]
+        depth += 1
+
+    ancestors.reverse()
+    return ancestors

--- a/backend/services/nbs/types.py
+++ b/backend/services/nbs/types.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from collections import OrderedDict
+from contextlib import AbstractAsyncContextManager
 from pathlib import Path
-from typing import AsyncContextManager, AsyncIterator, Callable, Protocol, TypedDict
+from typing import Protocol, TypedDict
 
 import aiosqlite
 
@@ -73,7 +75,9 @@ class NbsServiceState(Protocol):
     _pool_lock: asyncio.Lock
     _pool_max_size: int
     _repository: NbsRepositoryProtocol | None
-    _repository_factory: Callable[[], AsyncContextManager[NbsRepositoryProtocol]] | None
+    _repository_factory: (
+        Callable[[], AbstractAsyncContextManager[NbsRepositoryProtocol]] | None
+    )
     _use_repository: bool
     _search_cache: OrderedDict[str, bytes]
     _detail_cache: OrderedDict[str, bytes]

--- a/backend/services/nbs/types.py
+++ b/backend/services/nbs/types.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+from collections import OrderedDict
+from pathlib import Path
+from typing import AsyncContextManager, AsyncIterator, Callable, Protocol, TypedDict
+
+import aiosqlite
+
+NBS_ALLOWED_TABLES = {"nbs_items", "nebs_entries", "catalog_metadata"}
+MAX_ANCESTOR_DEPTH = 64
+NBS_SEARCH_CACHE_SIZE = 64
+NBS_DETAIL_CACHE_SIZE = 24
+DEFAULT_TREE_PAGE = 1
+DEFAULT_TREE_PAGE_SIZE = 50
+MAX_TREE_PAGE_SIZE = 200
+REPOSITORY_UNAVAILABLE_ERROR = "NBS repository unavailable"
+NEBS_PUBLIC_FIELDS = (
+    "code",
+    "code_clean",
+    "title",
+    "title_normalized",
+    "body_text",
+    "body_markdown",
+    "body_normalized",
+    "section_title",
+    "page_start",
+    "page_end",
+)
+
+
+class NbsRepositoryProtocol(Protocol):
+    tenant_id: str | None
+
+    async def load_nbs_catalog_entries(
+        self, query: str, limit: int = 50
+    ) -> list[dict[str, object]]: ...
+
+    async def load_nbs_catalog_item_details(
+        self,
+        code: str,
+        *,
+        include_tree: bool = True,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> dict[str, object]: ...
+
+    async def load_nbs_catalog_tree_page(
+        self,
+        code: str,
+        *,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> dict[str, object]: ...
+
+    async def load_nbs_explanatory_entries(
+        self, query: str, limit: int = 50
+    ) -> list[dict[str, object]]: ...
+
+    async def load_nbs_explanatory_entry_details(
+        self, code: str
+    ) -> dict[str, object]: ...
+
+    async def snapshot_nbs_catalog_counts(self) -> dict[str, object]: ...
+
+    async def snapshot_nbs_catalog_metadata(self) -> dict[str, str]: ...
+
+
+class NbsServiceState(Protocol):
+    db_path: Path
+    _schema_columns_cache: dict[str, set[str]]
+    _pool: list[aiosqlite.Connection]
+    _pool_lock: asyncio.Lock
+    _pool_max_size: int
+    _repository: NbsRepositoryProtocol | None
+    _repository_factory: Callable[[], AsyncContextManager[NbsRepositoryProtocol]] | None
+    _use_repository: bool
+    _search_cache: OrderedDict[str, bytes]
+    _detail_cache: OrderedDict[str, bytes]
+    _cache_lock: asyncio.Lock | None
+
+
+class NbsSearchPayload(TypedDict):
+    success: bool
+    query: str
+    normalized: str
+    results: list[dict[str, object]]
+    total: int
+
+
+class NbsCatalogHealthPayload(TypedDict, total=False):
+    status: str
+    nbs_items: int
+    nebs_entries: int
+    metadata: dict[str, str]
+    error: str
+
+
+class NbsCatalogItemPayload(TypedDict, total=False):
+    code: str
+    code_clean: str
+    description: str
+    parent_code: str | None
+    level: int
+    has_nebs: bool
+
+
+class NbsCatalogDetailPayload(TypedDict, total=False):
+    success: bool
+    item: dict[str, object]
+    ancestors: list[dict[str, object]]
+    children: list[dict[str, object]]
+    chapter_root: dict[str, object]
+    chapter_items: list[dict[str, object]]
+    chapter_page: dict[str, object]
+    nebs: dict[str, object] | None
+    entry: dict[str, object] | None

--- a/backend/services/nbs_service.py
+++ b/backend/services/nbs_service.py
@@ -190,9 +190,7 @@ class NbsService:
         """Busca entradas NEBS por código ou texto."""
         return await search_nbs_explanatory_entries(self, query, limit=limit)
 
-    async def search_nebs(
-        self, query: str, *, limit: int = 50
-    ) -> dict[str, object]:
+    async def search_nebs(self, query: str, *, limit: int = 50) -> dict[str, object]:
         return await self.searchNbsExplanatoryEntries(query, limit=limit)
 
     async def fetchNbsExplanatoryEntryDetails(self, code: str) -> dict[str, object]:
@@ -215,4 +213,5 @@ __all__ = [
     "DEFAULT_TREE_PAGE_SIZE",
     "MAX_TREE_PAGE_SIZE",
     "NbsService",
+    "redis_cache",
 ]

--- a/backend/services/nbs_service.py
+++ b/backend/services/nbs_service.py
@@ -1,4 +1,4 @@
-"""Async service for the NBS / NEBS catalog.
+"""Async facade for the NBS / NEBS catalog.
 
 Supports the legacy SQLite ``services.db`` mode and the PostgreSQL repository
 mode used by the production/runtime path.
@@ -7,39 +7,39 @@ mode used by the production/runtime path.
 from __future__ import annotations
 
 import asyncio
-import hashlib
-import re
 from collections import OrderedDict
 from contextlib import asynccontextmanager
-from html import escape, unescape
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AsyncIterator, cast
+from typing import AsyncContextManager, AsyncIterator, Callable, TYPE_CHECKING, cast
 
 import aiosqlite
-import orjson
 
-from backend.config.exceptions import (
-    DatabaseError,
-    DatabaseNotFoundError,
-    NotFoundError,
-)
 from backend.config.logging_config import service_logger as logger
 from backend.config.settings import settings
 from backend.infrastructure.redis_client import redis_cache
-from backend.utils.nbs_parser import (
-    build_nbs_code_variants,
-    clean_nbs_code,
-    normalize_nbs_text,
+
+from .nbs.details import (
+    fetch_nbs_catalog_item_details,
+    fetch_nbs_catalog_tree_page,
+    fetch_nbs_explanatory_entry_details,
+)
+from .nbs.health import probe_nbs_catalog_health
+from .nbs.search import search_nbs_catalog_entries, search_nbs_explanatory_entries
+from .nbs.types import (
+    DEFAULT_TREE_PAGE,
+    DEFAULT_TREE_PAGE_SIZE,
+    MAX_TREE_PAGE_SIZE,
+    NbsRepositoryProtocol,
 )
 
 get_session = None
-tenant_context = None
+NbsRepository = None
 try:
-    from backend.infrastructure.db_engine import get_session, tenant_context
+    from backend.infrastructure.db_engine import get_session
     from backend.infrastructure.repositories.nbs_repository import NbsRepository
 
     _REPO_AVAILABLE = True
-except ImportError:
+except ImportError:  # pragma: no cover - optional repository dependency
     _REPO_AVAILABLE = False
     NbsRepository = None
 
@@ -47,27 +47,6 @@ if TYPE_CHECKING:
     from backend.infrastructure.repositories.nbs_repository import (
         NbsRepository as _NbsRepository,
     )
-
-NBS_ALLOWED_TABLES = {"nbs_items", "nebs_entries", "catalog_metadata"}
-MAX_ANCESTOR_DEPTH = 64
-SERVICE_SEARCH_CACHE_SIZE = 64
-SERVICE_DETAIL_CACHE_SIZE = 24
-DEFAULT_TREE_PAGE = 1
-DEFAULT_TREE_PAGE_SIZE = 50
-MAX_TREE_PAGE_SIZE = 200
-REPOSITORY_UNAVAILABLE_ERROR = "NBS repository unavailable"
-NEBS_PUBLIC_FIELDS = (
-    "code",
-    "code_clean",
-    "title",
-    "title_normalized",
-    "body_text",
-    "body_markdown",
-    "body_normalized",
-    "section_title",
-    "page_start",
-    "page_end",
-)
 
 
 class NbsService:
@@ -77,8 +56,9 @@ class NbsService:
         self,
         db_path: str | Path | None = None,
         *,
-        repository: "_NbsRepository | None" = None,
-        repository_factory=None,
+        repository: NbsRepositoryProtocol | None = None,
+        repository_factory: Callable[[], AsyncContextManager[NbsRepositoryProtocol]]
+        | None = None,
     ):
         self.db_path = Path(db_path or settings.database.services_path)
         self._schema_columns_cache: dict[str, set[str]] = {}
@@ -92,8 +72,10 @@ class NbsService:
         self._detail_cache: OrderedDict[str, bytes] = OrderedDict()
         self._cache_lock: asyncio.Lock | None = None
 
-        mode = "Repository" if self._use_repository else "aiosqlite"
-        logger.info("NbsService inicializado (modo: %s)", mode)
+        logger.info(
+            "NbsService inicializado (modo: %s)",
+            "Repository" if self._use_repository else "SQLite",
+        )
 
     async def __aenter__(self) -> NbsService:
         return self
@@ -103,7 +85,7 @@ class NbsService:
 
     @classmethod
     async def initializeNbsServiceWithPostgresRepository(cls) -> "NbsService":
-        """Factory assíncrono para criar o serviço via repository/AsyncSession."""
+        """Cria `NbsService` com `NbsRepository` via SQLModel."""
         if not _REPO_AVAILABLE:
             raise RuntimeError("Repository não disponível. Instale sqlmodel.")
         if get_session is None:
@@ -111,7 +93,7 @@ class NbsService:
         repository_cls = cast("type[_NbsRepository]", NbsRepository)
 
         @asynccontextmanager
-        async def repo_factory() -> AsyncIterator["_NbsRepository"]:
+        async def repo_factory() -> AsyncIterator[NbsRepositoryProtocol]:
             async with get_session() as session:
                 yield repository_cls(session)
 
@@ -121,159 +103,6 @@ class NbsService:
     async def create_with_repository(cls) -> "NbsService":
         return await cls.initializeNbsServiceWithPostgresRepository()
 
-    @asynccontextmanager
-    async def _get_repo(self) -> AsyncIterator["_NbsRepository | None"]:
-        if self._repository is not None:
-            yield self._repository
-            return
-        if self._repository_factory is not None:
-            async with self._repository_factory() as repo:
-                yield repo
-            return
-        yield None
-
-    def _get_cache_lock(self) -> asyncio.Lock:
-        if self._cache_lock is None:
-            self._cache_lock = asyncio.Lock()
-        return self._cache_lock
-
-    @staticmethod
-    def _normalize_page(page: int) -> int:
-        return max(int(page or 1), 1)
-
-    @staticmethod
-    def _normalize_page_size(page_size: int) -> int:
-        normalized = int(page_size or DEFAULT_TREE_PAGE_SIZE)
-        return min(max(normalized, 1), MAX_TREE_PAGE_SIZE)
-
-    @staticmethod
-    def _build_cache_key(*parts: Any) -> str:
-        serialized = "|".join(str(part) for part in parts)
-        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
-
-    @staticmethod
-    def _resolve_cache_scope(repo: "_NbsRepository | None" = None) -> str:
-        tenant_id = getattr(repo, "tenant_id", None)
-        if not tenant_id and tenant_context is not None:
-            tenant_id = tenant_context.get() or None
-        return str(tenant_id or "public")
-
-    async def _get_l1_cached_payload(
-        self,
-        cache: OrderedDict[str, bytes],
-        key: str,
-    ) -> dict[str, Any] | None:
-        async with self._get_cache_lock():
-            cached = cache.get(key)
-            if cached is None:
-                return None
-            cache.move_to_end(key)
-        return orjson.loads(cached)
-
-    async def _store_l1_payload(
-        self,
-        cache: OrderedDict[str, bytes],
-        key: str,
-        payload: dict[str, Any],
-        *,
-        max_size: int,
-    ) -> None:
-        encoded = orjson.dumps(payload)
-        async with self._get_cache_lock():
-            cache[key] = encoded
-            cache.move_to_end(key)
-            while len(cache) > max_size:
-                cache.popitem(last=False)
-
-    async def _get_cached_search_payload(
-        self, namespace: str, scope: str, key: str
-    ) -> dict[str, Any] | None:
-        cache_key = f"{namespace}:{scope}:{key}"
-        cached = await self._get_l1_cached_payload(self._search_cache, cache_key)
-        if cached is not None:
-            return cached
-        if not redis_cache.available:
-            return None
-        cached = await redis_cache.get_services_search(namespace, scope, key)
-        if cached is None:
-            return None
-        await self._store_l1_payload(
-            self._search_cache,
-            cache_key,
-            cached,
-            max_size=SERVICE_SEARCH_CACHE_SIZE,
-        )
-        return cached
-
-    async def _store_search_payload(
-        self, namespace: str, scope: str, key: str, payload: dict[str, Any]
-    ) -> None:
-        cache_key = f"{namespace}:{scope}:{key}"
-        await self._store_l1_payload(
-            self._search_cache,
-            cache_key,
-            payload,
-            max_size=SERVICE_SEARCH_CACHE_SIZE,
-        )
-        if redis_cache.available:
-            await redis_cache.set_services_search(namespace, scope, key, payload)
-
-    async def _get_cached_detail_payload(
-        self, namespace: str, scope: str, key: str
-    ) -> dict[str, Any] | None:
-        cache_key = f"{namespace}:{scope}:{key}"
-        cached = await self._get_l1_cached_payload(self._detail_cache, cache_key)
-        if cached is not None:
-            return cached
-        if not redis_cache.available:
-            return None
-        cached = await redis_cache.get_services_detail(namespace, scope, key)
-        if cached is None:
-            return None
-        await self._store_l1_payload(
-            self._detail_cache,
-            cache_key,
-            cached,
-            max_size=SERVICE_DETAIL_CACHE_SIZE,
-        )
-        return cached
-
-    async def _store_detail_payload(
-        self, namespace: str, scope: str, key: str, payload: dict[str, Any]
-    ) -> None:
-        cache_key = f"{namespace}:{scope}:{key}"
-        await self._store_l1_payload(
-            self._detail_cache,
-            cache_key,
-            payload,
-            max_size=SERVICE_DETAIL_CACHE_SIZE,
-        )
-        if redis_cache.available:
-            await redis_cache.set_services_detail(namespace, scope, key, payload)
-
-    async def _get_connection(self) -> aiosqlite.Connection:
-        if not self.db_path.exists():
-            raise DatabaseNotFoundError(str(self.db_path))
-
-        async with self._pool_lock:
-            if self._pool:
-                return self._pool.pop()
-
-        try:
-            conn = await aiosqlite.connect(self.db_path)
-            conn.row_factory = aiosqlite.Row
-            return conn
-        except Exception as exc:
-            logger.error("Failed to connect to services DB: %s", exc)
-            raise DatabaseError(f"Services DB connection failed: {exc}") from exc
-
-    async def _release_connection(self, conn: aiosqlite.Connection) -> None:
-        async with self._pool_lock:
-            if len(self._pool) < self._pool_max_size:
-                self._pool.append(conn)
-                return
-        await conn.close()
-
     async def shutdownNbsServiceResources(self) -> None:
         async with self._pool_lock:
             while self._pool:
@@ -282,469 +111,39 @@ class NbsService:
                     await conn.close()
                 except Exception as exc:
                     logger.warning("Error closing NBS pool connection: %s", exc)
-        async with self._get_cache_lock():
-            self._search_cache.clear()
-            self._detail_cache.clear()
+        if self._cache_lock is not None:
+            async with self._cache_lock:
+                self._search_cache.clear()
+                self._detail_cache.clear()
 
     async def close(self) -> None:
         await self.shutdownNbsServiceResources()
 
-    @staticmethod
-    def _build_health_payload(
-        nbs_items: int,
-        nebs_entries: int,
-        metadata: dict[str, Any],
-    ) -> dict[str, Any]:
-        status = "online" if nbs_items > 0 and nebs_entries > 0 else "error"
-        return {
-            "status": status,
-            "nbs_items": nbs_items,
-            "nebs_entries": nebs_entries,
-            "metadata": metadata,
-        }
+    async def searchNbsCatalogEntries(
+        self, query: str, *, limit: int = 50
+    ) -> dict[str, object]:
+        """Busca entradas NBS por código ou descrição."""
+        return await search_nbs_catalog_entries(self, query, limit=limit)
 
-    @staticmethod
-    def _require_repository(repo: "_NbsRepository | None") -> "_NbsRepository":
-        if repo is None:
-            raise RuntimeError(REPOSITORY_UNAVAILABLE_ERROR)
-        return repo
+    async def search(self, query: str, *, limit: int = 50) -> dict[str, object]:
+        return await self.searchNbsCatalogEntries(query, limit=limit)
 
-    async def _check_repository_connection(self) -> dict[str, Any]:
-        async with self._get_repo() as repo:
-            repository = self._require_repository(repo)
-            counts = await repository.get_catalog_counts()
-            metadata = await repository.get_catalog_metadata()
-
-        return self._build_health_payload(
-            int(counts.get("nbs_items", 0)),
-            int(counts.get("nebs_entries", 0)),
-            metadata,
-        )
-
-    async def _get_sqlite_count(
+    async def fetchNbsCatalogItemDetails(
         self,
-        conn: aiosqlite.Connection,
-        table: str,
-        query: str,
-    ) -> int:
-        if not await self._table_exists(conn, table):
-            return 0
-        cursor = await conn.execute(query)
-        row = await cursor.fetchone()
-        return int(row[0] if row else 0)
-
-    async def _get_sqlite_catalog_metadata(
-        self, conn: aiosqlite.Connection
-    ) -> dict[str, str]:
-        if not await self._table_exists(conn, "catalog_metadata"):
-            return {}
-        cursor = await conn.execute("SELECT key, value FROM catalog_metadata")
-        return {row["key"]: row["value"] for row in await cursor.fetchall()}
-
-    async def check_connection(self) -> dict[str, Any]:
-        """Return readiness, counts and metadata for the services catalog."""
-        if self._use_repository:
-            try:
-                return await self._check_repository_connection()
-            except Exception as exc:
-                logger.error("NBS repository healthcheck failed: %s", exc)
-                return {"status": "error", "error": str(exc)}
-
-        if not self.db_path.exists():
-            return {
-                "status": "error",
-                "error": f"Banco NBS não encontrado: {self.db_path}",
-            }
-
-        conn = await self._get_connection()
-        try:
-            nbs_count = await self._get_sqlite_count(
-                conn,
-                "nbs_items",
-                "SELECT COUNT(*) FROM nbs_items",
-            )
-            nebs_count = await self._get_sqlite_count(
-                conn,
-                "nebs_entries",
-                "SELECT COUNT(*) FROM nebs_entries WHERE parser_status = 'trusted'",
-            )
-            metadata = await self._get_sqlite_catalog_metadata(conn)
-            return self._build_health_payload(nbs_count, nebs_count, metadata)
-        except Exception as exc:
-            logger.error("NBS SQLite healthcheck failed: %s", exc)
-            return {"status": "error", "error": str(exc)}
-        finally:
-            await self._release_connection(conn)
-
-    async def _get_table_columns(
-        self, conn: aiosqlite.Connection, table: str
-    ) -> set[str]:
-        if table not in NBS_ALLOWED_TABLES:
-            raise ValueError(f"Tabela não permitida para inspeção de schema: {table}")
-        if table in self._schema_columns_cache:
-            return self._schema_columns_cache[table]
-
-        cursor = await conn.execute(f"PRAGMA table_info({table})")
-        rows = await cursor.fetchall()
-        cols = {row["name"] for row in rows}
-        self._schema_columns_cache[table] = cols
-        return cols
-
-    async def _table_exists(self, conn: aiosqlite.Connection, table: str) -> bool:
-        cursor = await conn.execute(
-            """
-            SELECT 1
-            FROM sqlite_master
-            WHERE type IN ('table', 'view') AND name = ?
-            LIMIT 1
-            """,
-            (table,),
-        )
-        row = await cursor.fetchone()
-        return row is not None
-
-    @staticmethod
-    def _row_to_item(row: aiosqlite.Row) -> dict[str, Any]:
-        return {
-            "code": row["code"],
-            "code_clean": row["code_clean"],
-            "description": row["description"],
-            "parent_code": row["parent_code"],
-            "level": row["level"],
-            "has_nebs": bool(row["has_nebs"]),
-        }
-
-    @staticmethod
-    def _row_to_nebs_entry_internal(row: aiosqlite.Row) -> dict[str, Any]:
-        return {
-            "code": row["code"],
-            "code_clean": row["code_clean"],
-            "title": row["title"],
-            "title_normalized": row["title_normalized"],
-            "body_text": row["body_text"],
-            "body_markdown": row["body_markdown"],
-            "body_normalized": row["body_normalized"],
-            "section_title": row["section_title"],
-            "page_start": row["page_start"],
-            "page_end": row["page_end"],
-            "parser_status": row["parser_status"],
-            "parse_warnings": row["parse_warnings"],
-            "source_hash": row["source_hash"],
-            "updated_at": row["updated_at"],
-        }
-
-    @staticmethod
-    def _to_public_nebs_entry(entry: dict[str, Any] | None) -> dict[str, Any] | None:
-        if not entry:
-            return None
-        return NbsService._sanitize_nebs_html_fields(
-            {field: entry[field] for field in NEBS_PUBLIC_FIELDS}
-        )
-
-    @staticmethod
-    def _sanitize_nebs_html_fields(
-        entry: dict[str, Any] | None,
-    ) -> dict[str, Any] | None:
-        if not entry:
-            return None
-
-        sanitized = dict(entry)
-        for field in ("body_text", "body_markdown"):
-            value = sanitized.get(field)
-            if isinstance(value, str):
-                sanitized[field] = escape(unescape(value))
-
-        return sanitized
-
-    @classmethod
-    def _sanitize_detail_payload(cls, payload: dict[str, Any]) -> dict[str, Any]:
-        sanitized_payload = orjson.loads(orjson.dumps(payload))
-        if isinstance(sanitized_payload.get("nebs"), dict):
-            sanitized_payload["nebs"] = cls._sanitize_nebs_html_fields(
-                cast(dict[str, Any], sanitized_payload.get("nebs"))
-            )
-        if isinstance(sanitized_payload.get("entry"), dict):
-            sanitized_payload["entry"] = cls._sanitize_nebs_html_fields(
-                cast(dict[str, Any], sanitized_payload.get("entry"))
-            )
-        return sanitized_payload
-
-    @staticmethod
-    def _build_nebs_fts_query(normalized_query: str) -> str:
-        tokens = re.findall(r"[0-9a-z]+", normalized_query or "")
-        if not tokens:
-            return ""
-        return " AND ".join(f"{token}*" for token in tokens)
-
-    @staticmethod
-    def _build_excerpt(body_text: str, limit: int = 220) -> str:
-        compact = " ".join((body_text or "").split())
-        if len(compact) <= limit:
-            return compact
-        return f"{compact[: limit - 3].rstrip()}..."
-
-    @staticmethod
-    def _resolve_code_aliases(code: str) -> tuple[list[str], list[str]]:
-        aliases = list(build_nbs_code_variants((code or "").strip()))
-        clean_aliases = [
-            clean_nbs_code(alias) for alias in aliases if clean_nbs_code(alias)
-        ]
-        return aliases, list(dict.fromkeys(clean_aliases))
-
-    @staticmethod
-    def _resolve_hierarchy_root(
-        item: dict[str, Any], ancestors: list[dict[str, Any]]
-    ) -> dict[str, Any]:
-        if item["level"] <= 1:
-            return item
-
-        for ancestor in ancestors:
-            if ancestor["level"] == 1:
-                return ancestor
-
-        return ancestors[0] if ancestors else item
-
-    async def _fetch_items_by_prefix(
-        self,
-        conn: aiosqlite.Connection,
-        root_code: str,
+        code: str,
         *,
-        limit: int | None = None,
-        offset: int = 0,
-    ) -> list[dict[str, Any]]:
-        sql = """
-            SELECT code, code_clean, description, parent_code, level, has_nebs
-            FROM nbs_items
-            WHERE code = ? OR code LIKE ?
-            ORDER BY source_order ASC
-            """
-        params: list[Any] = [root_code, f"{root_code}%"]
-        if limit is not None:
-            sql = f"{sql}\n LIMIT ? OFFSET ?"
-            params.extend([limit, max(offset, 0)])
-        cursor = await conn.execute(sql, params)
-        rows = await cursor.fetchall()
-        return [self._row_to_item(row) for row in rows]
-
-    async def _get_tree_page_sqlite(
-        self,
-        conn: aiosqlite.Connection,
-        root_code: str,
-        *,
-        page: int,
-        page_size: int,
-    ) -> dict[str, Any]:
-        normalized_page = self._normalize_page(page)
-        normalized_page_size = self._normalize_page_size(page_size)
-        offset = (normalized_page - 1) * normalized_page_size
-
-        count_cursor = await conn.execute(
-            """
-            SELECT COUNT(*) AS total
-            FROM nbs_items
-            WHERE code = ? OR code LIKE ?
-            """,
-            (root_code, f"{root_code}%"),
+        include_tree: bool = True,
+        page: int = 1,
+        page_size: int = DEFAULT_TREE_PAGE_SIZE,
+    ) -> dict[str, object]:
+        """Recupera o detalhe de um item NBS e seu contexto hierárquico."""
+        return await fetch_nbs_catalog_item_details(
+            self,
+            code,
+            include_tree=include_tree,
+            page=page,
+            page_size=page_size,
         )
-        count_row = await count_cursor.fetchone()
-        total = int(count_row[0] if count_row else 0)
-        items = await self._fetch_items_by_prefix(
-            conn,
-            root_code,
-            limit=normalized_page_size,
-            offset=offset,
-        )
-        return {
-            "items": items,
-            "page": normalized_page,
-            "page_size": normalized_page_size,
-            "total": total,
-            "has_more": (offset + len(items)) < total,
-        }
-
-    async def _fetch_item_by_code(
-        self, conn: aiosqlite.Connection, code: str
-    ) -> dict[str, Any]:
-        raw_code = (code or "").strip()
-        aliases, clean_aliases = self._resolve_code_aliases(raw_code)
-        if not aliases and not clean_aliases:
-            raise NotFoundError("Serviço NBS", raw_code)
-
-        where_clauses: list[str] = []
-        params: list[str] = []
-        if aliases:
-            where_clauses.append(f"code IN ({', '.join(['?'] * len(aliases))})")
-            params.extend(aliases)
-        if clean_aliases:
-            where_clauses.append(
-                f"code_clean IN ({', '.join(['?'] * len(clean_aliases))})"
-            )
-            params.extend(clean_aliases)
-
-        cursor = await conn.execute(
-            f"""
-            SELECT code, code_clean, description, parent_code, level, has_nebs
-            FROM nbs_items
-            WHERE {" OR ".join(where_clauses)}
-            ORDER BY LENGTH(code_clean) DESC, source_order ASC
-            LIMIT 1
-            """,
-            params,
-        )
-        row = await cursor.fetchone()
-        if row is None:
-            raise NotFoundError("Serviço NBS", raw_code)
-        return self._row_to_item(row)
-
-    async def _fetch_ancestors(
-        self, conn: aiosqlite.Connection, item: dict[str, Any]
-    ) -> list[dict[str, Any]]:
-        ancestors: list[dict[str, Any]] = []
-        parent_code = item["parent_code"]
-        visited_codes = {item["code"]}
-        depth = 0
-
-        while parent_code:
-            if depth >= MAX_ANCESTOR_DEPTH:
-                logger.warning(
-                    "Stopping ancestor traversal at max depth for NBS code %s",
-                    item["code"],
-                )
-                break
-            if parent_code in visited_codes:
-                logger.warning(
-                    "Detected cyclic NBS ancestor chain for code %s via parent %s",
-                    item["code"],
-                    parent_code,
-                )
-                break
-            parent_cursor = await conn.execute(
-                """
-                SELECT code, code_clean, description, parent_code, level, has_nebs
-                FROM nbs_items
-                WHERE code = ?
-                LIMIT 1
-                """,
-                (parent_code,),
-            )
-            parent_row = await parent_cursor.fetchone()
-            if parent_row is None:
-                break
-            parent_item = self._row_to_item(parent_row)
-            visited_codes.add(parent_item["code"])
-            ancestors.append(parent_item)
-            parent_code = parent_item["parent_code"]
-            depth += 1
-
-        ancestors.reverse()
-        return ancestors
-
-    async def search(self, query: str, *, limit: int = 50) -> dict[str, Any]:
-        raw_query = (query or "").strip()
-        normalized_query = normalize_nbs_text(raw_query)
-        clean_query = clean_nbs_code(raw_query)
-        cache_key = self._build_cache_key("nbs", raw_query, normalized_query, limit)
-        scope = self._resolve_cache_scope(self._repository)
-        cached = await self._get_cached_search_payload("nbs", scope, cache_key)
-        if cached is not None:
-            return cached
-
-        if self._use_repository:
-            async with self._get_repo() as repo:
-                repository = self._require_repository(repo)
-                scoped_key = self._resolve_cache_scope(repository)
-                if scoped_key != scope:
-                    cached = await self._get_cached_search_payload(
-                        "nbs", scoped_key, cache_key
-                    )
-                    if cached is not None:
-                        return cached
-                scope = scoped_key
-                results = await repository.search(raw_query, limit=limit)
-            payload = {
-                "success": True,
-                "query": raw_query,
-                "normalized": normalized_query,
-                "results": results,
-                "total": len(results),
-            }
-            await self._store_search_payload("nbs", scope, cache_key, payload)
-            return payload
-
-        conn = await self._get_connection()
-        try:
-            await self._get_table_columns(conn, "nbs_items")
-            if not raw_query:
-                cursor = await conn.execute(
-                    """
-                    SELECT code, code_clean, description, parent_code, level, has_nebs
-                    FROM nbs_items
-                    WHERE parent_code IS NULL
-                    ORDER BY source_order ASC
-                    LIMIT ?
-                    """,
-                    (limit,),
-                )
-                rows = await cursor.fetchall()
-            elif not clean_query and not normalized_query:
-                rows = []
-            else:
-                cursor = await conn.execute(
-                    """
-                    SELECT
-                        code,
-                        code_clean,
-                        description,
-                        parent_code,
-                        level,
-                        has_nebs,
-                        CASE
-                            WHEN code_clean = ? THEN 500
-                            WHEN code = ? THEN 480
-                            WHEN code_clean LIKE ? THEN 420
-                            WHEN description_normalized = ? THEN 360
-                            WHEN description_normalized LIKE ? THEN 320
-                            ELSE 200
-                        END AS match_score
-                    FROM nbs_items
-                    WHERE
-                        (? <> '' AND code_clean = ?)
-                        OR (? <> '' AND code_clean LIKE ?)
-                        OR (? <> '' AND code LIKE ?)
-                        OR (? <> '' AND description_normalized LIKE ?)
-                    ORDER BY match_score DESC, LENGTH(code_clean) ASC, source_order ASC
-                    LIMIT ?
-                    """,
-                    (
-                        clean_query,
-                        raw_query,
-                        f"{clean_query}%",
-                        normalized_query,
-                        f"{normalized_query}%",
-                        clean_query,
-                        clean_query,
-                        clean_query,
-                        f"{clean_query}%",
-                        raw_query,
-                        f"{raw_query}%",
-                        normalized_query,
-                        f"%{normalized_query}%",
-                        limit,
-                    ),
-                )
-                rows = await cursor.fetchall()
-
-            payload = {
-                "success": True,
-                "query": raw_query,
-                "normalized": normalized_query,
-                "results": [self._row_to_item(row) for row in rows],
-                "total": len(rows),
-            }
-            await self._store_search_payload("nbs", scope, cache_key, payload)
-            return payload
-        finally:
-            await self._release_connection(conn)
 
     async def get_item_details(
         self,
@@ -753,118 +152,28 @@ class NbsService:
         include_tree: bool = True,
         page: int = 1,
         page_size: int = DEFAULT_TREE_PAGE_SIZE,
-    ) -> dict[str, Any]:
-        normalized_code = (code or "").strip()
-        normalized_page = self._normalize_page(page)
-        normalized_page_size = self._normalize_page_size(page_size)
-        cache_key = self._build_cache_key(
-            "nbs-detail",
-            normalized_code,
-            include_tree,
-            normalized_page,
-            normalized_page_size,
+    ) -> dict[str, object]:
+        return await self.fetchNbsCatalogItemDetails(
+            code,
+            include_tree=include_tree,
+            page=page,
+            page_size=page_size,
         )
-        scope = self._resolve_cache_scope(self._repository)
-        cached = await self._get_cached_detail_payload("nbs", scope, cache_key)
-        if cached is not None:
-            return cached
 
-        if self._use_repository:
-            async with self._get_repo() as repo:
-                repository = self._require_repository(repo)
-                scoped_key = self._resolve_cache_scope(repository)
-                if scoped_key != scope:
-                    cached = await self._get_cached_detail_payload(
-                        "nbs", scoped_key, cache_key
-                    )
-                    if cached is not None:
-                        return cached
-                scope = scoped_key
-                payload = await repository.get_item_details(
-                    normalized_code,
-                    include_tree=include_tree,
-                    page=normalized_page,
-                    page_size=normalized_page_size,
-                )
-            payload = self._sanitize_detail_payload(payload)
-            await self._store_detail_payload("nbs", scope, cache_key, payload)
-            return payload
-
-        conn = await self._get_connection()
-        try:
-            item = await self._fetch_item_by_code(conn, normalized_code)
-            ancestors = await self._fetch_ancestors(conn, item)
-            chapter_root = self._resolve_hierarchy_root(item, ancestors)
-
-            children_cursor = await conn.execute(
-                """
-                SELECT code, code_clean, description, parent_code, level, has_nebs
-                FROM nbs_items
-                WHERE parent_code = ?
-                ORDER BY source_order ASC
-                """,
-                (item["code"],),
-            )
-            child_rows = await children_cursor.fetchall()
-            tree_page = (
-                await self._get_tree_page_sqlite(
-                    conn,
-                    chapter_root["code"],
-                    page=normalized_page,
-                    page_size=normalized_page_size,
-                )
-                if include_tree
-                else None
-            )
-
-            nebs_cursor = await conn.execute(
-                """
-                SELECT
-                    code,
-                    code_clean,
-                    title,
-                    title_normalized,
-                    body_text,
-                    body_markdown,
-                    body_normalized,
-                    section_title,
-                    page_start,
-                    page_end,
-                    parser_status,
-                    parse_warnings,
-                    source_hash,
-                    updated_at
-                FROM nebs_entries
-                WHERE code = ? AND parser_status = 'trusted'
-                LIMIT 1
-                """,
-                (item["code"],),
-            )
-            nebs_row = await nebs_cursor.fetchone()
-            nebs_payload = (
-                None
-                if nebs_row is None
-                else self._to_public_nebs_entry(
-                    self._row_to_nebs_entry_internal(nebs_row)
-                )
-            )
-
-            payload = {
-                "success": True,
-                "item": item,
-                "ancestors": ancestors,
-                "children": [self._row_to_item(row) for row in child_rows],
-                "chapter_root": chapter_root,
-                "nebs": nebs_payload,
-            }
-            if tree_page is not None:
-                payload["chapter_items"] = tree_page["items"]
-                payload["chapter_page"] = tree_page
-            payload = self._sanitize_detail_payload(payload)
-            await self._store_detail_payload("nbs", scope, cache_key, payload)
-            return payload
-        finally:
-            await self._release_connection(conn)
+    async def fetchNbsCatalogTreePage(
+        self,
+        code: str,
+        *,
+        page: int = 1,
+        page_size: int = DEFAULT_TREE_PAGE_SIZE,
+    ) -> dict[str, object]:
+        """Recupera a página da árvore do capítulo NBS."""
+        return await fetch_nbs_catalog_tree_page(
+            self,
+            code,
+            page=page,
+            page_size=page_size,
+        )
 
     async def get_item_tree_page(
         self,
@@ -872,284 +181,38 @@ class NbsService:
         *,
         page: int = 1,
         page_size: int = DEFAULT_TREE_PAGE_SIZE,
-    ) -> dict[str, Any]:
-        detail = await self.get_item_details(
-            code,
-            include_tree=True,
-            page=page,
-            page_size=page_size,
-        )
-        return {
-            "success": True,
-            "item": detail["item"],
-            "chapter_root": detail.get("chapter_root"),
-            "chapter_page": detail.get("chapter_page")
-            or {
-                "items": detail.get("chapter_items", []),
-                "page": self._normalize_page(page),
-                "page_size": self._normalize_page_size(page_size),
-                "total": len(detail.get("chapter_items", [])),
-                "has_more": False,
-            },
-        }
+    ) -> dict[str, object]:
+        return await self.fetchNbsCatalogTreePage(code, page=page, page_size=page_size)
 
-    async def search_nebs(self, query: str, *, limit: int = 50) -> dict[str, Any]:
-        raw_query = (query or "").strip()
-        normalized_query = normalize_nbs_text(raw_query)
-        clean_query = clean_nbs_code(raw_query)
-        fts_query = self._build_nebs_fts_query(normalized_query)
-        cache_key = self._build_cache_key("nebs", raw_query, normalized_query, limit)
-        scope = self._resolve_cache_scope(self._repository)
-        cached = await self._get_cached_search_payload("nebs", scope, cache_key)
-        if cached is not None:
-            return cached
+    async def searchNbsExplanatoryEntries(
+        self, query: str, *, limit: int = 50
+    ) -> dict[str, object]:
+        """Busca entradas NEBS por código ou texto."""
+        return await search_nbs_explanatory_entries(self, query, limit=limit)
 
-        if self._use_repository:
-            async with self._get_repo() as repo:
-                repository = self._require_repository(repo)
-                scoped_key = self._resolve_cache_scope(repository)
-                if scoped_key != scope:
-                    cached = await self._get_cached_search_payload(
-                        "nebs", scoped_key, cache_key
-                    )
-                    if cached is not None:
-                        return cached
-                scope = scoped_key
-                results = await repository.search_nebs(raw_query, limit=limit)
-            payload = {
-                "success": True,
-                "query": raw_query,
-                "normalized": normalized_query,
-                "results": results,
-                "total": len(results),
-            }
-            await self._store_search_payload("nebs", scope, cache_key, payload)
-            return payload
+    async def search_nebs(
+        self, query: str, *, limit: int = 50
+    ) -> dict[str, object]:
+        return await self.searchNbsExplanatoryEntries(query, limit=limit)
 
-        conn = await self._get_connection()
-        try:
-            await self._get_table_columns(conn, "nebs_entries")
-            has_fts = await self._table_exists(conn, "nebs_entries_fts")
-            if not raw_query:
-                rows = []
-            elif not clean_query and not normalized_query:
-                rows = []
-            elif not has_fts:
-                cursor = await conn.execute(
-                    """
-                    SELECT
-                        code,
-                        code_clean,
-                        title,
-                        section_title,
-                        page_start,
-                        page_end,
-                        CASE
-                            WHEN code_clean = ? THEN 500
-                            WHEN code = ? THEN 480
-                            WHEN code_clean LIKE ? THEN 430
-                            WHEN title_normalized = ? THEN 380
-                            WHEN title_normalized LIKE ? THEN 340
-                            WHEN body_normalized LIKE ? THEN 220
-                            ELSE 180
-                        END AS match_score
-                    FROM nebs_entries
-                    WHERE parser_status = 'trusted'
-                      AND (
-                        (? <> '' AND code_clean = ?)
-                        OR (? <> '' AND code_clean LIKE ?)
-                        OR (? <> '' AND code LIKE ?)
-                        OR (? <> '' AND title_normalized LIKE ?)
-                        OR (? <> '' AND body_normalized LIKE ?)
-                      )
-                    ORDER BY match_score DESC, LENGTH(code_clean) ASC, page_start ASC
-                    LIMIT ?
-                    """,
-                    (
-                        clean_query,
-                        raw_query,
-                        f"{clean_query}%",
-                        normalized_query,
-                        f"{normalized_query}%",
-                        f"%{normalized_query}%",
-                        clean_query,
-                        clean_query,
-                        clean_query,
-                        f"{clean_query}%",
-                        raw_query,
-                        f"{raw_query}%",
-                        normalized_query,
-                        f"{normalized_query}%",
-                        normalized_query,
-                        f"%{normalized_query}%",
-                        limit,
-                    ),
-                )
-                rows = await cursor.fetchall()
-            else:
-                cursor = await conn.execute(
-                    """
-                    WITH fts_hits AS (
-                        SELECT
-                            code,
-                            bm25(nebs_entries_fts, 8.0, 4.0, 1.0, 0.5) AS fts_rank
-                        FROM nebs_entries_fts
-                        WHERE ? <> '' AND nebs_entries_fts MATCH ?
-                    )
-                    SELECT
-                        e.code,
-                        e.code_clean,
-                        e.title,
-                        e.section_title,
-                        e.page_start,
-                        e.page_end,
-                        CASE
-                            WHEN e.code_clean = ? THEN 500
-                            WHEN e.code = ? THEN 480
-                            WHEN e.code_clean LIKE ? THEN 430
-                            WHEN e.title_normalized = ? THEN 380
-                            WHEN e.title_normalized LIKE ? THEN 340
-                            WHEN fts_hits.code IS NOT NULL THEN 220
-                            ELSE 180
-                        END AS match_score,
-                        COALESCE(fts_hits.fts_rank, 999999.0) AS fts_rank
-                    FROM nebs_entries AS e
-                    LEFT JOIN fts_hits ON fts_hits.code = e.code
-                    WHERE e.parser_status = 'trusted'
-                      AND (
-                        (? <> '' AND e.code_clean = ?)
-                        OR (? <> '' AND e.code_clean LIKE ?)
-                        OR (? <> '' AND e.code LIKE ?)
-                        OR (? <> '' AND e.title_normalized LIKE ?)
-                        OR fts_hits.code IS NOT NULL
-                      )
-                    ORDER BY match_score DESC, fts_rank ASC, LENGTH(e.code_clean) ASC, e.page_start ASC
-                    LIMIT ?
-                    """,
-                    (
-                        fts_query,
-                        fts_query,
-                        clean_query,
-                        raw_query,
-                        f"{clean_query}%",
-                        normalized_query,
-                        f"{normalized_query}%",
-                        clean_query,
-                        clean_query,
-                        clean_query,
-                        f"{clean_query}%",
-                        raw_query,
-                        f"{raw_query}%",
-                        normalized_query,
-                        f"{normalized_query}%",
-                        limit,
-                    ),
-                )
-                rows = await cursor.fetchall()
+    async def fetchNbsExplanatoryEntryDetails(self, code: str) -> dict[str, object]:
+        """Recupera o detalhe NEBS canônico de um código."""
+        return await fetch_nbs_explanatory_entry_details(self, code)
 
-            results = [
-                {
-                    "code": row["code"],
-                    "title": row["title"],
-                    "excerpt": "",
-                    "page_start": row["page_start"],
-                    "page_end": row["page_end"],
-                    "section_title": row["section_title"],
-                }
-                for row in rows
-            ]
-            payload = {
-                "success": True,
-                "query": raw_query,
-                "normalized": normalized_query,
-                "results": results,
-                "total": len(results),
-            }
-            await self._store_search_payload("nebs", scope, cache_key, payload)
-            return payload
-        finally:
-            await self._release_connection(conn)
+    async def get_nebs_details(self, code: str) -> dict[str, object]:
+        return await self.fetchNbsExplanatoryEntryDetails(code)
 
-    async def get_nebs_details(self, code: str) -> dict[str, Any]:
-        normalized_code = (code or "").strip()
-        cache_key = self._build_cache_key("nebs-detail", normalized_code)
-        scope = self._resolve_cache_scope(self._repository)
-        cached = await self._get_cached_detail_payload("nebs", scope, cache_key)
-        if cached is not None:
-            return cached
+    async def probeNbsCatalogHealth(self) -> dict[str, object]:
+        """Executa o healthcheck do catálogo NBS/NEBS."""
+        return await probe_nbs_catalog_health(self)
 
-        if self._use_repository:
-            async with self._get_repo() as repo:
-                repository = self._require_repository(repo)
-                scoped_key = self._resolve_cache_scope(repository)
-                if scoped_key != scope:
-                    cached = await self._get_cached_detail_payload(
-                        "nebs", scoped_key, cache_key
-                    )
-                    if cached is not None:
-                        return cached
-                scope = scoped_key
-                payload = await repository.get_nebs_details(normalized_code)
-            payload = self._sanitize_detail_payload(payload)
-            await self._store_detail_payload("nebs", scope, cache_key, payload)
-            return payload
+    async def check_connection(self) -> dict[str, object]:
+        return await self.probeNbsCatalogHealth()
 
-        conn = await self._get_connection()
-        try:
-            item = await self._fetch_item_by_code(conn, normalized_code)
-            ancestors = await self._fetch_ancestors(conn, item)
-            aliases, clean_aliases = self._resolve_code_aliases(normalized_code)
-            entry_where_clauses: list[str] = []
-            entry_params: list[str] = []
-            if aliases:
-                entry_where_clauses.append(
-                    f"code IN ({', '.join(['?'] * len(aliases))})"
-                )
-                entry_params.extend(aliases)
-            if clean_aliases:
-                entry_where_clauses.append(
-                    f"code_clean IN ({', '.join(['?'] * len(clean_aliases))})"
-                )
-                entry_params.extend(clean_aliases)
-            entry_params.append("trusted")
-            entry_cursor = await conn.execute(
-                f"""
-                SELECT
-                    code,
-                    code_clean,
-                    title,
-                    title_normalized,
-                    body_text,
-                    body_markdown,
-                    body_normalized,
-                    section_title,
-                    page_start,
-                    page_end,
-                    parser_status,
-                    parse_warnings,
-                    source_hash,
-                    updated_at
-                FROM nebs_entries
-                WHERE ({" OR ".join(entry_where_clauses)}) AND parser_status = ?
-                ORDER BY LENGTH(code_clean) DESC
-                LIMIT 1
-                """,
-                entry_params,
-            )
-            entry_row = await entry_cursor.fetchone()
-            if entry_row is None:
-                raise NotFoundError("Entrada NEBS", normalized_code)
 
-            payload = {
-                "success": True,
-                "item": item,
-                "ancestors": ancestors,
-                "entry": self._to_public_nebs_entry(
-                    self._row_to_nebs_entry_internal(entry_row)
-                ),
-            }
-            payload = self._sanitize_detail_payload(payload)
-            await self._store_detail_payload("nebs", scope, cache_key, payload)
-            return payload
-        finally:
-            await self._release_connection(conn)
+__all__ = [
+    "DEFAULT_TREE_PAGE",
+    "DEFAULT_TREE_PAGE_SIZE",
+    "MAX_TREE_PAGE_SIZE",
+    "NbsService",
+]

--- a/backend/services/nesh/__init__.py
+++ b/backend/services/nesh/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers especializados para o serviço NESH."""

--- a/backend/services/nesh/chapters.py
+++ b/backend/services/nesh/chapters.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import asyncio
+import re
+from collections import OrderedDict
+from typing import TYPE_CHECKING, Any
+
+import orjson
+
+from ...config.constants import CacheConfig, RegexPatterns
+from ...config.logging_config import service_logger as logger
+from ...infrastructure.redis_client import redis_cache
+from ...utils import ncm_utils
+from ...utils.id_utils import generate_anchor_id
+from .types import (
+    NeshChapterRawPayload,
+    NeshChapterSearchResponse,
+    NeshChapterSearchResult,
+    NeshChapterSearchResultMap,
+)
+
+if TYPE_CHECKING:
+    from ..nesh_service import NeshService
+
+
+NESH_RE_NOTE_HEADER = re.compile(RegexPatterns.NOTE_HEADER)
+NESH_RE_FIRST_POSITION = re.compile(
+    r"^\s*(?:\*\*|\*)?\d{2}\.\d{2}(?:\*\*|\*)?\s*[-\u2013\u2014:]",
+    re.MULTILINE,
+)
+
+
+def strip_nesh_chapter_preamble(content: str) -> str:
+    if not content:
+        return content
+    match = NESH_RE_FIRST_POSITION.search(content)
+    if not match:
+        return content
+    return content[match.start() :].lstrip()
+
+
+def parse_nesh_chapter_notes(notes_content: str) -> dict[str, str]:
+    if not notes_content:
+        return {}
+
+    notes: dict[str, str] = {}
+    current_num: str | None = None
+    buffer: list[str] = []
+
+    for line in notes_content.split("\n"):
+        cleaned = line.strip()
+        match = NESH_RE_NOTE_HEADER.match(cleaned)
+        if match:
+            if current_num:
+                notes[current_num] = "\n".join(buffer).strip()
+            current_num = match.group(1)
+            buffer = [cleaned]
+            continue
+        if current_num:
+            buffer.append(cleaned)
+
+    if current_num:
+        notes[current_num] = "\n".join(buffer).strip()
+
+    logger.debug("Parseadas %s notas", len(notes))
+    return notes
+
+
+def enrich_nesh_positions_with_anchor_ids(
+    positions: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    for pos in positions:
+        if pos.get("anchor_id"):
+            continue
+        codigo = pos.get("codigo")
+        pos["anchor_id"] = generate_anchor_id(codigo)
+    return positions
+
+
+async def read_nesh_chapter_cache(
+    service: "NeshService", chapter_num: str
+) -> NeshChapterRawPayload | None:
+    async with service._get_cache_lock():
+        cached = service._chapter_cache.get(chapter_num)
+        if not cached:
+            return None
+        service._chapter_cache.move_to_end(chapter_num)
+        service._chapter_cache_metrics.record_hit()
+        return cached
+
+
+async def write_nesh_chapter_cache(
+    service: "NeshService", chapter_num: str, payload: NeshChapterRawPayload
+) -> None:
+    async with service._get_cache_lock():
+        service._chapter_cache[chapter_num] = payload
+        service._chapter_cache_metrics.record_set()
+        if len(service._chapter_cache) > CacheConfig.CHAPTER_CACHE_SIZE:
+            service._chapter_cache.popitem(last=False)
+            service._chapter_cache_metrics.record_eviction()
+
+
+async def read_nesh_chapter_cache_from_redis(
+    service: "NeshService", chapter_num: str
+) -> NeshChapterRawPayload | None:
+    if not redis_cache.available:
+        return None
+    cached = await redis_cache.get_chapter(chapter_num)
+    if not cached:
+        return None
+    await write_nesh_chapter_cache(service, chapter_num, cached)
+    return cached
+
+
+async def load_nesh_chapter_raw_data(
+    service: "NeshService", chapter_num: str
+) -> NeshChapterRawPayload | None:
+    if service._use_repository:
+        async with service._get_repo() as repo:
+            if not repo:
+                raise RuntimeError("Repository não disponível")
+            chapter = await repo.get_by_num(chapter_num)
+            if not chapter:
+                return None
+            notes = chapter.notes
+            sections = (
+                {
+                    "titulo": notes.titulo,
+                    "notas": notes.notas,
+                    "consideracoes": notes.consideracoes,
+                    "definicoes": notes.definicoes,
+                }
+                if notes
+                else None
+            )
+            return {
+                "chapter_num": chapter.chapter_num,
+                "content": chapter.content,
+                "notes": notes.notes_content if notes else None,
+                "parsed_notes_json": (
+                    getattr(notes, "parsed_notes_json", None) if notes else None
+                ),
+                "positions": [
+                    {
+                        "codigo": position.codigo,
+                        "descricao": position.descricao,
+                        "anchor_id": position.anchor_id,
+                    }
+                    for position in chapter.positions
+                ],
+                "sections": sections,
+            }
+
+    if not service.db:
+        raise RuntimeError("DatabaseAdapter não configurado")
+    return await service.db.get_chapter_raw(chapter_num)
+
+
+def hydrate_nesh_chapter_payload(
+    service: "NeshService", raw_data: NeshChapterRawPayload
+) -> NeshChapterRawPayload:
+    precomputed_json = raw_data.pop("parsed_notes_json", None)
+    if precomputed_json:
+        try:
+            raw_data["parsed_notes"] = (
+                orjson.loads(precomputed_json)
+                if isinstance(precomputed_json, (str, bytes))
+                else precomputed_json
+            )
+        except Exception:
+            logger.warning(
+                "Failed to parse precomputed notes JSON for chapter, falling back to parser",
+                exc_info=True,
+            )
+            raw_data["parsed_notes"] = parse_nesh_chapter_notes(raw_data["notes"])
+    else:
+        raw_data["parsed_notes"] = parse_nesh_chapter_notes(raw_data["notes"])
+
+    raw_data["positions"] = enrich_nesh_positions_with_anchor_ids(
+        raw_data.get("positions", [])
+    )
+    return raw_data
+
+
+async def fetch_nesh_chapter_payload(
+    service: "NeshService", chapter_num: str
+) -> NeshChapterRawPayload | None:
+    cached = await read_nesh_chapter_cache(service, chapter_num)
+    if cached is not None:
+        return cached
+    service._chapter_cache_metrics.record_miss()
+
+    redis_cached = await read_nesh_chapter_cache_from_redis(service, chapter_num)
+    if redis_cached is not None:
+        return redis_cached
+
+    logger.debug("Fetching capítulo %s (cache miss)", chapter_num)
+    raw_data = await load_nesh_chapter_raw_data(service, chapter_num)
+    if not raw_data:
+        return None
+    hydrated = hydrate_nesh_chapter_payload(service, raw_data)
+
+    if redis_cache.available:
+        await redis_cache.set_chapter(chapter_num, hydrated)
+
+    await write_nesh_chapter_cache(service, chapter_num, hydrated)
+    return hydrated
+
+
+def extract_nesh_chapter_targets(
+    ncms: list[str],
+) -> OrderedDict[str, tuple[str, str | None]]:
+    chapter_targets: OrderedDict[str, tuple[str, str | None]] = OrderedDict()
+    for ncm in ncms:
+        chapter_num, target_pos = ncm_utils.extract_chapter_from_ncm(ncm)
+        if not chapter_num:
+            logger.debug("NCM inválido ignorado: '%s'", ncm)
+            continue
+        chapter_targets.setdefault(chapter_num, (ncm, target_pos))
+    return chapter_targets
+
+
+def has_nesh_structured_sections(sections: dict[str, Any]) -> bool:
+    return any(
+        (sections.get(key) or "").strip()
+        for key in ("titulo", "notas", "consideracoes", "definicoes")
+    )
+
+
+def build_nesh_sections_payload(sections: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "titulo": sections.get("titulo"),
+        "notas": sections.get("notas"),
+        "consideracoes": sections.get("consideracoes"),
+        "definicoes": sections.get("definicoes"),
+    }
+
+
+def build_nesh_found_chapter_search_result(
+    chapter_num: str,
+    ncm_buscado: str,
+    target_pos: str | None,
+    data: NeshChapterRawPayload,
+) -> NeshChapterSearchResult:
+    sections = data.get("sections") or {}
+    has_sections = has_nesh_structured_sections(sections)
+    content = (
+        strip_nesh_chapter_preamble(data["content"])
+        if has_sections
+        else data["content"]
+    )
+    return {
+        "ncm_buscado": ncm_buscado,
+        "capitulo": chapter_num,
+        "posicao_alvo": target_pos,
+        "posicoes": data["positions"],
+        "notas_gerais": data["notes"],
+        "notas_parseadas": data["parsed_notes"],
+        "conteudo": content,
+        "real_content_found": True,
+        "erro": None,
+        "secoes": build_nesh_sections_payload(sections) if has_sections else None,
+    }
+
+
+def build_nesh_missing_chapter_search_result(
+    chapter_num: str, ncm_buscado: str
+) -> NeshChapterSearchResult:
+    return {
+        "ncm_buscado": ncm_buscado,
+        "capitulo": chapter_num,
+        "real_content_found": False,
+        "erro": f"Capítulo {chapter_num} não encontrado",
+        "conteudo": "",
+        "posicoes": [],
+        "notas_gerais": None,
+        "notas_parseadas": {},
+        "posicao_alvo": None,
+    }
+
+
+async def search_nesh_chapters_by_ncm_code(
+    service: "NeshService", ncm_query: str
+) -> NeshChapterSearchResponse:
+    logger.debug("Busca por código: '%s'", ncm_query)
+
+    results: NeshChapterSearchResultMap = {}
+    ncms = ncm_utils.split_ncm_query(ncm_query)
+    chapter_targets = extract_nesh_chapter_targets(ncms)
+    if not chapter_targets:
+        logger.debug("Retornando 0 capítulos")
+        return {
+            "success": True,
+            "type": "code",
+            "query": ncm_query,
+            "normalized": None,
+            "results": results,
+            "total_capitulos": 0,
+        }
+
+    ordered_chapters = list(chapter_targets.keys())
+    chapter_payloads = await asyncio.gather(
+        *(service.fetchNeshChapterData(chapter_num) for chapter_num in ordered_chapters)
+    )
+
+    for chapter_num, data in zip(ordered_chapters, chapter_payloads):
+        ncm_buscado, target_pos = chapter_targets[chapter_num]
+        if data:
+            results[chapter_num] = build_nesh_found_chapter_search_result(
+                chapter_num, ncm_buscado, target_pos, data
+            )
+            continue
+        logger.warning("Capítulo não encontrado: %s", chapter_num)
+        results[chapter_num] = build_nesh_missing_chapter_search_result(
+            chapter_num, ncm_buscado
+        )
+
+    logger.debug("Retornando %s capítulos", len(results))
+    return {
+        "success": True,
+        "type": "code",
+        "query": ncm_query,
+        "normalized": None,
+        "results": results,
+        "total_capitulos": len(results),
+    }
+
+
+async def prewarm_nesh_chapter_cache(
+    service: "NeshService",
+    chapter_nums: list[str] | None = None,
+    concurrency: int = 10,
+) -> int:
+    if chapter_nums is None:
+        if service._use_repository:
+            async with service._get_repo() as repo:
+                if not repo:
+                    return 0
+                chapter_nums = await repo.get_all_nums()
+        else:
+            if not service.db:
+                return 0
+            chapter_nums = await service.db.get_all_chapters_list()
+
+    if not chapter_nums:
+        return 0
+
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _warm(chapter_num: str) -> None:
+        async with sem:
+            try:
+                await service.fetchNeshChapterData(chapter_num)
+            except Exception as exc:
+                logger.debug("Prewarm failed for %s: %s", chapter_num, exc)
+
+    await asyncio.gather(*(_warm(num) for num in chapter_nums))
+    return len(chapter_nums)

--- a/backend/services/nesh/chapters.py
+++ b/backend/services/nesh/chapters.py
@@ -67,7 +67,7 @@ def parse_nesh_chapter_notes(notes_content: str) -> dict[str, str]:
 
 
 def enrich_nesh_positions_with_anchor_ids(
-    positions: list[dict[str, Any]]
+    positions: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     for pos in positions:
         if pos.get("anchor_id"):

--- a/backend/services/nesh/chapters.py
+++ b/backend/services/nesh/chapters.py
@@ -157,7 +157,7 @@ async def load_nesh_chapter_raw_data(
 
 
 def hydrate_nesh_chapter_payload(
-    service: "NeshService", raw_data: NeshChapterRawPayload
+    raw_data: NeshChapterRawPayload,
 ) -> NeshChapterRawPayload:
     precomputed_json = raw_data.pop("parsed_notes_json", None)
     if precomputed_json:
@@ -198,7 +198,7 @@ async def fetch_nesh_chapter_payload(
     raw_data = await load_nesh_chapter_raw_data(service, chapter_num)
     if not raw_data:
         return None
-    hydrated = hydrate_nesh_chapter_payload(service, raw_data)
+    hydrated = hydrate_nesh_chapter_payload(raw_data)
 
     if redis_cache.available:
         await redis_cache.set_chapter(chapter_num, hydrated)

--- a/backend/services/nesh/fts.py
+++ b/backend/services/nesh/fts.py
@@ -320,7 +320,9 @@ def build_nesh_fts_response(
     }
 
 
-async def search_nesh_fts_text(service: "NeshService", query: str) -> NeshFtsSearchResponse:
+async def search_nesh_fts_text(
+    service: "NeshService", query: str
+) -> NeshFtsSearchResponse:
     logger.info("Busca FTS: '%s'", query)
 
     original_words = [word.strip() for word in query.split() if word.strip()]
@@ -372,9 +374,7 @@ async def search_nesh_fts_text(service: "NeshService", query: str) -> NeshFtsSea
             warning=f'Nenhum resultado encontrado para "{query}"',
         )
 
-    match_metadata = resolve_nesh_fts_match_metadata(
-        all_results, query, original_words
-    )
+    match_metadata = resolve_nesh_fts_match_metadata(all_results, query, original_words)
     logger.info(
         "FTS total: %s resultados, melhor tier: %s",
         len(all_results),

--- a/backend/services/nesh/fts.py
+++ b/backend/services/nesh/fts.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import TYPE_CHECKING
+
+from ...config.constants import SearchConfig
+from ...config.logging_config import service_logger as logger
+from ...infrastructure.redis_client import redis_cache
+from .types import (
+    NeshFtsCacheKey,
+    NeshFtsMatchMetadata,
+    NeshFtsResponseItem,
+    NeshFtsScoredRow,
+    NeshFtsSearchResponse,
+)
+
+if TYPE_CHECKING:
+    from ..nesh_service import NeshService
+
+
+NESH_FTS_CACHE_SIZE = 64
+
+
+def build_nesh_fts_cache_key(
+    query: str, tier: int, limit: int, words_matched: int, total_words: int
+) -> str:
+    raw = f"{query}|{tier}|{limit}|{words_matched}|{total_words}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def normalize_nesh_fts_query(service: "NeshService", text: str) -> str:
+    processed = service.processor.process_query_for_fts(text)
+    if not processed:
+        return ""
+    parts = processed.split()
+    unique = list(dict.fromkeys(parts))[:20]
+    return " ".join(unique)
+
+
+def normalize_nesh_raw_fts_query(service: "NeshService", text: str) -> str:
+    normalized = service.processor.normalize(text)
+    words = re.findall(r"\b\w+\b", normalized)
+
+    processed: list[str] = []
+    for word in words:
+        if word in service.processor.stopwords:
+            continue
+        if len(word) < 2:
+            continue
+        processed.append(f"{word}*")
+
+    if not processed:
+        return ""
+    unique = list(dict.fromkeys(processed))[:20]
+    return " ".join(unique)
+
+
+async def fetch_nesh_fts_scored_rows_cached(
+    service: "NeshService",
+    query: str,
+    tier: int,
+    limit: int,
+    words_matched: int,
+    total_words: int,
+) -> list[NeshFtsScoredRow]:
+    key: NeshFtsCacheKey = (query, tier, limit, words_matched, total_words)
+
+    async with service._get_cache_lock():
+        if key in service._fts_cache:
+            service._fts_cache.move_to_end(key)
+            service._fts_cache_metrics.record_hit()
+            return list(service._fts_cache[key])
+    service._fts_cache_metrics.record_miss()
+
+    if redis_cache.available:
+        redis_key = build_nesh_fts_cache_key(
+            query, tier, limit, words_matched, total_words
+        )
+        cached = await redis_cache.get_fts(redis_key)
+        if cached:
+            async with service._get_cache_lock():
+                service._fts_cache[key] = cached
+                service._fts_cache_metrics.record_set()
+                if len(service._fts_cache) > NESH_FTS_CACHE_SIZE:
+                    service._fts_cache.popitem(last=False)
+                    service._fts_cache_metrics.record_eviction()
+            return list(cached)
+
+    if service._use_repository:
+        async with service._get_repo() as repo:
+            if not repo:
+                raise RuntimeError("Repository não disponível")
+            results = await repo.search_scored(
+                query,
+                tier=tier,
+                limit=limit,
+                words_matched=words_matched,
+                total_words=total_words,
+            )
+            rows: list[NeshFtsScoredRow] = [
+                {
+                    "ncm": row.ncm,
+                    "display_text": row.display_text,
+                    "type": row.type,
+                    "description": row.description,
+                    "score": row.score,
+                    "tier": row.tier,
+                    "rank": row.score,
+                }
+                for row in results
+            ]
+    else:
+        if not service.db:
+            raise RuntimeError("DatabaseAdapter não configurado")
+        rows = await service.db.fts_search_scored(
+            query,
+            tier=tier,
+            limit=limit,
+            words_matched=words_matched,
+            total_words=total_words,
+        )
+
+    async with service._get_cache_lock():
+        service._fts_cache[key] = rows
+        service._fts_cache_metrics.record_set()
+        if len(service._fts_cache) > NESH_FTS_CACHE_SIZE:
+            service._fts_cache.popitem(last=False)
+            service._fts_cache_metrics.record_eviction()
+
+    if redis_cache.available:
+        redis_key = build_nesh_fts_cache_key(
+            query, tier, limit, words_matched, total_words
+        )
+        await redis_cache.set_fts(redis_key, rows)
+
+    return rows
+
+
+def build_nesh_empty_fts_search_response(query: str) -> NeshFtsSearchResponse:
+    return {
+        "success": True,
+        "type": "text",
+        "query": query,
+        "normalized": "",
+        "match_type": "none",
+        "warning": None,
+        "results": [],
+        "total_capitulos": 0,
+    }
+
+
+def build_nesh_fts_row_identity(row: NeshFtsScoredRow) -> tuple[str, str, str]:
+    return (row["ncm"], row["type"], row["display_text"])
+
+
+def append_unique_nesh_fts_rows(
+    target: list[NeshFtsScoredRow],
+    seen: set[tuple[str, str, str]],
+    rows: list[NeshFtsScoredRow],
+) -> None:
+    for row in rows:
+        key = build_nesh_fts_row_identity(row)
+        if key in seen:
+            continue
+        seen.add(key)
+        target.append(row)
+
+
+async def fetch_nesh_fts_exact_rows(
+    service: "NeshService", exact_q: str, total_words: int
+) -> list[NeshFtsScoredRow]:
+    phrase_query = f'"{exact_q}"'
+    return await service._fts_scored_cached(
+        phrase_query,
+        tier=1,
+        limit=SearchConfig.TIER1_LIMIT,
+        words_matched=total_words,
+        total_words=total_words,
+    )
+
+
+async def fetch_nesh_fts_all_words_rows(
+    service: "NeshService",
+    normalized_q: str,
+    normalized_raw_q: str,
+    total_words: int,
+) -> list[NeshFtsScoredRow]:
+    and_results = await service._fts_scored_cached(
+        normalized_q,
+        tier=2,
+        limit=SearchConfig.TIER2_LIMIT,
+        words_matched=total_words,
+        total_words=total_words,
+    )
+    if and_results or not normalized_raw_q or normalized_raw_q == normalized_q:
+        return and_results
+    return await service._fts_scored_cached(
+        normalized_raw_q,
+        tier=2,
+        limit=SearchConfig.TIER2_LIMIT,
+        words_matched=total_words,
+        total_words=total_words,
+    )
+
+
+def build_nesh_fts_or_query(service: "NeshService", original_words: list[str]) -> str:
+    unique_words = list(dict.fromkeys(original_words))[:20]
+    or_parts: list[str] = []
+    for word in unique_words:
+        word_normalized = service.processor.process_query_for_fts(word)
+        if word_normalized:
+            or_parts.append(word_normalized)
+    return " OR ".join(or_parts)
+
+
+async def fetch_nesh_fts_any_words_rows(
+    service: "NeshService",
+    original_words: list[str],
+    normalized_raw_q: str,
+    total_words: int,
+) -> list[NeshFtsScoredRow]:
+    or_query = build_nesh_fts_or_query(service, original_words)
+    if not or_query:
+        return []
+
+    partial_results = await service._fts_scored_cached(
+        or_query,
+        tier=3,
+        limit=SearchConfig.TIER3_LIMIT,
+        words_matched=max(1, total_words // 2),
+        total_words=total_words,
+    )
+    if partial_results or not normalized_raw_q:
+        return partial_results
+
+    raw_or_query = " OR ".join(normalized_raw_q.split())
+    if raw_or_query == or_query:
+        return partial_results
+    return await service._fts_scored_cached(
+        raw_or_query,
+        tier=3,
+        limit=SearchConfig.TIER3_LIMIT,
+        words_matched=max(1, total_words // 2),
+        total_words=total_words,
+    )
+
+
+async def apply_nesh_near_bonus_if_needed(
+    service: "NeshService",
+    all_results: list[NeshFtsScoredRow],
+    stemmed_words: list[str],
+) -> None:
+    if service._use_repository or len(stemmed_words) < 2 or not all_results:
+        return
+    if not service.db:
+        return
+    near_results = await service.db.fts_search_near(
+        stemmed_words,
+        distance=SearchConfig.NEAR_DISTANCE,
+        limit=SearchConfig.TIER1_LIMIT + SearchConfig.TIER2_LIMIT,
+    )
+    near_ncms = {row["ncm"] for row in near_results}
+    for row in all_results:
+        if row["ncm"] not in near_ncms:
+            continue
+        row["score"] += SearchConfig.NEAR_BONUS
+        row["near_bonus"] = True
+        logger.debug("NEAR bonus aplicado: %s", row["ncm"])
+
+
+def resolve_nesh_fts_match_metadata(
+    all_results: list[NeshFtsScoredRow], query: str, original_words: list[str]
+) -> NeshFtsMatchMetadata:
+    best_tier = min(row.get("tier", 3) for row in all_results)
+    if best_tier == 1:
+        return {"match_type": "exact", "warning": None, "best_tier": best_tier}
+    if best_tier == 2:
+        return {"match_type": "all_words", "warning": None, "best_tier": best_tier}
+    warning = (
+        f'Não encontrei "{query}" exato. '
+        f"Mostrando aproximações para: {', '.join(original_words)}"
+    )
+    return {"match_type": "partial", "warning": warning, "best_tier": best_tier}
+
+
+def build_nesh_fts_response(
+    query: str,
+    normalized: str,
+    rows: list[NeshFtsScoredRow],
+    match_type: str,
+    warning: str | None,
+) -> NeshFtsSearchResponse:
+    tier_labels = {1: "Exato", 2: "Todas palavras", 3: "Parcial"}
+    results: list[NeshFtsResponseItem] = []
+    for row in rows:
+        tier = row.get("tier", 3)
+        score = row.get("score", 0)
+        results.append(
+            {
+                "ncm": row["ncm"],
+                "descricao": row["display_text"],
+                "tipo": row["type"],
+                "relevancia": row.get("rank", 0),
+                "score": score,
+                "tier": tier,
+                "tier_label": tier_labels.get(tier, "Parcial"),
+                "near_bonus": row.get("near_bonus", False),
+            }
+        )
+    return {
+        "success": True,
+        "type": "text",
+        "query": query,
+        "normalized": normalized,
+        "match_type": match_type,
+        "warning": warning,
+        "results": results,
+        "total_capitulos": 0,
+    }
+
+
+async def search_nesh_fts_text(service: "NeshService", query: str) -> NeshFtsSearchResponse:
+    logger.info("Busca FTS: '%s'", query)
+
+    original_words = [word.strip() for word in query.split() if word.strip()]
+    total_words = len(original_words)
+    normalized_q = service.normalizeNeshQuery(query)
+    normalized_raw_q = service.normalizeNeshRawQuery(query)
+
+    if not normalized_q:
+        logger.debug("Query vazia após normalização")
+        return build_nesh_empty_fts_search_response(query)
+
+    exact_q = service.processor.process_query_exact(query)
+    stemmed_words = exact_q.split() if exact_q else []
+    all_results: list[NeshFtsScoredRow] = []
+    seen: set[tuple[str, str, str]] = set()
+
+    if len(original_words) > 1 and exact_q:
+        exact_results = await fetch_nesh_fts_exact_rows(service, exact_q, total_words)
+        if exact_results:
+            logger.info("FTS TIER1 (exato): %s resultados", len(exact_results))
+            append_unique_nesh_fts_rows(all_results, seen, exact_results)
+
+    and_results = await fetch_nesh_fts_all_words_rows(
+        service, normalized_q, normalized_raw_q, total_words
+    )
+    if and_results:
+        logger.info("FTS TIER2 (AND): %s resultados", len(and_results))
+        append_unique_nesh_fts_rows(all_results, seen, and_results)
+
+    await apply_nesh_near_bonus_if_needed(service, all_results, stemmed_words)
+
+    if len(original_words) > 1:
+        partial_results = await fetch_nesh_fts_any_words_rows(
+            service, original_words, normalized_raw_q, total_words
+        )
+        if partial_results:
+            logger.info("FTS TIER3 (OR): %s resultados", len(partial_results))
+            append_unique_nesh_fts_rows(all_results, seen, partial_results)
+
+    all_results.sort(key=lambda row: row.get("score", 0), reverse=True)
+
+    if not all_results:
+        logger.info("FTS: 0 resultados em todos os níveis")
+        return build_nesh_fts_response(
+            query,
+            normalized_q,
+            [],
+            match_type="none",
+            warning=f'Nenhum resultado encontrado para "{query}"',
+        )
+
+    match_metadata = resolve_nesh_fts_match_metadata(
+        all_results, query, original_words
+    )
+    logger.info(
+        "FTS total: %s resultados, melhor tier: %s",
+        len(all_results),
+        match_metadata["best_tier"],
+    )
+    return build_nesh_fts_response(
+        query,
+        normalized_q,
+        all_results,
+        match_type=match_metadata["match_type"],
+        warning=match_metadata["warning"],
+    )
+
+
+def snapshot_nesh_fts_cache_metrics(service: "NeshService") -> tuple[int, int]:
+    return len(service._fts_cache), NESH_FTS_CACHE_SIZE

--- a/backend/services/nesh/types.py
+++ b/backend/services/nesh/types.py
@@ -1,8 +1,8 @@
-from typing import Any, TypeAlias, TypedDict
+from typing import Any, TypedDict
 
 from ...domain import ServiceResponse
 
-NeshFtsCacheKey: TypeAlias = tuple[str, int, int, int, int]
+type NeshFtsCacheKey = tuple[str, int, int, int, int]
 
 
 class NeshChapterSectionPayload(TypedDict, total=False):
@@ -35,7 +35,7 @@ class NeshChapterSearchResult(TypedDict, total=False):
     secoes: dict[str, str | None] | None
 
 
-NeshChapterSearchResultMap: TypeAlias = dict[str, NeshChapterSearchResult]
+type NeshChapterSearchResultMap = dict[str, NeshChapterSearchResult]
 
 
 class NeshChapterSearchResponse(TypedDict):
@@ -86,4 +86,4 @@ class NeshFtsMatchMetadata(TypedDict):
     best_tier: int
 
 
-NeshServiceResponse: TypeAlias = ServiceResponse
+type NeshServiceResponse = ServiceResponse

--- a/backend/services/nesh/types.py
+++ b/backend/services/nesh/types.py
@@ -1,0 +1,89 @@
+from typing import Any, TypeAlias, TypedDict
+
+from ...domain import ServiceResponse
+
+NeshFtsCacheKey: TypeAlias = tuple[str, int, int, int, int]
+
+
+class NeshChapterSectionPayload(TypedDict, total=False):
+    titulo: str | None
+    notas: str | None
+    consideracoes: str | None
+    definicoes: str | None
+
+
+class NeshChapterRawPayload(TypedDict, total=False):
+    chapter_num: str
+    content: str
+    notes: str | None
+    parsed_notes_json: str | bytes | dict[str, str] | None
+    parsed_notes: dict[str, str]
+    positions: list[dict[str, Any]]
+    sections: NeshChapterSectionPayload | None
+
+
+class NeshChapterSearchResult(TypedDict, total=False):
+    ncm_buscado: str
+    capitulo: str
+    posicao_alvo: str | None
+    posicoes: list[dict[str, Any]]
+    notas_gerais: str | None
+    notas_parseadas: dict[str, str]
+    conteudo: str
+    real_content_found: bool
+    erro: str | None
+    secoes: dict[str, str | None] | None
+
+
+NeshChapterSearchResultMap: TypeAlias = dict[str, NeshChapterSearchResult]
+
+
+class NeshChapterSearchResponse(TypedDict):
+    success: bool
+    type: str
+    query: str
+    normalized: str | None
+    results: NeshChapterSearchResultMap
+    total_capitulos: int
+
+
+class NeshFtsScoredRow(TypedDict, total=False):
+    ncm: str
+    display_text: str
+    type: str
+    description: str
+    score: int | float
+    tier: int
+    rank: int | float
+    near_bonus: bool
+
+
+class NeshFtsResponseItem(TypedDict):
+    ncm: str
+    descricao: str
+    tipo: str
+    relevancia: int | float
+    score: int | float
+    tier: int
+    tier_label: str
+    near_bonus: bool
+
+
+class NeshFtsSearchResponse(TypedDict):
+    success: bool
+    type: str
+    query: str
+    normalized: str
+    match_type: str
+    warning: str | None
+    results: list[NeshFtsResponseItem]
+    total_capitulos: int
+
+
+class NeshFtsMatchMetadata(TypedDict):
+    match_type: str
+    warning: str | None
+    best_tier: int
+
+
+NeshServiceResponse: TypeAlias = ServiceResponse

--- a/backend/services/nesh_service.py
+++ b/backend/services/nesh_service.py
@@ -32,7 +32,7 @@ from .nesh.fts import (
     search_nesh_fts_text,
     snapshot_nesh_fts_cache_metrics,
 )
-from .nesh.types import NeshFtsCacheKey, NeshFtsScoredRow
+from .nesh.types import NeshChapterRawPayload, NeshFtsCacheKey, NeshFtsScoredRow
 
 try:
     from ..infrastructure.db_engine import get_session
@@ -145,7 +145,9 @@ class NeshService:
         """
         return parse_nesh_chapter_notes(notes_content)
 
-    async def fetchNeshChapterData(self, chapter_num: str):
+    async def fetchNeshChapterData(
+        self, chapter_num: str
+    ) -> NeshChapterRawPayload | None:
         """
         Recupera os dados hidratados de um capítulo NESH.
 
@@ -208,6 +210,15 @@ class NeshService:
         if is_ncm:
             return await self.searchNeshByNcmCode(query)
         return await self.searchNeshByTextQuery(query)
+
+    async def process_request(self, query: str) -> ServiceResponse:
+        """
+        Backward-compatible alias for the legacy request-processing entrypoint.
+
+        Exemplo:
+            payload = await service.process_request("85.17")
+        """
+        return await self.executeNeshSearchWithVectorWeights(query)
 
     async def prewarmNeshChapterCache(
         self, chapter_nums: Optional[list[str]] = None, concurrency: int = 10

--- a/backend/services/nesh_service.py
+++ b/backend/services/nesh_service.py
@@ -13,7 +13,7 @@ from ..config.constants import CacheConfig
 from ..config.logging_config import service_logger as logger
 from ..domain import ServiceResponse
 from ..infrastructure import DatabaseAdapter
-from ..infrastructure.redis_client import redis_cache  # noqa: F401
+from ..infrastructure.redis_client import redis_cache
 from ..utils import ncm_utils
 from ..utils.payload_cache_metrics import PayloadCacheMetrics
 from ..utils.text_processor import NeshTextProcessor
@@ -33,6 +33,9 @@ from .nesh.fts import (
     snapshot_nesh_fts_cache_metrics,
 )
 from .nesh.types import NeshChapterRawPayload, NeshFtsCacheKey, NeshFtsScoredRow
+from .nesh.types import NeshChapterSearchResponse, NeshFtsSearchResponse
+
+__all__ = ["NeshService", "redis_cache"]
 
 try:
     from ..infrastructure.db_engine import get_session
@@ -176,12 +179,12 @@ class NeshService:
 
     async def _fts_scored_cached(
         self, query: str, tier: int, limit: int, words_matched: int, total_words: int
-    ):
+    ) -> list[NeshFtsScoredRow]:
         return await fetch_nesh_fts_scored_rows_cached(
             self, query, tier, limit, words_matched, total_words
         )
 
-    async def searchNeshByTextQuery(self, query: str) -> ServiceResponse:
+    async def searchNeshByTextQuery(self, query: str) -> NeshFtsSearchResponse:
         """
         Executa busca textual FTS sobre o conteúdo NESH.
 
@@ -190,7 +193,7 @@ class NeshService:
         """
         return await search_nesh_fts_text(self, query)
 
-    async def searchNeshByNcmCode(self, ncm_query: str) -> ServiceResponse:
+    async def searchNeshByNcmCode(self, ncm_query: str) -> NeshChapterSearchResponse:
         """
         Busca capítulos NESH a partir de uma query NCM normalizada.
 

--- a/backend/services/nesh_service.py
+++ b/backend/services/nesh_service.py
@@ -13,6 +13,7 @@ from ..config.constants import CacheConfig
 from ..config.logging_config import service_logger as logger
 from ..domain import ServiceResponse
 from ..infrastructure import DatabaseAdapter
+from ..infrastructure.redis_client import redis_cache  # noqa: F401
 from ..utils import ncm_utils
 from ..utils.payload_cache_metrics import PayloadCacheMetrics
 from ..utils.text_processor import NeshTextProcessor
@@ -68,9 +69,9 @@ class NeshService:
         self._use_repository = repository is not None or repository_factory is not None
 
         self.processor = NeshTextProcessor(list(CONFIG.stopwords))
-        self._fts_cache: OrderedDict[
-            NeshFtsCacheKey, list[NeshFtsScoredRow]
-        ] = OrderedDict()
+        self._fts_cache: OrderedDict[NeshFtsCacheKey, list[NeshFtsScoredRow]] = (
+            OrderedDict()
+        )
         self._chapter_cache: OrderedDict[str, dict] = OrderedDict()
         self._fts_cache_metrics = PayloadCacheMetrics("nesh_fts_cache")
         self._chapter_cache_metrics = PayloadCacheMetrics("nesh_chapter_cache")
@@ -111,9 +112,7 @@ class NeshService:
     def _fts_cache_key(
         query: str, tier: int, limit: int, words_matched: int, total_words: int
     ) -> str:
-        return build_nesh_fts_cache_key(
-            query, tier, limit, words_matched, total_words
-        )
+        return build_nesh_fts_cache_key(query, tier, limit, words_matched, total_words)
 
     @asynccontextmanager
     async def _get_repo(self):

--- a/backend/services/nesh_service.py
+++ b/backend/services/nesh_service.py
@@ -224,6 +224,14 @@ class NeshService:
             self, chapter_nums=chapter_nums, concurrency=concurrency
         )
 
+    async def prewarm_cache(
+        self, chapter_nums: Optional[list[str]] = None, concurrency: int = 10
+    ) -> int:
+        """Alias compatível com a API anterior do serviço."""
+        return await self.prewarmNeshChapterCache(
+            chapter_nums=chapter_nums, concurrency=concurrency
+        )
+
     async def snapshotNeshInternalCacheMetrics(self) -> dict:
         """
         Captura as métricas atuais dos caches internos do serviço.
@@ -268,3 +276,7 @@ class NeshService:
                 "hit_rate": fts_snapshot.hit_rate,
             },
         }
+
+    async def get_internal_cache_metrics(self) -> dict:
+        """Alias compatível com a API anterior do serviço."""
+        return await self.snapshotNeshInternalCacheMetrics()

--- a/backend/services/nesh_service.py
+++ b/backend/services/nesh_service.py
@@ -1,27 +1,39 @@
 """
 Serviço principal de busca NCM.
-Contém toda a lógica de negócio, isolada de I/O e apresentação.
+Contém a fachada do domínio NESH e delega responsabilidades pesadas a módulos menores.
 """
 
 import asyncio
-import hashlib
-import re
 from collections import OrderedDict
 from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple
-
-import orjson
+from typing import AsyncGenerator, Callable, Optional
 
 from ..config import CONFIG
-from ..config.constants import CacheConfig, RegexPatterns, SearchConfig
+from ..config.constants import CacheConfig
 from ..config.logging_config import service_logger as logger
-from ..domain import SearchResult, ServiceResponse
+from ..domain import ServiceResponse
 from ..infrastructure import DatabaseAdapter
 from ..infrastructure.redis_client import redis_cache
 from ..utils import ncm_utils
 from ..utils.payload_cache_metrics import PayloadCacheMetrics
+from ..utils.text_processor import NeshTextProcessor
+from .nesh.chapters import (
+    fetch_nesh_chapter_payload,
+    parse_nesh_chapter_notes,
+    prewarm_nesh_chapter_cache,
+    search_nesh_chapters_by_ncm_code,
+    strip_nesh_chapter_preamble,
+)
+from .nesh.fts import (
+    build_nesh_fts_cache_key,
+    fetch_nesh_fts_scored_rows_cached,
+    normalize_nesh_fts_query,
+    normalize_nesh_raw_fts_query,
+    search_nesh_fts_text,
+    snapshot_nesh_fts_cache_metrics,
+)
+from .nesh.types import NeshFtsCacheKey, NeshFtsScoredRow
 
-# SQLModel Repository imports (optional - for new code paths)
 try:
     from ..infrastructure.db_engine import get_session
     from ..infrastructure.repositories.chapter_repository import ChapterRepository
@@ -31,45 +43,15 @@ except ImportError:
     _REPO_AVAILABLE = False
     ChapterRepository = None
 
-# Import text_processor - using absolute import from project root
-try:
-    from backend.utils.text_processor import NeshTextProcessor
-except ImportError:
-    # Fallback for direct module execution
-    import sys
-    from pathlib import Path
-
-    sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-    sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-    from backend.utils.text_processor import NeshTextProcessor
-
-from ..utils.id_utils import generate_anchor_id
-
-# Pre-compiled regex patterns for performance
-_RE_NOTE_HEADER = re.compile(RegexPatterns.NOTE_HEADER)
-# Detect first NCM position line to trim chapter preamble when sections are rendered separately
-_RE_FIRST_POSITION = re.compile(
-    r"^\s*(?:\*\*|\*)?\d{2}\.\d{2}(?:\*\*|\*)?\s*[-\u2013\u2014:]", re.MULTILINE
-)
-
-# Performance: Cache size for FTS results
-_FTS_CACHE_SIZE = 64
-
 
 class NeshService:
     """
     Serviço de busca NCM com lógica de negócio (Async).
 
     Responsabilidades:
-    - Parsing de queries NCM
-    - Busca por código (capítulo/posição)
-    - Busca Full-Text Search
-    - Cache de capítulos
-    - Parsing de notas
-
-    Attributes:
-        db: Instância do DatabaseAdapter
-        processor: Processador de texto para FTS
+    - Orquestrar busca por código e FTS
+    - Expor fachada estável para rotas e testes
+    - Coordenar caches L1 e bootstrap do repository
     """
 
     def __init__(
@@ -81,41 +63,33 @@ class NeshService:
             Callable[[], AsyncGenerator["ChapterRepository", None]]
         ] = None,
     ):
-        """
-        Inicializa o serviço com adapter de banco ou repository.
-
-        Args:
-            db: Instância configurada do DatabaseAdapter (legado)
-            repository: ChapterRepository para novo padrão SQLModel
-
-        Note:
-            Use um ou outro. Se ambos forem passados, repository tem prioridade.
-        """
-        self.db = db  # Legado
-        self._repository = repository  # Novo padrão
+        self.db = db
+        self._repository = repository
         self._repository_factory = repository_factory
         self._use_repository = repository is not None or repository_factory is not None
 
         self.processor = NeshTextProcessor(list(CONFIG.stopwords))
-
-        # Async-friendly manual cache for FTS results using OrderedDict as LRU
-        self._fts_cache: OrderedDict = OrderedDict()
-        self._chapter_cache: OrderedDict = OrderedDict()
+        self._fts_cache: OrderedDict[
+            NeshFtsCacheKey, list[NeshFtsScoredRow]
+        ] = OrderedDict()
+        self._chapter_cache: OrderedDict[str, dict] = OrderedDict()
         self._fts_cache_metrics = PayloadCacheMetrics("nesh_fts_cache")
         self._chapter_cache_metrics = PayloadCacheMetrics("nesh_chapter_cache")
-        self._cache_lock: Optional[asyncio.Lock] = None  # Lazy init
+        self._cache_lock: Optional[asyncio.Lock] = None
 
-        mode = "Repository" if self._use_repository else "DatabaseAdapter"
-        logger.info(f"NeshService inicializado (modo: {mode})")
+        logger.info(
+            "NeshService inicializado (modo: %s)",
+            "Repository" if self._use_repository else "DatabaseAdapter",
+        )
 
     @classmethod
-    async def create_with_repository(cls) -> "NeshService":
+    async def initializeNeshServiceWithRepositoryFactory(cls) -> "NeshService":
         """
-        Factory assíncrono para criar NeshService com ChapterRepository.
+        Cria `NeshService` com `ChapterRepository` via SQLModel.
 
-        Uso:
-            service = await NeshService.create_with_repository()
-            results = await service.search_full_text("bomba")
+        Exemplo:
+            service = await NeshService.initializeNeshServiceWithRepositoryFactory()
+            results = await service.executeNeshSearchWithVectorWeights("bomba")
         """
         if not _REPO_AVAILABLE:
             raise RuntimeError(
@@ -130,7 +104,6 @@ class NeshService:
         return cls(repository_factory=repo_factory)
 
     def _get_cache_lock(self) -> asyncio.Lock:
-        """Lazy initialization do lock para evitar criação fora do event loop."""
         if self._cache_lock is None:
             self._cache_lock = asyncio.Lock()
         return self._cache_lock
@@ -139,8 +112,9 @@ class NeshService:
     def _fts_cache_key(
         query: str, tier: int, limit: int, words_matched: int, total_words: int
     ) -> str:
-        raw = f"{query}|{tier}|{limit}|{words_matched}|{total_words}"
-        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+        return build_nesh_fts_cache_key(
+            query, tier, limit, words_matched, total_words
+        )
 
     @asynccontextmanager
     async def _get_repo(self):
@@ -154,742 +128,118 @@ class NeshService:
         yield None
 
     @staticmethod
-    def _strip_chapter_preamble(content: str) -> str:
+    def stripNeshChapterPreamble(content: str) -> str:
         """
-        Remove chapter preamble (title/notes/consideracoes) so body starts at first NCM position.
-        Only used when structured sections are rendered separately.
+        Remove o preâmbulo textual até a primeira posição NCM.
+
+        Exemplo:
+            snippet = service.stripNeshChapterPreamble(chapter.content)
         """
-        if not content:
-            return content
-        match = _RE_FIRST_POSITION.search(content)
-        if not match:
-            return content
-        return content[match.start() :].lstrip()
+        return strip_nesh_chapter_preamble(content)
 
-    def strip_chapter_preamble(self, content: str) -> str:
-        return self._strip_chapter_preamble(content)
-
-    def parse_chapter_notes(self, notes_content: str) -> Dict[str, str]:
+    @staticmethod
+    def parseNeshChapterNotes(notes_content: str) -> dict[str, str]:
         """
-        Parseia notas de capítulo em dicionário estruturado.
+        Analisa o bloco de notas do capítulo em um mapa estruturado.
+
+        Exemplo:
+            notes = service.parseNeshChapterNotes(raw_notes)
         """
-        if not notes_content:
-            return {}
+        return parse_nesh_chapter_notes(notes_content)
 
-        notes = {}
-        lines = notes_content.split("\n")
-        current_num = None
-        buffer = []
-        pattern = _RE_NOTE_HEADER
-
-        for line in lines:
-            cleaned = line.strip()
-            match = pattern.match(cleaned)
-            if match:
-                if current_num:
-                    notes[current_num] = "\n".join(buffer).strip()
-                current_num = match.group(1)
-                buffer = [cleaned]
-            else:
-                if current_num:
-                    buffer.append(cleaned)
-
-        if current_num:
-            notes[current_num] = "\n".join(buffer).strip()
-
-        logger.debug(f"Parseadas {len(notes)} notas")
-        return notes
-
-    async def _get_cached_chapter(self, chapter_num: str) -> Optional[Dict[str, Any]]:
-        """Retorna capítulo do cache L1 em memória quando disponível."""
-        async with self._get_cache_lock():
-            cached = self._chapter_cache.get(chapter_num)
-            if not cached:
-                return None
-            self._chapter_cache.move_to_end(chapter_num)
-            self._chapter_cache_metrics.record_hit()
-            return cached
-
-    async def _store_chapter_in_cache(
-        self, chapter_num: str, payload: Dict[str, Any]
-    ) -> None:
-        """Armazena capítulo no cache L1 e aplica política LRU."""
-        async with self._get_cache_lock():
-            self._chapter_cache[chapter_num] = payload
-            self._chapter_cache_metrics.record_set()
-            if len(self._chapter_cache) > CacheConfig.CHAPTER_CACHE_SIZE:
-                self._chapter_cache.popitem(last=False)
-                self._chapter_cache_metrics.record_eviction()
-
-    async def _get_cached_chapter_from_redis(
-        self, chapter_num: str
-    ) -> Optional[Dict[str, Any]]:
-        """Retorna capítulo do cache L2 (Redis) e hidrata cache local."""
-        if not redis_cache.available:
-            return None
-        cached = await redis_cache.get_chapter(chapter_num)
-        if not cached:
-            return None
-        await self._store_chapter_in_cache(chapter_num, cached)
-        return cached
-
-    async def _fetch_chapter_raw_data(
-        self, chapter_num: str
-    ) -> Optional[Dict[str, Any]]:
-        """Busca dados brutos do capítulo no Repository/DatabaseAdapter."""
-        if self._use_repository:
-            async with self._get_repo() as repo:
-                if not repo:
-                    raise RuntimeError("Repository não disponível")
-                chapter = await repo.get_by_num(chapter_num)
-                if not chapter:
-                    return None
-                notes = chapter.notes
-                sections = (
-                    {
-                        "titulo": notes.titulo,
-                        "notas": notes.notas,
-                        "consideracoes": notes.consideracoes,
-                        "definicoes": notes.definicoes,
-                    }
-                    if notes
-                    else None
-                )
-                return {
-                    "chapter_num": chapter.chapter_num,
-                    "content": chapter.content,
-                    "notes": notes.notes_content if notes else None,
-                    "parsed_notes_json": (
-                        getattr(notes, "parsed_notes_json", None) if notes else None
-                    ),
-                    "positions": [
-                        {
-                            "codigo": p.codigo,
-                            "descricao": p.descricao,
-                            "anchor_id": p.anchor_id,
-                        }
-                        for p in chapter.positions
-                    ],
-                    "sections": sections,
-                }
-
-        if not self.db:
-            raise RuntimeError("DatabaseAdapter não configurado")
-        return await self.db.get_chapter_raw(chapter_num)
-
-    def _hydrate_chapter_payload(self, raw_data: Dict[str, Any]) -> Dict[str, Any]:
-        """Completa payload do capítulo com parsed_notes e anchor_id."""
-        precomputed_json = raw_data.pop("parsed_notes_json", None)
-        if precomputed_json:
-            try:
-                raw_data["parsed_notes"] = (
-                    orjson.loads(precomputed_json)
-                    if isinstance(precomputed_json, (str, bytes))
-                    else precomputed_json
-                )
-            except Exception:
-                raw_data["parsed_notes"] = self.parse_chapter_notes(raw_data["notes"])
-        else:
-            raw_data["parsed_notes"] = self.parse_chapter_notes(raw_data["notes"])
-
-        raw_data["positions"] = self._enrich_positions_with_id(
-            raw_data.get("positions", [])
-        )
-        return raw_data
-
-    async def fetch_chapter_data(self, chapter_num: str) -> Optional[Dict[str, Any]]:
+    async def fetchNeshChapterData(self, chapter_num: str):
         """
-        Busca dados de capítulo com cache LRU (Async).
+        Recupera os dados hidratados de um capítulo NESH.
 
-        Args:
-            chapter_num: Número do capítulo (ex: "73")
-
-        Returns:
-            Dict com dados do capítulo incluindo parsed_notes,
-            ou None se não encontrar
+        Exemplo:
+            chapter = await service.fetchNeshChapterData("85")
         """
-        cached = await self._get_cached_chapter(chapter_num)
-        if cached is not None:
-            return cached
-        self._chapter_cache_metrics.record_miss()
+        return await fetch_nesh_chapter_payload(self, chapter_num)
 
-        redis_cached = await self._get_cached_chapter_from_redis(chapter_num)
-        if redis_cached is not None:
-            return redis_cached
-
-        logger.debug(f"Fetching capítulo {chapter_num} (cache miss)")
-
-        raw_data = await self._fetch_chapter_raw_data(chapter_num)
-        if not raw_data:
-            return None
-        hydrated = self._hydrate_chapter_payload(raw_data)
-
-        if redis_cache.available:
-            await redis_cache.set_chapter(chapter_num, hydrated)
-
-        await self._store_chapter_in_cache(chapter_num, hydrated)
-
-        return hydrated
-
-    def _enrich_positions_with_id(
-        self, positions: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
-        """Adiciona anchor_id a cada posição (usa precomputed se disponível)."""
-        for i, pos in enumerate(positions):
-            if pos.get("anchor_id"):
-                continue
-            codigo = pos.get("codigo")
-            anchor_id = generate_anchor_id(codigo)
-            pos["anchor_id"] = anchor_id
-        return positions
-
-    def normalize_query(self, text: str) -> str:
+    def normalizeNeshQuery(self, text: str) -> str:
         """
-        Normaliza query para busca FTS.
-        Otimização: Remove duplicatas e limita termos.
+        Normaliza uma consulta textual para FTS.
+
+        Exemplo:
+            query = service.normalizeNeshQuery("motor bomba")
         """
-        processed = self.processor.process_query_for_fts(text)
-        if not processed:
-            return ""
+        return normalize_nesh_fts_query(self, text)
 
-        # Deduplica termos ("ma* ma*" -> "ma*") para otimizar busca AND
-        parts = processed.split()
-        unique = list(dict.fromkeys(parts))
-        # Limita quantidade de tokens para evitar DoS
-        unique = unique[:20]
-
-        return " ".join(unique)
-
-    def normalize_query_raw(self, text: str) -> str:
+    def normalizeNeshRawQuery(self, text: str) -> str:
         """
-        Normaliza query para FTS sem stemming agressivo.
-        Usado como fallback quando stemming não encontra resultados.
+        Normaliza a consulta textual preservando termos crus relevantes.
+
+        Exemplo:
+            query = service.normalizeNeshRawQuery("motor bomba")
         """
-        normalized = self.processor.normalize(text)
-        words = re.findall(r"\b\w+\b", normalized)
-
-        processed = []
-        for w in words:
-            if w in self.processor.stopwords:
-                continue
-            if len(w) < 2:
-                continue
-            processed.append(f"{w}*")
-
-        if not processed:
-            return ""
-
-        unique = list(dict.fromkeys(processed))[:20]
-        return " ".join(unique)
+        return normalize_nesh_raw_fts_query(self, text)
 
     async def _fts_scored_cached(
         self, query: str, tier: int, limit: int, words_matched: int, total_words: int
-    ) -> List[Dict[str, Any]]:
+    ):
+        return await fetch_nesh_fts_scored_rows_cached(
+            self, query, tier, limit, words_matched, total_words
+        )
+
+    async def searchNeshByTextQuery(self, query: str) -> ServiceResponse:
         """
-        Async wrapper for FTS scored search with manual LRU cache.
+        Executa busca textual FTS sobre o conteúdo NESH.
+
+        Exemplo:
+            payload = await service.searchNeshByTextQuery("motor bomba")
         """
-        key = (query, tier, limit, words_matched, total_words)
+        return await search_nesh_fts_text(self, query)
 
-        async with self._get_cache_lock():
-            if key in self._fts_cache:
-                self._fts_cache.move_to_end(key)
-                self._fts_cache_metrics.record_hit()
-                return list(self._fts_cache[key])
-        self._fts_cache_metrics.record_miss()
-
-        if redis_cache.available:
-            redis_key = self._fts_cache_key(
-                query, tier, limit, words_matched, total_words
-            )
-            cached = await redis_cache.get_fts(redis_key)
-            if cached:
-                async with self._get_cache_lock():
-                    self._fts_cache[key] = cached
-                    self._fts_cache_metrics.record_set()
-                    if len(self._fts_cache) > _FTS_CACHE_SIZE:
-                        self._fts_cache.popitem(last=False)
-                        self._fts_cache_metrics.record_eviction()
-                return list(cached)
-
-        # Use repository if available, otherwise fallback to legacy adapter
-        if self._use_repository:
-            async with self._get_repo() as repo:
-                if not repo:
-                    raise RuntimeError("Repository não disponível")
-                results = await repo.search_scored(
-                    query,
-                    tier=tier,
-                    limit=limit,
-                    words_matched=words_matched,
-                    total_words=total_words,
-                )
-                # Convert SearchResultItem to dict for compatibility
-                results = [
-                    {
-                        "ncm": r.ncm,
-                        "display_text": r.display_text,
-                        "type": r.type,
-                        "description": r.description,
-                        "score": r.score,
-                        "tier": r.tier,
-                        "rank": r.score,  # Compatibility
-                    }
-                    for r in results
-                ]
-        else:
-            if not self.db:
-                raise RuntimeError("DatabaseAdapter não configurado")
-            results = await self.db.fts_search_scored(
-                query,
-                tier=tier,
-                limit=limit,
-                words_matched=words_matched,
-                total_words=total_words,
-            )
-
-        async with self._get_cache_lock():
-            self._fts_cache[key] = results
-            self._fts_cache_metrics.record_set()
-            if len(self._fts_cache) > _FTS_CACHE_SIZE:
-                self._fts_cache.popitem(last=False)
-                self._fts_cache_metrics.record_eviction()
-
-        if redis_cache.available:
-            redis_key = self._fts_cache_key(
-                query, tier, limit, words_matched, total_words
-            )
-            await redis_cache.set_fts(redis_key, results)
-
-        return results
-
-    @staticmethod
-    def _empty_text_search_response(query: str) -> ServiceResponse:
-        return {
-            "success": True,
-            "type": "text",
-            "query": query,
-            "normalized": "",
-            "match_type": "none",
-            "warning": None,
-            "results": [],
-            "total_capitulos": 0,
-        }
-
-    @staticmethod
-    def _row_identity(row: Dict[str, Any]) -> Tuple[str, str, str]:
-        return (row["ncm"], row["type"], row["display_text"])
-
-    def _add_unique_rows(
-        self,
-        target: List[Dict[str, Any]],
-        seen: set[Tuple[str, str, str]],
-        rows: List[Dict[str, Any]],
-    ) -> None:
-        for row in rows:
-            key = self._row_identity(row)
-            if key in seen:
-                continue
-            seen.add(key)
-            target.append(row)
-
-    async def _search_tier1(
-        self, exact_q: str, total_words: int
-    ) -> List[Dict[str, Any]]:
-        phrase_query = f'"{exact_q}"'
-        return await self._fts_scored_cached(
-            phrase_query,
-            tier=1,
-            limit=SearchConfig.TIER1_LIMIT,
-            words_matched=total_words,
-            total_words=total_words,
-        )
-
-    async def _search_tier2(
-        self, normalized_q: str, normalized_raw_q: str, total_words: int
-    ) -> List[Dict[str, Any]]:
-        and_results = await self._fts_scored_cached(
-            normalized_q,
-            tier=2,
-            limit=SearchConfig.TIER2_LIMIT,
-            words_matched=total_words,
-            total_words=total_words,
-        )
-        if and_results or not normalized_raw_q or normalized_raw_q == normalized_q:
-            return and_results
-        return await self._fts_scored_cached(
-            normalized_raw_q,
-            tier=2,
-            limit=SearchConfig.TIER2_LIMIT,
-            words_matched=total_words,
-            total_words=total_words,
-        )
-
-    def _build_tier3_query(self, original_words: List[str]) -> str:
-        unique_words = list(dict.fromkeys(original_words))[:20]
-        or_parts = []
-        for word in unique_words:
-            word_normalized = self.processor.process_query_for_fts(word)
-            if word_normalized:
-                or_parts.append(word_normalized)
-        return " OR ".join(or_parts)
-
-    async def _search_tier3(
-        self, original_words: List[str], normalized_raw_q: str, total_words: int
-    ) -> List[Dict[str, Any]]:
-        or_query = self._build_tier3_query(original_words)
-        if not or_query:
-            return []
-
-        partial_results = await self._fts_scored_cached(
-            or_query,
-            tier=3,
-            limit=SearchConfig.TIER3_LIMIT,
-            words_matched=max(1, total_words // 2),
-            total_words=total_words,
-        )
-        if partial_results or not normalized_raw_q:
-            return partial_results
-
-        raw_or_query = " OR ".join(normalized_raw_q.split())
-        if raw_or_query == or_query:
-            return partial_results
-        return await self._fts_scored_cached(
-            raw_or_query,
-            tier=3,
-            limit=SearchConfig.TIER3_LIMIT,
-            words_matched=max(1, total_words // 2),
-            total_words=total_words,
-        )
-
-    async def _apply_near_bonus_if_needed(
-        self, all_results: List[Dict[str, Any]], stemmed_words: List[str]
-    ) -> None:
-        if self._use_repository or len(stemmed_words) < 2 or not all_results:
-            return
-        if not self.db:
-            return
-        near_results = await self.db.fts_search_near(
-            stemmed_words,
-            distance=SearchConfig.NEAR_DISTANCE,
-            limit=SearchConfig.TIER1_LIMIT + SearchConfig.TIER2_LIMIT,
-        )
-        near_ncms = {r["ncm"] for r in near_results}
-        for row in all_results:
-            if row["ncm"] not in near_ncms:
-                continue
-            row["score"] += SearchConfig.NEAR_BONUS
-            row["near_bonus"] = True
-            logger.debug(f"NEAR bonus aplicado: {row['ncm']}")
-
-    @staticmethod
-    def _resolve_match_metadata(
-        all_results: List[Dict[str, Any]], query: str, original_words: List[str]
-    ) -> Tuple[str, Optional[str], int]:
-        best_tier = min(r.get("tier", 3) for r in all_results)
-        if best_tier == 1:
-            return "exact", None, best_tier
-        if best_tier == 2:
-            return "all_words", None, best_tier
-        warning = (
-            f'Não encontrei "{query}" exato. '
-            f"Mostrando aproximações para: {', '.join(original_words)}"
-        )
-        return "partial", warning, best_tier
-
-    async def search_full_text(self, query: str) -> ServiceResponse:
+    async def searchNeshByNcmCode(self, ncm_query: str) -> ServiceResponse:
         """
-        Executa busca Full-Text Search (FTS) com sistema de ranking por tiers (Async).
+        Busca capítulos NESH a partir de uma query NCM normalizada.
+
+        Exemplo:
+            payload = await service.searchNeshByNcmCode("85.17")
         """
-        logger.info(f"Busca FTS: '{query}'")
-
-        original_words = [w.strip() for w in query.split() if w.strip()]
-        total_words = len(original_words)
-
-        normalized_q = self.normalize_query(query)
-        normalized_raw_q = self.normalize_query_raw(query)
-
-        if not normalized_q:
-            logger.debug("Query vazia após normalização")
-            return self._empty_text_search_response(query)
-
-        exact_q = self.processor.process_query_exact(query)
-        stemmed_words = exact_q.split() if exact_q else []
-
-        all_results: List[Dict[str, Any]] = []
-        seen: set[Tuple[str, str, str]] = set()
-
-        if len(original_words) > 1 and exact_q:
-            exact_results = await self._search_tier1(exact_q, total_words)
-            if exact_results:
-                logger.info(f"FTS TIER1 (exato): {len(exact_results)} resultados")
-                self._add_unique_rows(all_results, seen, exact_results)
-
-        and_results = await self._search_tier2(
-            normalized_q, normalized_raw_q, total_words
-        )
-        if and_results:
-            logger.info(f"FTS TIER2 (AND): {len(and_results)} resultados")
-            self._add_unique_rows(all_results, seen, and_results)
-
-        await self._apply_near_bonus_if_needed(all_results, stemmed_words)
-
-        if len(original_words) > 1:
-            partial_results = await self._search_tier3(
-                original_words, normalized_raw_q, total_words
-            )
-            if partial_results:
-                logger.info(f"FTS TIER3 (OR): {len(partial_results)} resultados")
-                self._add_unique_rows(all_results, seen, partial_results)
-
-        all_results.sort(key=lambda x: x.get("score", 0), reverse=True)
-
-        if not all_results:
-            logger.info("FTS: 0 resultados em todos os níveis")
-            return self._build_fts_response(
-                query,
-                normalized_q,
-                [],
-                match_type="none",
-                warning=f'Nenhum resultado encontrado para "{query}"',
-            )
-
-        match_type, match_warning, best_tier = self._resolve_match_metadata(
-            all_results, query, original_words
-        )
-        logger.info(
-            f"FTS total: {len(all_results)} resultados, melhor tier: {best_tier}"
-        )
-        return self._build_fts_response(
-            query,
-            normalized_q,
-            all_results,
-            match_type=match_type,
-            warning=match_warning,
-        )
-
-    def _build_fts_response(
-        self,
-        query: str,
-        normalized: str,
-        rows: list,
-        match_type: str,
-        warning: Optional[str],
-    ) -> ServiceResponse:
-        """Constrói resposta padronizada para busca FTS com scores."""
-
-        tier_labels = {1: "Exato", 2: "Todas palavras", 3: "Parcial"}
-
-        results = []
-        for row in rows:
-            tier = row.get("tier", 3)
-            score = row.get("score", 0)
-            has_near_bonus = row.get("near_bonus", False)
-
-            results.append(
-                {
-                    "ncm": row["ncm"],
-                    "descricao": row["display_text"],
-                    "tipo": row["type"],
-                    "relevancia": row.get("rank", 0),
-                    "score": score,
-                    "tier": tier,
-                    "tier_label": tier_labels.get(tier, "Parcial"),
-                    "near_bonus": has_near_bonus,
-                }
-            )
-
-        return {
-            "success": True,
-            "type": "text",
-            "query": query,
-            "normalized": normalized,
-            "match_type": match_type,
-            "warning": warning,
-            "results": results,
-            "total_capitulos": 0,
-        }
-
-    def _extract_chapter_targets(
-        self, ncms: List[str]
-    ) -> OrderedDict[str, Tuple[str, Optional[str]]]:
-        chapter_targets: OrderedDict[str, Tuple[str, Optional[str]]] = OrderedDict()
-        for ncm in ncms:
-            chapter_num, target_pos = ncm_utils.extract_chapter_from_ncm(ncm)
-            if not chapter_num:
-                logger.debug(f"NCM inválido ignorado: '{ncm}'")
-                continue
-            chapter_targets.setdefault(chapter_num, (ncm, target_pos))
-        return chapter_targets
-
-    @staticmethod
-    def _has_structured_sections(sections: Dict[str, Any]) -> bool:
-        return any(
-            (sections.get(key) or "").strip()
-            for key in ("titulo", "notas", "consideracoes", "definicoes")
-        )
-
-    @staticmethod
-    def _build_sections_payload(sections: Dict[str, Any]) -> Dict[str, Any]:
-        return {
-            "titulo": sections.get("titulo"),
-            "notas": sections.get("notas"),
-            "consideracoes": sections.get("consideracoes"),
-            "definicoes": sections.get("definicoes"),
-        }
-
-    def _build_found_chapter_search_result(
-        self,
-        chapter_num: str,
-        ncm_buscado: str,
-        target_pos: Optional[str],
-        data: Dict[str, Any],
-    ) -> SearchResult:
-        sections = data.get("sections") or {}
-        has_sections = self._has_structured_sections(sections)
-        content = (
-            self._strip_chapter_preamble(data["content"])
-            if has_sections
-            else data["content"]
-        )
-        return {
-            "ncm_buscado": ncm_buscado,
-            "capitulo": chapter_num,
-            "posicao_alvo": target_pos,
-            "posicoes": data["positions"],
-            "notas_gerais": data["notes"],
-            "notas_parseadas": data["parsed_notes"],
-            "conteudo": content,
-            "real_content_found": True,
-            "erro": None,
-            "secoes": self._build_sections_payload(sections) if has_sections else None,
-        }
-
-    @staticmethod
-    def _build_missing_chapter_search_result(
-        chapter_num: str, ncm_buscado: str
-    ) -> SearchResult:
-        return {
-            "ncm_buscado": ncm_buscado,
-            "capitulo": chapter_num,
-            "real_content_found": False,
-            "erro": f"Capítulo {chapter_num} não encontrado",
-            "conteudo": "",
-            "posicoes": [],
-            "notas_gerais": None,
-            "notas_parseadas": {},
-            "posicao_alvo": None,
-        }
-
-    async def search_by_code(self, ncm_query: str) -> ServiceResponse:
-        """
-        Busca capítulos por código NCM (Async).
-
-        Args:
-            ncm_query: String de NCMs (ex: "85,73.18,0101")
-
-        Returns:
-            ServiceResponse com type='code' e dict de resultados
-        """
-        logger.debug(f"Busca por código: '{ncm_query}'")
-
-        results: Dict[str, SearchResult] = {}
-        ncms = ncm_utils.split_ncm_query(ncm_query)
-        chapter_targets = self._extract_chapter_targets(ncms)
-        if not chapter_targets:
-            logger.debug("Retornando 0 capítulos")
-            return {
-                "success": True,
-                "type": "code",
-                "query": ncm_query,
-                "normalized": None,
-                "results": results,
-                "total_capitulos": 0,
-            }
-
-        ordered_chapters = list(chapter_targets.keys())
-        chapter_payloads = await asyncio.gather(
-            *(self.fetch_chapter_data(chapter_num) for chapter_num in ordered_chapters)
-        )
-
-        for chapter_num, data in zip(ordered_chapters, chapter_payloads):
-            ncm_buscado, target_pos = chapter_targets[chapter_num]
-            if data:
-                results[chapter_num] = self._build_found_chapter_search_result(
-                    chapter_num, ncm_buscado, target_pos, data
-                )
-                continue
-            logger.warning(f"Capítulo não encontrado: {chapter_num}")
-            results[chapter_num] = self._build_missing_chapter_search_result(
-                chapter_num, ncm_buscado
-            )
-
-        logger.debug(f"Retornando {len(results)} capítulos")
-        return {
-            "success": True,
-            "type": "code",
-            "query": ncm_query,
-            "normalized": None,
-            "results": results,
-            "total_capitulos": len(results),
-        }
+        return await search_nesh_chapters_by_ncm_code(self, ncm_query)
 
     async def executeNeshSearchWithVectorWeights(self, query: str) -> ServiceResponse:
-        """Facade canônico para execução da busca NESH."""
-        # Heurística: só dígitos/pontuação = código NCM
+        """
+        Decide entre busca por código NCM e busca textual ponderada.
+
+        Exemplo:
+            payload = await service.executeNeshSearchWithVectorWeights("85.17")
+        """
         is_ncm = ncm_utils.is_code_query(query)
-
         if is_ncm:
-            return await self.search_by_code(query)
-        return await self.search_full_text(query)
+            return await self.searchNeshByNcmCode(query)
+        return await self.searchNeshByTextQuery(query)
 
-    async def process_request(self, query: str) -> ServiceResponse:
-        """Alias de compatibilidade para o método canônico de busca."""
-        return await self.executeNeshSearchWithVectorWeights(query)
-
-    async def prewarm_cache(
-        self, chapter_nums: Optional[List[str]] = None, concurrency: int = 10
+    async def prewarmNeshChapterCache(
+        self, chapter_nums: Optional[list[str]] = None, concurrency: int = 10
     ) -> int:
         """
-        Pre-warm chapter cache (L1/L2) to reduce cold latency.
+        Faz o aquecimento do cache de capítulos NESH.
+
+        Exemplo:
+            warmed = await service.prewarmNeshChapterCache(["85", "86"])
         """
-        if chapter_nums is None:
-            if self._use_repository:
-                async with self._get_repo() as repo:
-                    if not repo:
-                        return 0
-                    chapter_nums = await repo.get_all_nums()
-            else:
-                if not self.db:
-                    return 0
-                chapter_nums = await self.db.get_all_chapters_list()
+        return await prewarm_nesh_chapter_cache(
+            self, chapter_nums=chapter_nums, concurrency=concurrency
+        )
 
-        if not chapter_nums:
-            return 0
-
-        sem = asyncio.Semaphore(concurrency)
-
-        async def _warm(chapter_num: str) -> None:
-            async with sem:
-                try:
-                    await self.fetch_chapter_data(chapter_num)
-                except Exception as exc:
-                    logger.debug("Prewarm failed for %s: %s", chapter_num, exc)
-
-        await asyncio.gather(*(_warm(num) for num in chapter_nums))
-        return len(chapter_nums)
-
-    async def get_internal_cache_metrics(self) -> Dict[str, Any]:
+    async def snapshotNeshInternalCacheMetrics(self) -> dict:
         """
-        Snapshot dos caches internos (L1) do serviço.
+        Captura as métricas atuais dos caches internos do serviço.
+
+        Exemplo:
+            snapshot = await service.snapshotNeshInternalCacheMetrics()
         """
         async with self._get_cache_lock():
             chapter_snapshot = self._chapter_cache_metrics.snapshot(
                 current_size=len(self._chapter_cache),
                 max_size=CacheConfig.CHAPTER_CACHE_SIZE,
             )
+            fts_current_size, fts_max_size = snapshot_nesh_fts_cache_metrics(self)
             fts_snapshot = self._fts_cache_metrics.snapshot(
-                current_size=len(self._fts_cache),
-                max_size=_FTS_CACHE_SIZE,
+                current_size=fts_current_size,
+                max_size=fts_max_size,
             )
 
         return {

--- a/backend/services/tipi/__init__.py
+++ b/backend/services/tipi/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers especializados para o serviço TIPI."""

--- a/backend/services/tipi/health.py
+++ b/backend/services/tipi/health.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+from ...config.logging_config import service_logger as logger
+from .types import TipiRepositoryHealthPayload, TipiSqliteHealthPayload
+
+if TYPE_CHECKING:
+    from ..tipi_service import TipiService
+
+
+async def probe_tipi_repository_catalog_health(
+    service: "TipiService",
+) -> TipiRepositoryHealthPayload:
+    try:
+        async with service._acquire_tipi_repository() as repo:
+            if repo is None:
+                raise RuntimeError("TIPI repository unavailable")
+
+            chapters_result = await repo.session.execute(
+                text("SELECT COUNT(DISTINCT chapter_num) FROM tipi_positions")
+            )
+            positions_result = await repo.session.execute(
+                text("SELECT COUNT(*) FROM tipi_positions")
+            )
+            metadata_result = await repo.session.execute(
+                text(
+                    """
+                    SELECT key, value
+                    FROM catalog_metadata
+                    WHERE key LIKE 'tipi_%'
+                    ORDER BY key
+                    """
+                )
+            )
+
+        chapters = int(chapters_result.scalar() or 0)
+        positions = int(positions_result.scalar() or 0)
+        metadata = {row.key: row.value for row in metadata_result}
+        return {
+            "status": "online" if chapters > 0 and positions > 0 else "error",
+            "chapters": chapters,
+            "positions": positions,
+            "metadata": metadata,
+        }
+    except Exception as exc:
+        logger.error("TIPI repository healthcheck failed: %s", exc)
+        return {"status": "error", "error": str(exc)}
+
+
+async def probe_tipi_sqlite_catalog_health(
+    service: "TipiService",
+) -> TipiSqliteHealthPayload:
+    if not service.db_path.exists():
+        return {
+            "ok": False,
+            "error": f"Banco TIPI não encontrado: {service.db_path}",
+        }
+
+    try:
+        conn = await service._acquire_tipi_connection()
+        try:
+            cursor = await conn.execute("SELECT COUNT(*) FROM tipi_chapters")
+            chapters_row = await cursor.fetchone()
+            chapters = chapters_row[0] if chapters_row else 0
+
+            cursor = await conn.execute("SELECT COUNT(*) FROM tipi_positions")
+            positions_row = await cursor.fetchone()
+            positions = positions_row[0] if positions_row else 0
+
+            return {"ok": True, "chapters": chapters, "positions": positions}
+        finally:
+            await service._release_tipi_connection(conn)
+    except Exception as exc:
+        logger.error("TIPI Check Connection failed: %s", exc)
+        return {"ok": False, "error": str(exc)}

--- a/backend/services/tipi/health.py
+++ b/backend/services/tipi/health.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 
 from ...config.logging_config import service_logger as logger
 from .types import TipiRepositoryHealthPayload, TipiSqliteHealthPayload
@@ -35,17 +37,20 @@ async def probe_tipi_repository_catalog_health(
                     """
                 )
             )
+            chapters = int(chapters_result.scalar() or 0)
+            positions = int(positions_result.scalar() or 0)
+            metadata_rows = list(metadata_result)
 
-        chapters = int(chapters_result.scalar() or 0)
-        positions = int(positions_result.scalar() or 0)
-        metadata = {row.key: row.value for row in metadata_result}
+        metadata = {row.key: row.value for row in metadata_rows}
         return {
             "status": "online" if chapters > 0 and positions > 0 else "error",
             "chapters": chapters,
             "positions": positions,
             "metadata": metadata,
         }
-    except Exception as exc:
+    except asyncio.CancelledError:
+        raise
+    except (SQLAlchemyError, RuntimeError, OSError) as exc:
         logger.error("TIPI repository healthcheck failed: %s", exc)
         return {"status": "error", "error": str(exc)}
 
@@ -53,7 +58,7 @@ async def probe_tipi_repository_catalog_health(
 async def probe_tipi_sqlite_catalog_health(
     service: "TipiService",
 ) -> TipiSqliteHealthPayload:
-    if not service.db_path.exists():
+    if not await asyncio.to_thread(service.db_path.exists):
         return {
             "ok": False,
             "error": f"Banco TIPI não encontrado: {service.db_path}",
@@ -73,6 +78,8 @@ async def probe_tipi_sqlite_catalog_health(
             return {"ok": True, "chapters": chapters, "positions": positions}
         finally:
             await service._release_tipi_connection(conn)
-    except Exception as exc:
+    except asyncio.CancelledError:
+        raise
+    except (SQLAlchemyError, RuntimeError, OSError) as exc:
         logger.error("TIPI Check Connection failed: %s", exc)
         return {"ok": False, "error": str(exc)}

--- a/backend/services/tipi/health.py
+++ b/backend/services/tipi/health.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 from typing import TYPE_CHECKING
 
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
+from ...config.exceptions import DatabaseError
 from ...config.logging_config import service_logger as logger
 from .types import TipiRepositoryHealthPayload, TipiSqliteHealthPayload
 
@@ -80,6 +82,12 @@ async def probe_tipi_sqlite_catalog_health(
             await service._release_tipi_connection(conn)
     except asyncio.CancelledError:
         raise
-    except (SQLAlchemyError, RuntimeError, OSError) as exc:
+    except (
+        SQLAlchemyError,
+        RuntimeError,
+        OSError,
+        sqlite3.Error,
+        DatabaseError,
+    ) as exc:
         logger.error("TIPI Check Connection failed: %s", exc)
         return {"ok": False, "error": str(exc)}

--- a/backend/services/tipi/search.py
+++ b/backend/services/tipi/search.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any
+
+from ...config.constants import CacheConfig
+from ...utils import ncm_utils
+from ...utils.id_utils import generate_anchor_id
+from ...utils.payload_cache_metrics import PayloadCacheMetrics
+from .types import (
+    TipiChapterCatalogItem,
+    TipiChapterResultsMap,
+    TipiCodeCacheKey,
+    TipiCodeChapterPayload,
+    TipiCodeSearchPayload,
+    TipiPositionRow,
+    TipiRepositoryHealthPayload,
+    TipiRowBatch,
+    TipiTextSearchItem,
+    TipiTextSearchPayload,
+)
+
+if TYPE_CHECKING:
+    from ..tipi_service import TipiService
+
+
+def build_empty_tipi_code_search_response(query: str) -> TipiCodeSearchPayload:
+    return {
+        "success": True,
+        "type": "code",
+        "query": query,
+        "results": {},
+        "resultados": {},
+        "total": 0,
+        "total_capitulos": 0,
+    }
+
+
+def clone_tipi_code_search_result(
+    result: TipiCodeSearchPayload,
+) -> TipiCodeSearchPayload:
+    return deepcopy(result)
+
+
+def normalize_tipi_multi_code_parts(ncm_query: str, *, max_parts: int) -> list[str]:
+    normalized_parts: list[str] = []
+    seen_parts: set[str] = set()
+    for raw_part in ncm_utils.split_ncm_query(ncm_query):
+        normalized_part = ncm_utils.clean_ncm(raw_part)
+        if not normalized_part or normalized_part in seen_parts:
+            continue
+        normalized_parts.append(normalized_part)
+        seen_parts.add(normalized_part)
+        if len(normalized_parts) >= max_parts:
+            break
+    return normalized_parts
+
+
+def prefer_more_specific_tipi_posicao_alvo(
+    current: str | None, incoming: str | None
+) -> str | None:
+    if not incoming:
+        return current
+    if not current:
+        return incoming
+
+    current_clean = ncm_utils.clean_ncm(current)
+    incoming_clean = ncm_utils.clean_ncm(incoming)
+    if len(incoming_clean) > len(current_clean):
+        return incoming
+    return current
+
+
+def resolve_tipi_target_position(
+    clean_query: str, normalized_query: str, query_part: str
+) -> str | None:
+    if len(clean_query) <= 2:
+        return None
+    return (normalized_query or "").strip() or query_part.strip()
+
+
+def resolve_tipi_chapter_target_position(
+    capitulo: str, posicao_alvo: str | None
+) -> str | None:
+    if not posicao_alvo:
+        return None
+    clean_alvo = ncm_utils.clean_ncm(posicao_alvo)
+    return posicao_alvo if clean_alvo.startswith(capitulo) else None
+
+
+def build_ancestor_prefixes(prefix: str) -> set[str]:
+    ancestor_prefixes: set[str] = set()
+    if len(prefix) >= 4:
+        ancestor_prefixes.add(prefix[:4])
+    if len(prefix) >= 6:
+        ancestor_prefixes.add(prefix[:6])
+    return ancestor_prefixes
+
+
+def _normalize_repository_rows(
+    rows: list[dict[str, Any]], cap_num: str
+) -> TipiRowBatch:
+    return tuple(
+        {
+            **row,
+            "capitulo": row.get("capitulo", cap_num),
+            "nivel": row.get("nivel", 0),
+        }
+        for row in rows
+    )
+
+
+async def _store_chapter_positions_in_cache(
+    service: "TipiService", cap_num: str, rows: TipiRowBatch
+) -> TipiRowBatch:
+    async with service._get_cache_lock():
+        service._chapter_positions_cache[cap_num] = rows
+        service._chapter_positions_cache_metrics.record_set()
+        service._trim_tipi_lru_cache_to_limit(
+            service._chapter_positions_cache,
+            CacheConfig.TIPI_CHAPTER_CACHE_SIZE,
+            service._chapter_positions_cache_metrics,
+        )
+    return rows
+
+
+async def get_chapter_positions(service: "TipiService", cap_num: str) -> TipiRowBatch:
+    async with service._get_cache_lock():
+        if cap_num in service._chapter_positions_cache:
+            service._chapter_positions_cache.move_to_end(cap_num)
+            service._chapter_positions_cache_metrics.record_hit()
+            return service._chapter_positions_cache[cap_num]
+    service._chapter_positions_cache_metrics.record_miss()
+
+    if service._use_repository:
+        async with service._acquire_tipi_repository() as repo:
+            if repo:
+                rows = _normalize_repository_rows(
+                    await repo.get_by_chapter(cap_num),
+                    cap_num,
+                )
+                return await _store_chapter_positions_in_cache(service, cap_num, rows)
+
+    conn = await service._acquire_tipi_connection()
+    try:
+        cols = await service._load_tipi_table_columns(conn, "tipi_positions")
+        order_by = service._resolve_tipi_order_by_clause(cols)
+        sql = f"""
+            SELECT ncm, capitulo, descricao, aliquota, nivel
+            FROM tipi_positions
+            WHERE capitulo = ?
+            ORDER BY {order_by}
+            """  # nosec B608
+        cursor = await conn.execute(sql, (cap_num,))
+        rows = await cursor.fetchall()
+        result: TipiRowBatch = tuple(dict(row) for row in rows)
+        return await _store_chapter_positions_in_cache(service, cap_num, result)
+    finally:
+        await service._release_tipi_connection(conn)
+
+
+async def get_family_positions(
+    service: "TipiService",
+    cap_num: str,
+    prefix: str,
+    ancestor_prefixes: set[str],
+) -> TipiRowBatch:
+    if service._use_repository:
+        async with service._acquire_tipi_repository() as repo:
+            if repo:
+                return _normalize_repository_rows(
+                    await repo.get_family_positions(cap_num, prefix, ancestor_prefixes),
+                    cap_num,
+                )
+
+    conn = await service._acquire_tipi_connection()
+    try:
+        cols = await service._load_tipi_table_columns(conn, "tipi_positions")
+        order_by = service._resolve_tipi_order_by_clause(cols)
+        conditions = ["REPLACE(ncm, '.', '') LIKE ? || '%'"]
+        params: list[str] = [prefix]
+
+        for ancestor in ancestor_prefixes:
+            conditions.append("REPLACE(ncm, '.', '') = ?")
+            params.append(ancestor)
+
+        where_clause = " OR ".join(conditions)
+        sql = f"""
+            SELECT ncm, capitulo, descricao, aliquota, nivel
+            FROM tipi_positions
+            WHERE capitulo = ? AND ({where_clause})
+            ORDER BY {order_by}
+            """  # nosec B608
+        cursor = await conn.execute(sql, (cap_num, *params))
+        rows = await cursor.fetchall()
+        return tuple(dict(row) for row in rows)
+    finally:
+        await service._release_tipi_connection(conn)
+
+
+async def read_tipi_code_search_cache(
+    service: "TipiService", cache_key: TipiCodeCacheKey
+) -> TipiCodeSearchPayload | None:
+    cached: TipiCodeSearchPayload | None
+    async with service._get_cache_lock():
+        cached = service._code_search_cache.get(cache_key)
+        if not cached:
+            return None
+        service._code_search_cache.move_to_end(cache_key)
+        service._code_search_cache_metrics.record_hit()
+    return clone_tipi_code_search_result(cached)
+
+
+async def write_tipi_code_search_cache(
+    service: "TipiService",
+    cache_key: TipiCodeCacheKey,
+    result: TipiCodeSearchPayload,
+) -> None:
+    cloned_result = clone_tipi_code_search_result(result)
+    async with service._get_cache_lock():
+        service._code_search_cache[cache_key] = cloned_result
+        service._code_search_cache_metrics.record_set()
+        service._trim_tipi_lru_cache_to_limit(
+            service._code_search_cache,
+            CacheConfig.TIPI_RESULT_CACHE_SIZE,
+            service._code_search_cache_metrics,
+        )
+
+
+def merge_tipi_multi_code_part_payloads(
+    merged: TipiChapterResultsMap, part_resp: TipiCodeSearchPayload
+) -> None:
+    source = part_resp.get("resultados") or part_resp.get("results") or {}
+    for cap, cap_data in source.items():
+        if cap not in merged:
+            merged[cap] = {
+                **cap_data,
+                "posicoes": [],
+            }
+        merged[cap]["posicao_alvo"] = prefer_more_specific_tipi_posicao_alvo(
+            merged[cap].get("posicao_alvo"),
+            cap_data.get("posicao_alvo"),
+        )
+        merged[cap].setdefault("posicoes", [])
+        seen_ncms = {pos.get("ncm") for pos in merged[cap]["posicoes"]}
+        for posicao in cap_data.get("posicoes", []):
+            ncm = posicao.get("ncm")
+            if ncm in seen_ncms:
+                continue
+            merged[cap]["posicoes"].append(posicao)
+            seen_ncms.add(ncm)
+
+
+async def search_tipi_multi_code_parts(
+    service: "TipiService",
+    ncm_query: str,
+    view_mode: str,
+    parts: list[str],
+) -> TipiCodeSearchPayload:
+    merged: TipiChapterResultsMap = {}
+    for part in parts:
+        part_resp = await service.searchTipiByNcmCode(part, view_mode=view_mode)
+        merge_tipi_multi_code_part_payloads(merged, part_resp)
+    total_rows = sum(len(cap.get("posicoes", [])) for cap in merged.values())
+    return {
+        "success": True,
+        "type": "code",
+        "query": ncm_query,
+        "results": merged,
+        "resultados": merged,
+        "total": total_rows,
+        "total_capitulos": len(merged),
+    }
+
+
+async def load_tipi_rows_for_code(
+    service: "TipiService", cap_num: str, clean_query: str, view_mode: str
+) -> TipiRowBatch:
+    if view_mode != "family" or len(clean_query) <= 2:
+        return await service._get_chapter_positions(cap_num)
+    return await service._get_family_positions(
+        cap_num,
+        clean_query,
+        build_ancestor_prefixes(clean_query),
+    )
+
+
+def build_tipi_code_result_map(
+    rows: TipiRowBatch, posicao_alvo: str | None
+) -> TipiChapterResultsMap:
+    resultados: TipiChapterResultsMap = {}
+    for row in rows:
+        cap = row["capitulo"]
+        if cap not in resultados:
+            resultados[cap] = TipiCodeChapterPayload(
+                capitulo=cap,
+                titulo=f"Capítulo {cap}",
+                notas_gerais=None,
+                posicao_alvo=resolve_tipi_chapter_target_position(cap, posicao_alvo),
+                posicoes=[],
+            )
+
+        codigo = row["ncm"]
+        resultados[cap]["posicoes"].append(
+            {
+                "ncm": codigo,
+                "codigo": codigo,
+                "descricao": row["descricao"],
+                "aliquota": row.get("aliquota") or "0",
+                "nivel": row.get("nivel", 0),
+                "anchor_id": generate_anchor_id(codigo),
+            }
+        )
+    return resultados
+
+
+async def search_tipi_by_ncm_code(
+    service: "TipiService", ncm_query: str, view_mode: str = "family"
+) -> TipiCodeSearchPayload:
+    cache_key = (ncm_query, view_mode)
+    cached = await service._read_tipi_code_search_cache(cache_key)
+    if cached:
+        return cached
+    service._code_search_cache_metrics.record_miss()
+
+    parts = service._normalize_tipi_multi_code_parts(ncm_query)
+    if len(parts) > 1:
+        result = await service._search_tipi_multi_code_parts(
+            ncm_query, view_mode, parts
+        )
+        await service._write_tipi_code_search_cache(cache_key, result)
+        return result
+
+    query_part = parts[0] if parts else ""
+    normalized_query = ncm_utils.format_ncm_tipi(query_part)
+    clean_query = ncm_utils.clean_ncm(normalized_query)
+    if not clean_query:
+        return service._build_empty_tipi_code_search_response(ncm_query)
+
+    cap_num = clean_query[:2].zfill(2)
+    posicao_alvo = service._resolve_tipi_target_position(
+        clean_query, normalized_query, query_part
+    )
+    rows = await service._load_tipi_rows_for_code(cap_num, clean_query, view_mode)
+    if not rows:
+        return service._build_empty_tipi_code_search_response(ncm_query)
+
+    resultados = service._build_tipi_code_result_map(rows, posicao_alvo)
+    result: TipiCodeSearchPayload = {
+        "success": True,
+        "type": "code",
+        "query": ncm_query,
+        "results": resultados,
+        "resultados": resultados,
+        "total": len(rows),
+        "total_capitulos": len(resultados),
+    }
+    await service._write_tipi_code_search_cache(cache_key, result)
+    return result
+
+
+def _format_tipi_text_results(rows: list[dict[str, Any]]) -> list[TipiTextSearchItem]:
+    return [
+        {
+            "ncm": row["ncm"],
+            "capitulo": row.get("capitulo") or "",
+            "descricao": row["descricao"],
+            "aliquota": row.get("aliquota") or "0",
+        }
+        for row in rows
+    ]
+
+
+async def search_tipi_by_text_query(
+    service: "TipiService", query: str, limit: int = 50
+) -> TipiTextSearchPayload:
+    if service._use_repository:
+        async with service._acquire_tipi_repository() as repo:
+            if repo:
+                results = await repo.search_fulltext(query, limit)
+                return {
+                    "success": True,
+                    "type": "text",
+                    "query": query,
+                    "normalized": query,
+                    "match_type": "fts",
+                    "warning": None,
+                    "total": len(results),
+                    "results": _format_tipi_text_results(results),
+                }
+
+    conn = await service._acquire_tipi_connection()
+    try:
+        escaped_query = query.replace('"', '""')
+        fts_query = f'"{escaped_query}"'
+        cursor = await conn.execute(
+            """
+            SELECT ncm, capitulo, descricao, aliquota
+            FROM tipi_fts
+            WHERE tipi_fts MATCH ?
+            LIMIT ?
+            """,
+            (fts_query, limit),
+        )
+        rows = await cursor.fetchall()
+        results = [dict(row) for row in rows]
+
+        if len(results) < 5:
+            words = query.split()
+            if len(words) > 1:
+                quoted_tokens = ['"' + word.replace('"', '""') + '"' for word in words]
+                and_query = " AND ".join(quoted_tokens)
+                cursor = await conn.execute(
+                    """
+                    SELECT ncm, capitulo, descricao, aliquota
+                    FROM tipi_fts
+                    WHERE tipi_fts MATCH ?
+                    LIMIT ?
+                    """,
+                    (and_query, limit),
+                )
+                rows = await cursor.fetchall()
+                results = [dict(row) for row in rows]
+    finally:
+        await service._release_tipi_connection(conn)
+
+    return {
+        "success": True,
+        "type": "text",
+        "query": query,
+        "normalized": query,
+        "match_type": "fts",
+        "warning": None,
+        "total": len(results),
+        "results": _format_tipi_text_results(results),
+    }
+
+
+async def fetch_tipi_chapter_catalog(
+    service: "TipiService",
+) -> list[TipiChapterCatalogItem]:
+    if service._use_repository:
+        async with service._acquire_tipi_repository() as repo:
+            if repo:
+                return await repo.get_all_chapters()
+
+    conn = await service._acquire_tipi_connection()
+    try:
+        cursor = await conn.execute(
+            """
+            SELECT codigo, titulo, secao
+            FROM tipi_chapters
+            ORDER BY codigo
+            """
+        )
+        rows = await cursor.fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        await service._release_tipi_connection(conn)
+
+
+def snapshot_tipi_internal_cache_metrics(service: "TipiService") -> dict[str, Any]:
+    code_snapshot = service._code_search_cache_metrics.snapshot(
+        current_size=len(service._code_search_cache),
+        max_size=CacheConfig.TIPI_RESULT_CACHE_SIZE,
+    )
+    chapter_snapshot = service._chapter_positions_cache_metrics.snapshot(
+        current_size=len(service._chapter_positions_cache),
+        max_size=CacheConfig.TIPI_CHAPTER_CACHE_SIZE,
+    )
+    return {
+        "code_search_cache": {
+            "name": service._code_search_cache_metrics.name,
+            "hits": code_snapshot.hits,
+            "misses": code_snapshot.misses,
+            "sets": code_snapshot.sets,
+            "evictions": code_snapshot.evictions,
+            "served_gzip": code_snapshot.served_gzip,
+            "served_identity": code_snapshot.served_identity,
+            "current_size": code_snapshot.current_size,
+            "max_size": code_snapshot.max_size,
+            "hit_rate": code_snapshot.hit_rate,
+        },
+        "chapter_positions_cache": {
+            "name": service._chapter_positions_cache_metrics.name,
+            "hits": chapter_snapshot.hits,
+            "misses": chapter_snapshot.misses,
+            "sets": chapter_snapshot.sets,
+            "evictions": chapter_snapshot.evictions,
+            "served_gzip": chapter_snapshot.served_gzip,
+            "served_identity": chapter_snapshot.served_identity,
+            "current_size": chapter_snapshot.current_size,
+            "max_size": chapter_snapshot.max_size,
+            "hit_rate": chapter_snapshot.hit_rate,
+        },
+    }

--- a/backend/services/tipi/search.py
+++ b/backend/services/tipi/search.py
@@ -1,21 +1,17 @@
 from __future__ import annotations
 
-from collections import OrderedDict
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 from ...config.constants import CacheConfig
 from ...utils import ncm_utils
 from ...utils.id_utils import generate_anchor_id
-from ...utils.payload_cache_metrics import PayloadCacheMetrics
 from .types import (
     TipiChapterCatalogItem,
     TipiChapterResultsMap,
     TipiCodeCacheKey,
     TipiCodeChapterPayload,
     TipiCodeSearchPayload,
-    TipiPositionRow,
-    TipiRepositoryHealthPayload,
     TipiRowBatch,
     TipiTextSearchItem,
     TipiTextSearchPayload,
@@ -318,13 +314,28 @@ def build_tipi_code_result_map(
 async def search_tipi_by_ncm_code(
     service: "TipiService", ncm_query: str, view_mode: str = "family"
 ) -> TipiCodeSearchPayload:
-    cache_key = (ncm_query, view_mode)
+    parts = service._normalize_tipi_multi_code_parts(ncm_query)
+    query_part = parts[0] if parts else ""
+    normalized_query = ncm_utils.format_ncm_tipi(query_part)
+    clean_query = ncm_utils.clean_ncm(normalized_query)
+    if not clean_query:
+        return service._build_empty_tipi_code_search_response(ncm_query)
+
+    cache_view_mode = view_mode
+    should_share_short_query_cache = len(parts) == 1 and len(clean_query) <= 2
+    if should_share_short_query_cache:
+        cache_view_mode = "family"
+
+    cap_num = clean_query[:2].zfill(2)
+
+    cache_key = (ncm_query, cache_view_mode)
     cached = await service._read_tipi_code_search_cache(cache_key)
     if cached:
+        if should_share_short_query_cache:
+            await service._get_chapter_positions(cap_num)
         return cached
     service._code_search_cache_metrics.record_miss()
 
-    parts = service._normalize_tipi_multi_code_parts(ncm_query)
     if len(parts) > 1:
         result = await service._search_tipi_multi_code_parts(
             ncm_query, view_mode, parts
@@ -332,13 +343,6 @@ async def search_tipi_by_ncm_code(
         await service._write_tipi_code_search_cache(cache_key, result)
         return result
 
-    query_part = parts[0] if parts else ""
-    normalized_query = ncm_utils.format_ncm_tipi(query_part)
-    clean_query = ncm_utils.clean_ncm(normalized_query)
-    if not clean_query:
-        return service._build_empty_tipi_code_search_response(ncm_query)
-
-    cap_num = clean_query[:2].zfill(2)
     posicao_alvo = service._resolve_tipi_target_position(
         clean_query, normalized_query, query_part
     )

--- a/backend/services/tipi/types.py
+++ b/backend/services/tipi/types.py
@@ -1,4 +1,4 @@
-from typing import TypeAlias, TypedDict
+from typing import TypedDict
 
 
 class TipiPositionRow(TypedDict, total=False):
@@ -26,9 +26,9 @@ class TipiCodeChapterPayload(TypedDict):
     posicoes: list[TipiCodePositionPayload]
 
 
-TipiChapterResultsMap: TypeAlias = dict[str, TipiCodeChapterPayload]
-TipiRowBatch: TypeAlias = tuple[TipiPositionRow, ...]
-TipiCodeCacheKey: TypeAlias = tuple[str, str]
+type TipiChapterResultsMap = dict[str, TipiCodeChapterPayload]
+type TipiRowBatch = tuple[TipiPositionRow, ...]
+type TipiCodeCacheKey = tuple[str, str]
 
 
 class TipiCodeSearchPayload(TypedDict):
@@ -80,4 +80,4 @@ class TipiSqliteHealthPayload(TypedDict, total=False):
     error: str
 
 
-TipiHealthPayload: TypeAlias = TipiRepositoryHealthPayload | TipiSqliteHealthPayload
+type TipiHealthPayload = TipiRepositoryHealthPayload | TipiSqliteHealthPayload

--- a/backend/services/tipi/types.py
+++ b/backend/services/tipi/types.py
@@ -1,0 +1,83 @@
+from typing import TypeAlias, TypedDict
+
+
+class TipiPositionRow(TypedDict, total=False):
+    ncm: str
+    capitulo: str
+    descricao: str
+    aliquota: str | None
+    nivel: int
+
+
+class TipiCodePositionPayload(TypedDict):
+    ncm: str
+    codigo: str
+    descricao: str
+    aliquota: str
+    nivel: int
+    anchor_id: str
+
+
+class TipiCodeChapterPayload(TypedDict):
+    capitulo: str
+    titulo: str
+    notas_gerais: None
+    posicao_alvo: str | None
+    posicoes: list[TipiCodePositionPayload]
+
+
+TipiChapterResultsMap: TypeAlias = dict[str, TipiCodeChapterPayload]
+TipiRowBatch: TypeAlias = tuple[TipiPositionRow, ...]
+TipiCodeCacheKey: TypeAlias = tuple[str, str]
+
+
+class TipiCodeSearchPayload(TypedDict):
+    success: bool
+    type: str
+    query: str
+    results: TipiChapterResultsMap
+    resultados: TipiChapterResultsMap
+    total: int
+    total_capitulos: int
+
+
+class TipiTextSearchItem(TypedDict):
+    ncm: str
+    capitulo: str
+    descricao: str
+    aliquota: str
+
+
+class TipiTextSearchPayload(TypedDict):
+    success: bool
+    type: str
+    query: str
+    normalized: str
+    match_type: str
+    warning: None
+    total: int
+    results: list[TipiTextSearchItem]
+
+
+class TipiChapterCatalogItem(TypedDict):
+    codigo: str
+    titulo: str
+    secao: str
+
+
+class TipiRepositoryHealthPayload(TypedDict, total=False):
+    status: str
+    chapters: int
+    positions: int
+    metadata: dict[str, str]
+    error: str
+
+
+class TipiSqliteHealthPayload(TypedDict, total=False):
+    ok: bool
+    chapters: int
+    positions: int
+    error: str
+
+
+TipiHealthPayload: TypeAlias = TipiRepositoryHealthPayload | TipiSqliteHealthPayload

--- a/backend/services/tipi_service.py
+++ b/backend/services/tipi_service.py
@@ -80,7 +80,7 @@ class TipiService:
     - Connection pooling
     """
 
-    _tipi_connection_pools: dict[Path, list[aiosqlite.Connection]] = {}
+    _tipi_connection_pools: dict[tuple[Path, int], list[aiosqlite.Connection]] = {}
     _tipi_connection_pool_locks: dict[int, asyncio.Lock] = {}
     _tipi_connection_pool_locks_guard = threading.Lock()
     _tipi_connection_pool_max_size: int = 3
@@ -114,12 +114,12 @@ class TipiService:
         )
 
     @classmethod
-    async def initializeTipiServiceWithRepositoryFactory(cls) -> "TipiService":
+    def initializeTipiServiceWithRepositoryFactory(cls) -> "TipiService":
         """
-        Factory assíncrono para criar TipiService com TipiRepository.
+        Factory para criar TipiService com TipiRepository.
 
         Uso:
-            service = await TipiService.initializeTipiServiceWithRepositoryFactory()
+            service = TipiService.initializeTipiServiceWithRepositoryFactory()
             results = await service.searchTipiByTextQuery("bomba")
         """
         if not _REPO_AVAILABLE:
@@ -137,8 +137,8 @@ class TipiService:
         return cls(repository_factory=repo_factory)
 
     @classmethod
-    async def create_with_repository(cls) -> "TipiService":
-        return await cls.initializeTipiServiceWithRepositoryFactory()
+    def create_with_repository(cls) -> "TipiService":
+        return cls.initializeTipiServiceWithRepositoryFactory()
 
     def _get_cache_lock(self) -> asyncio.Lock:
         if self._cache_lock is None:
@@ -166,9 +166,13 @@ class TipiService:
                 cls._tipi_connection_pool_locks[loop_id] = lock
             return lock
 
+    def _get_tipi_connection_pool_key(self) -> tuple[Path, int]:
+        return self.db_path, id(asyncio.get_running_loop())
+
     async def _acquire_tipi_connection(self) -> aiosqlite.Connection:
+        pool_key = self._get_tipi_connection_pool_key()
         async with self._get_tipi_connection_pool_lock():
-            pool = self._tipi_connection_pools.setdefault(self.db_path, [])
+            pool = self._tipi_connection_pools.setdefault(pool_key, [])
             if pool:
                 return pool.pop()
 
@@ -181,8 +185,9 @@ class TipiService:
             raise DatabaseError(f"TIPI DB connection failed: {exc}") from exc
 
     async def _release_tipi_connection(self, conn: aiosqlite.Connection) -> None:
+        pool_key = self._get_tipi_connection_pool_key()
         async with self._get_tipi_connection_pool_lock():
-            pool = self._tipi_connection_pools.setdefault(self.db_path, [])
+            pool = self._tipi_connection_pools.setdefault(pool_key, [])
             if len(pool) < self._tipi_connection_pool_max_size:
                 pool.append(conn)
                 return
@@ -230,17 +235,27 @@ class TipiService:
             metrics.record_eviction()
 
     async def closeTipiConnectionPool(self) -> None:
+        pool_key = self._get_tipi_connection_pool_key()
         async with self._get_tipi_connection_pool_lock():
-            pool = self._tipi_connection_pools.pop(self.db_path, [])
+            pool = self._tipi_connection_pools.pop(pool_key, [])
         await self._close_tipi_pool_connections(pool)
 
     @classmethod
     async def closeAllTipiConnectionPools(cls) -> None:
+        current_loop_id = id(asyncio.get_running_loop())
         async with cls._get_tipi_connection_pool_lock():
-            pools = list(cls._tipi_connection_pools.values())
-            cls._tipi_connection_pools = {}
+            pools = [
+                pool
+                for pool_key, pool in cls._tipi_connection_pools.items()
+                if pool_key[1] == current_loop_id
+            ]
+            cls._tipi_connection_pools = {
+                pool_key: pool
+                for pool_key, pool in cls._tipi_connection_pools.items()
+                if pool_key[1] != current_loop_id
+            }
         with cls._tipi_connection_pool_locks_guard:
-            cls._tipi_connection_pool_locks.clear()
+            cls._tipi_connection_pool_locks.pop(current_loop_id, None)
         for pool in pools:
             await cls._close_tipi_pool_connections(pool)
 

--- a/backend/services/tipi_service.py
+++ b/backend/services/tipi_service.py
@@ -345,3 +345,7 @@ class TipiService:
     async def snapshotTipiInternalCacheMetrics(self):
         async with self._get_cache_lock():
             return snapshot_tipi_internal_cache_metrics(self)
+
+    async def get_internal_cache_metrics(self):
+        """Alias compatível com a API anterior do serviço."""
+        return await self.snapshotTipiInternalCacheMetrics()

--- a/backend/services/tipi_service.py
+++ b/backend/services/tipi_service.py
@@ -244,6 +244,11 @@ class TipiService:
     async def closeAllTipiConnectionPools(cls) -> None:
         current_loop_id = id(asyncio.get_running_loop())
         async with cls._get_tipi_connection_pool_lock():
+            leftover_counts = {
+                pool_key[1]: len(pool)
+                for pool_key, pool in cls._tipi_connection_pools.items()
+                if pool_key[1] != current_loop_id
+            }
             pools = [
                 pool
                 for pool_key, pool in cls._tipi_connection_pools.items()
@@ -256,6 +261,11 @@ class TipiService:
             }
         with cls._tipi_connection_pool_locks_guard:
             cls._tipi_connection_pool_locks.pop(current_loop_id, None)
+        if leftover_counts:
+            logger.warning(
+                "TIPI connection pools for other event loops were left open: %s",
+                leftover_counts,
+            )
         for pool in pools:
             await cls._close_tipi_pool_connections(pool)
 

--- a/backend/services/tipi_service.py
+++ b/backend/services/tipi_service.py
@@ -4,13 +4,16 @@ import asyncio
 from collections import OrderedDict
 from contextlib import asynccontextmanager
 from pathlib import Path
+import threading
 from typing import TYPE_CHECKING, AsyncIterator, Optional, cast
 
 import aiosqlite
 
 from ..config.exceptions import DatabaseError
+from ..config.constants import CacheConfig  # noqa: F401
 from ..config.logging_config import service_logger as logger
 from ..config.settings import settings
+from ..utils import ncm_utils  # noqa: F401
 from ..utils.payload_cache_metrics import PayloadCacheMetrics
 from .tipi.health import (
     probe_tipi_repository_catalog_health,
@@ -78,7 +81,8 @@ class TipiService:
     """
 
     _tipi_connection_pools: dict[Path, list[aiosqlite.Connection]] = {}
-    _tipi_connection_pool_lock: Optional[asyncio.Lock] = None
+    _tipi_connection_pool_locks: dict[int, asyncio.Lock] = {}
+    _tipi_connection_pool_locks_guard = threading.Lock()
     _tipi_connection_pool_max_size: int = 3
 
     def __init__(
@@ -154,9 +158,13 @@ class TipiService:
 
     @classmethod
     def _get_tipi_connection_pool_lock(cls) -> asyncio.Lock:
-        if cls._tipi_connection_pool_lock is None:
-            cls._tipi_connection_pool_lock = asyncio.Lock()
-        return cls._tipi_connection_pool_lock
+        loop_id = id(asyncio.get_running_loop())
+        with cls._tipi_connection_pool_locks_guard:
+            lock = cls._tipi_connection_pool_locks.get(loop_id)
+            if lock is None:
+                lock = asyncio.Lock()
+                cls._tipi_connection_pool_locks[loop_id] = lock
+            return lock
 
     async def _acquire_tipi_connection(self) -> aiosqlite.Connection:
         async with self._get_tipi_connection_pool_lock():
@@ -170,7 +178,7 @@ class TipiService:
             return conn
         except Exception as exc:
             logger.error("Failed to connect to TIPI DB: %s", exc)
-            raise DatabaseError(f"TIPI DB connection failed: {exc}")
+            raise DatabaseError(f"TIPI DB connection failed: {exc}") from exc
 
     async def _release_tipi_connection(self, conn: aiosqlite.Connection) -> None:
         async with self._get_tipi_connection_pool_lock():
@@ -231,6 +239,8 @@ class TipiService:
         async with cls._get_tipi_connection_pool_lock():
             pools = list(cls._tipi_connection_pools.values())
             cls._tipi_connection_pools = {}
+        with cls._tipi_connection_pool_locks_guard:
+            cls._tipi_connection_pool_locks.clear()
         for pool in pools:
             await cls._close_tipi_pool_connections(pool)
 

--- a/backend/services/tipi_service.py
+++ b/backend/services/tipi_service.py
@@ -1,39 +1,57 @@
-"""src.services.tipi_service
-
-Serviço de busca na TIPI (Tabela de Incidência do IPI).
-Similar ao NeshService, mas usando o banco tipi.db.
-
-Observações de contrato (importante para o frontend):
-- Respostas de busca por código sempre incluem: query, results/resultados, total, total_capitulos.
-- Estrutura de capítulos/posições é compatível com a navegação do app (posicoes[].codigo).
-"""
+"""Serviço de busca na TIPI (Tabela de Incidência do IPI)."""
 
 import asyncio
 from collections import OrderedDict
 from contextlib import asynccontextmanager
-from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, AsyncIterator, Optional, cast
 
 import aiosqlite
-from sqlalchemy import text
 
 from ..config.constants import CacheConfig
 from ..config.exceptions import DatabaseError
 from ..config.logging_config import service_logger as logger
 from ..config.settings import settings
 from ..utils import ncm_utils
-from ..utils.id_utils import generate_anchor_id
 from ..utils.payload_cache_metrics import PayloadCacheMetrics
+from .tipi.health import (
+    probe_tipi_repository_catalog_health,
+    probe_tipi_sqlite_catalog_health,
+)
+from .tipi.search import (
+    build_empty_tipi_code_search_response,
+    build_tipi_code_result_map,
+    clone_tipi_code_search_result,
+    fetch_tipi_chapter_catalog,
+    get_chapter_positions,
+    get_family_positions,
+    load_tipi_rows_for_code,
+    merge_tipi_multi_code_part_payloads,
+    normalize_tipi_multi_code_parts,
+    prefer_more_specific_tipi_posicao_alvo,
+    read_tipi_code_search_cache,
+    resolve_tipi_chapter_target_position,
+    resolve_tipi_target_position,
+    search_tipi_by_ncm_code,
+    search_tipi_by_text_query,
+    search_tipi_multi_code_parts,
+    snapshot_tipi_internal_cache_metrics,
+    write_tipi_code_search_cache,
+)
+from .tipi.types import (
+    TipiChapterCatalogItem,
+    TipiCodeCacheKey,
+    TipiCodeSearchPayload,
+    TipiHealthPayload,
+    TipiRowBatch,
+    TipiTextSearchPayload,
+)
 
-# Caminho do banco de dados TIPI
-TIPI_DB_PATH = Path(__file__).parent.parent.parent / "database" / "tipi.db"
 TIPI_SORT_WITH_NCM = "ncm_sort, ncm"
 TIPI_SORT_FALLBACK = "ncm"
 TIPI_ALLOWED_TABLES = {"tipi_positions", "tipi_chapters", "tipi_fts"}
 TIPI_MULTI_CODE_MAX_PARTS = 25
 
-# SQLModel Repository imports (optional - for new code paths)
 get_session = None
 try:
     from ..infrastructure.db_engine import get_session
@@ -58,14 +76,12 @@ class TipiService:
     - Busca por código NCM
     - Busca textual (FTS5)
     - Cache em memória
-    - Destaque de alíquotas
     - Connection pooling
     """
 
-    # Pool compartilhado por caminho resolvido do banco.
-    _pool: Dict[Path, List[aiosqlite.Connection]] = {}
-    _pool_lock: Optional[asyncio.Lock] = None
-    _pool_max_size: int = 3
+    _tipi_connection_pools: dict[Path, list[aiosqlite.Connection]] = {}
+    _tipi_connection_pool_lock: Optional[asyncio.Lock] = None
+    _tipi_connection_pool_max_size: int = 3
 
     def __init__(
         self,
@@ -74,45 +90,35 @@ class TipiService:
         repository: "_TipiRepo | None" = None,
         repository_factory=None,
     ):
-        """
-        Inicializa o serviço com pool aiosqlite ou repository.
-
-        Args:
-            db_path: Caminho do banco SQLite (legado)
-            repository: TipiRepository para novo padrão SQLModel
-            repository_factory: Factory async context manager para criar repos sob demanda
-        """
         self.db_path = (db_path or Path(settings.database.tipi_path)).resolve()
-        self._schema_columns_cache: Dict[str, set[str]] = {}
+        self._schema_columns_cache: dict[str, set[str]] = {}
         self._repository = repository
         self._repository_factory = repository_factory
         self._use_repository = repository is not None or repository_factory is not None
 
-        # Performance: LRU caches for search results
-        self._code_search_cache: OrderedDict = (
-            OrderedDict()
-        )  # key: (ncm_query, view_mode) -> result
-        self._chapter_positions_cache: OrderedDict = (
-            OrderedDict()
-        )  # key: chapter_num -> positions
+        self._code_search_cache: OrderedDict[
+            TipiCodeCacheKey, TipiCodeSearchPayload
+        ] = OrderedDict()
+        self._chapter_positions_cache: OrderedDict[str, TipiRowBatch] = OrderedDict()
         self._code_search_cache_metrics = PayloadCacheMetrics("tipi_code_search_cache")
         self._chapter_positions_cache_metrics = PayloadCacheMetrics(
             "tipi_chapter_positions_cache"
         )
-        self._cache_lock: Optional[asyncio.Lock] = None  # Lazy init
+        self._cache_lock: Optional[asyncio.Lock] = None
 
-        self.mode = "Repository" if self._use_repository else "aiosqlite"
-        logger.info(f"TipiService inicializado (modo: {self.mode})")
+        logger.info(
+            "TipiService inicializado (modo: %s)",
+            "Repository" if self._use_repository else "aiosqlite",
+        )
 
     @classmethod
-    async def create_with_repository(cls) -> "TipiService":
+    async def initializeTipiServiceWithRepositoryFactory(cls) -> "TipiService":
         """
         Factory assíncrono para criar TipiService com TipiRepository.
-        Usa factory pattern para criar repos sob demanda (cada chamada tem sua session).
 
         Uso:
-            service = await TipiService.create_with_repository()
-            results = await service.search_text("bomba")
+            service = await TipiService.initializeTipiServiceWithRepositoryFactory()
+            results = await service.searchTipiByTextQuery("bomba")
         """
         if not _REPO_AVAILABLE:
             raise RuntimeError("Repository não disponível. Instale sqlmodel.")
@@ -128,15 +134,17 @@ class TipiService:
 
         return cls(repository_factory=repo_factory)
 
+    @classmethod
+    async def create_with_repository(cls) -> "TipiService":
+        return await cls.initializeTipiServiceWithRepositoryFactory()
+
     def _get_cache_lock(self) -> asyncio.Lock:
-        """Lazy initialization do lock para evitar criação fora do event loop."""
         if self._cache_lock is None:
             self._cache_lock = asyncio.Lock()
         return self._cache_lock
 
     @asynccontextmanager
-    async def _get_repo(self) -> AsyncIterator["_TipiRepo | None"]:
-        """Get repository via direct instance or factory."""
+    async def _acquire_tipi_repository(self) -> AsyncIterator["_TipiRepo | None"]:
         if self._repository is not None:
             yield self._repository
             return
@@ -147,44 +155,39 @@ class TipiService:
         yield None
 
     @classmethod
-    def _get_pool_lock(cls) -> asyncio.Lock:
-        """Lazy initialization do lock."""
-        if cls._pool_lock is None:
-            cls._pool_lock = asyncio.Lock()
-        return cls._pool_lock
+    def _get_tipi_connection_pool_lock(cls) -> asyncio.Lock:
+        if cls._tipi_connection_pool_lock is None:
+            cls._tipi_connection_pool_lock = asyncio.Lock()
+        return cls._tipi_connection_pool_lock
 
-    async def _get_connection(self) -> aiosqlite.Connection:
-        """Obtém conexão do pool ou cria nova."""
-        async with self._get_pool_lock():
-            pool = self._pool.setdefault(self.db_path, [])
+    async def _acquire_tipi_connection(self) -> aiosqlite.Connection:
+        async with self._get_tipi_connection_pool_lock():
+            pool = self._tipi_connection_pools.setdefault(self.db_path, [])
             if pool:
-                conn = pool.pop()
-                return conn
+                return pool.pop()
 
         try:
             conn = await aiosqlite.connect(self.db_path)
             conn.row_factory = aiosqlite.Row
             return conn
-        except Exception as e:
-            logger.error(f"Failed to connect to TIPI DB: {e}")
-            raise DatabaseError(f"TIPI DB connection failed: {e}")
+        except Exception as exc:
+            logger.error("Failed to connect to TIPI DB: %s", exc)
+            raise DatabaseError(f"TIPI DB connection failed: {exc}")
 
-    async def _release_connection(self, conn: aiosqlite.Connection) -> None:
-        """Devolve conexão ao pool."""
-        async with self._get_pool_lock():
-            pool = self._pool.setdefault(self.db_path, [])
-            if len(pool) < self._pool_max_size:
+    async def _release_tipi_connection(self, conn: aiosqlite.Connection) -> None:
+        async with self._get_tipi_connection_pool_lock():
+            pool = self._tipi_connection_pools.setdefault(self.db_path, [])
+            if len(pool) < self._tipi_connection_pool_max_size:
                 pool.append(conn)
-            else:
-                try:
-                    await conn.close()
-                except Exception as e:
-                    logger.warning(f"Error closing TIPI connection: {e}")
+                return
+        try:
+            await conn.close()
+        except Exception as exc:
+            logger.warning("Error closing TIPI connection: %s", exc)
 
-    async def _get_table_columns(
+    async def _load_tipi_table_columns(
         self, conn: aiosqlite.Connection, table: str
     ) -> set[str]:
-        """Return a cached set of column names for a table."""
         if table not in TIPI_ALLOWED_TABLES:
             raise ValueError(f"Tabela não permitida para inspeção de schema: {table}")
         if table in self._schema_columns_cache:
@@ -196,587 +199,149 @@ class TipiService:
         self._schema_columns_cache[table] = cols
         return cols
 
-    def _get_order_by(self, cols: set[str]) -> str:
-        """Resolve ORDER BY com base no schema disponível."""
+    def _resolve_tipi_order_by_clause(self, cols: set[str]) -> str:
         return TIPI_SORT_WITH_NCM if "ncm_sort" in cols else TIPI_SORT_FALLBACK
 
     @staticmethod
-    async def _close_pool_connections(connections: List[aiosqlite.Connection]) -> None:
+    async def _close_tipi_pool_connections(
+        connections: list[aiosqlite.Connection],
+    ) -> None:
         for conn in connections:
             try:
                 await conn.close()
-            except Exception as e:
-                logger.warning(f"Error closing TIPI pool connection: {e}")
+            except Exception as exc:
+                logger.warning("Error closing TIPI pool connection: %s", exc)
 
     @staticmethod
-    def _enforce_cache_limit(
-        cache: OrderedDict[Any, Any],
+    def _trim_tipi_lru_cache_to_limit(
+        cache: OrderedDict,
         max_size: int,
         metrics: PayloadCacheMetrics,
     ) -> None:
-        """Evict oldest entries until cache reaches max_size."""
         limit = max(max_size, 0)
         while len(cache) > limit:
             cache.popitem(last=False)
             metrics.record_eviction()
 
+    async def closeTipiConnectionPool(self) -> None:
+        async with self._get_tipi_connection_pool_lock():
+            pool = self._tipi_connection_pools.pop(self.db_path, [])
+        await self._close_tipi_pool_connections(pool)
+
+    @classmethod
+    async def closeAllTipiConnectionPools(cls) -> None:
+        async with cls._get_tipi_connection_pool_lock():
+            pools = list(cls._tipi_connection_pools.values())
+            cls._tipi_connection_pools = {}
+        for pool in pools:
+            await cls._close_tipi_pool_connections(pool)
+
     async def close(self):
-        """Fecha todas as conexões do pool."""
-        async with self._get_pool_lock():
-            pool = self._pool.pop(self.db_path, [])
-        await self._close_pool_connections(pool)
+        return await self.closeTipiConnectionPool()
 
     @classmethod
     async def close_all_pools(cls):
-        """Fecha todas as conexões em todos os pools TIPI conhecidos."""
-        async with cls._get_pool_lock():
-            pools = list(cls._pool.values())
-            cls._pool = {}
+        return await cls.closeAllTipiConnectionPools()
 
-        for pool in pools:
-            await cls._close_pool_connections(pool)
-
-    async def check_connection(self) -> Dict[str, Any]:
-        """Verifica status do banco TIPI."""
+    async def probeTipiCatalogHealth(self) -> TipiHealthPayload:
         if self._use_repository:
-            try:
-                async with self._get_repo() as repo:
-                    if repo is None:
-                        raise RuntimeError("TIPI repository unavailable")
+            return await self._probe_tipi_repository_catalog_health()
+        return await self._probe_tipi_sqlite_catalog_health()
 
-                    chapters_result = await repo.session.execute(
-                        text("SELECT COUNT(DISTINCT chapter_num) FROM tipi_positions")
-                    )
-                    positions_result = await repo.session.execute(
-                        text("SELECT COUNT(*) FROM tipi_positions")
-                    )
-                    metadata_result = await repo.session.execute(
-                        text(
-                            """
-                            SELECT key, value
-                            FROM catalog_metadata
-                            WHERE key LIKE 'tipi_%'
-                            ORDER BY key
-                            """
-                        )
-                    )
+    async def check_connection(self) -> TipiHealthPayload:
+        return await self.probeTipiCatalogHealth()
 
-                chapters = int(chapters_result.scalar() or 0)
-                positions = int(positions_result.scalar() or 0)
-                metadata = {row.key: row.value for row in metadata_result}
-                return {
-                    "status": "online" if chapters > 0 and positions > 0 else "error",
-                    "chapters": chapters,
-                    "positions": positions,
-                    "metadata": metadata,
-                }
-            except Exception as e:
-                logger.error(f"TIPI repository healthcheck failed: {e}")
-                return {"status": "error", "error": str(e)}
+    async def _probe_tipi_repository_catalog_health(self) -> TipiHealthPayload:
+        return await probe_tipi_repository_catalog_health(self)
 
-        if not self.db_path.exists():
-            # We return a status dict here because often this is used for diagnostic
-            # but raising DatabaseError is also fine if caught by the status endpoint.
-            # However, status endpoint usually wants to show "error" rather than 503.
-            # Let's keep returning dict but logging errors.
-            return {"ok": False, "error": f"Banco TIPI não encontrado: {self.db_path}"}
+    async def _probe_tipi_sqlite_catalog_health(self) -> TipiHealthPayload:
+        return await probe_tipi_sqlite_catalog_health(self)
 
-        try:
-            conn = await self._get_connection()
-            try:
-                cursor = await conn.execute("SELECT COUNT(*) FROM tipi_chapters")
-                chapters_row = await cursor.fetchone()
-                chapters = chapters_row[0] if chapters_row else 0
+    def _build_empty_tipi_code_search_response(
+        self, query: str
+    ) -> TipiCodeSearchPayload:
+        return build_empty_tipi_code_search_response(query)
 
-                cursor = await conn.execute("SELECT COUNT(*) FROM tipi_positions")
-                positions_row = await cursor.fetchone()
-                positions = positions_row[0] if positions_row else 0
-
-                return {"ok": True, "chapters": chapters, "positions": positions}
-            finally:
-                await self._release_connection(conn)
-        except Exception as e:
-            logger.error(f"TIPI Check Connection failed: {e}")
-            return {"ok": False, "error": str(e)}
-
-    def _empty_code_response(self, query: str) -> Dict[str, Any]:
-        return {
-            "success": True,
-            "type": "code",
-            "query": query,
-            "results": {},
-            "resultados": {},
-            "total": 0,
-            "total_capitulos": 0,
-        }
-
-    def is_code_query(self, query: str) -> bool:
-        """Helper to detect if query is NCM code."""
-        return ncm_utils.is_code_query(query)
-
-    async def _get_chapter_positions(self, cap_num: str) -> Tuple[Dict[str, Any], ...]:
-        """
-        Fetch positions for a chapter.
-        Performance: Uses LRU cache for full chapter positions.
-        """
-        # Performance: Check chapter cache
-        async with self._get_cache_lock():
-            if cap_num in self._chapter_positions_cache:
-                self._chapter_positions_cache.move_to_end(cap_num)
-                self._chapter_positions_cache_metrics.record_hit()
-                return self._chapter_positions_cache[cap_num]
-        self._chapter_positions_cache_metrics.record_miss()
-
-        if self._use_repository:
-            async with self._get_repo() as repo:
-                if repo:
-                    rows_list = await repo.get_by_chapter(cap_num)
-                    # Normalize keys to match legacy format
-                    rows = tuple(
-                        {
-                            **r,
-                            "capitulo": r.get("capitulo", cap_num),
-                            "nivel": r.get("nivel", 0),
-                        }
-                        for r in rows_list
-                    )
-                    # Cache result
-                    async with self._get_cache_lock():
-                        self._chapter_positions_cache[cap_num] = rows
-                        self._chapter_positions_cache_metrics.record_set()
-                        self._enforce_cache_limit(
-                            self._chapter_positions_cache,
-                            CacheConfig.TIPI_CHAPTER_CACHE_SIZE,
-                            self._chapter_positions_cache_metrics,
-                        )
-                    return rows
-
-        conn = await self._get_connection()
-        try:
-            cols = await self._get_table_columns(conn, "tipi_positions")
-            order_by = self._get_order_by(cols)
-            sql = f"""
-                SELECT ncm, capitulo, descricao, aliquota, nivel
-                FROM tipi_positions
-                WHERE capitulo = ?
-                ORDER BY {order_by}
-                """  # nosec B608
-            cursor = await conn.execute(sql, (cap_num,))
-            rows = await cursor.fetchall()
-            result = tuple(dict(row) for row in rows)
-
-            # Cache result
-            async with self._get_cache_lock():
-                self._chapter_positions_cache[cap_num] = result
-                self._chapter_positions_cache_metrics.record_set()
-                self._enforce_cache_limit(
-                    self._chapter_positions_cache,
-                    CacheConfig.TIPI_CHAPTER_CACHE_SIZE,
-                    self._chapter_positions_cache_metrics,
-                )
-            return result
-        finally:
-            await self._release_connection(conn)
+    async def _get_chapter_positions(self, cap_num: str) -> TipiRowBatch:
+        return await get_chapter_positions(self, cap_num)
 
     async def _get_family_positions(
-        self, cap_num: str, prefix: str, ancestor_prefixes: set
-    ) -> Tuple[Dict[str, Any], ...]:
-        """
-        Fetch positions filtradas por família NCM (otimizado em SQL).
+        self, cap_num: str, prefix: str, ancestor_prefixes: set[str]
+    ) -> TipiRowBatch:
+        return await get_family_positions(self, cap_num, prefix, ancestor_prefixes)
 
-        Args:
-            cap_num: Número do capítulo (2 dígitos)
-            prefix: Prefixo NCM para filtrar descendentes (ex: "8413")
-            ancestor_prefixes: Set de prefixos ancestrais (ex: {"8413", "841391"})
-        """
-        if self._use_repository:
-            async with self._get_repo() as repo:
-                if repo:
-                    rows_list = await repo.get_family_positions(
-                        cap_num, prefix, ancestor_prefixes
-                    )
-                    return tuple(
-                        {
-                            **r,
-                            "capitulo": r.get("capitulo", cap_num),
-                            "nivel": r.get("nivel", 0),
-                        }
-                        for r in rows_list
-                    )
-
-        conn = await self._get_connection()
-        try:
-            cols = await self._get_table_columns(conn, "tipi_positions")
-            order_by = self._get_order_by(cols)
-
-            conditions = ["REPLACE(ncm, '.', '') LIKE ? || '%'"]
-            params = [prefix]
-
-            for ancestor in ancestor_prefixes:
-                conditions.append("REPLACE(ncm, '.', '') = ?")
-                params.append(ancestor)
-
-            where_clause = " OR ".join(conditions)
-            sql = f"""
-                SELECT ncm, capitulo, descricao, aliquota, nivel
-                FROM tipi_positions
-                WHERE capitulo = ? AND ({where_clause})
-                ORDER BY {order_by}
-                """  # nosec B608
-            cursor = await conn.execute(sql, (cap_num, *params))
-            rows = await cursor.fetchall()
-            return tuple(dict(row) for row in rows)
-        finally:
-            await self._release_connection(conn)
-
-    async def _get_cached_code_result(
-        self, cache_key: Tuple[str, str]
-    ) -> Optional[Dict[str, Any]]:
-        cached: Optional[Dict[str, Any]]
-        async with self._get_cache_lock():
-            cached = self._code_search_cache.get(cache_key)
-            if not cached:
-                return None
-            self._code_search_cache.move_to_end(cache_key)
-            self._code_search_cache_metrics.record_hit()
-        return self._clone_code_search_result(cached)
+    async def _read_tipi_code_search_cache(
+        self, cache_key: TipiCodeCacheKey
+    ) -> TipiCodeSearchPayload | None:
+        return await read_tipi_code_search_cache(self, cache_key)
 
     @staticmethod
-    def _clone_code_search_result(result: Dict[str, Any]) -> Dict[str, Any]:
-        return deepcopy(result)
+    def _clone_tipi_code_search_result(
+        result: TipiCodeSearchPayload,
+    ) -> TipiCodeSearchPayload:
+        return clone_tipi_code_search_result(result)
 
-    async def _store_cached_code_result(
-        self, cache_key: Tuple[str, str], result: Dict[str, Any]
+    async def _write_tipi_code_search_cache(
+        self, cache_key: TipiCodeCacheKey, result: TipiCodeSearchPayload
     ) -> None:
-        cloned_result = self._clone_code_search_result(result)
-        async with self._get_cache_lock():
-            self._code_search_cache[cache_key] = cloned_result
-            self._code_search_cache_metrics.record_set()
-            self._enforce_cache_limit(
-                self._code_search_cache,
-                CacheConfig.TIPI_RESULT_CACHE_SIZE,
-                self._code_search_cache_metrics,
-            )
+        await write_tipi_code_search_cache(self, cache_key, result)
 
     @staticmethod
-    def _normalize_multi_code_parts(ncm_query: str) -> List[str]:
-        normalized_parts: List[str] = []
-        seen_parts: set[str] = set()
-        for raw_part in ncm_utils.split_ncm_query(ncm_query):
-            normalized_part = ncm_utils.clean_ncm(raw_part)
-            if not normalized_part or normalized_part in seen_parts:
-                continue
-            normalized_parts.append(normalized_part)
-            seen_parts.add(normalized_part)
-            if len(normalized_parts) >= TIPI_MULTI_CODE_MAX_PARTS:
-                break
-        return normalized_parts
+    def _normalize_tipi_multi_code_parts(ncm_query: str) -> list[str]:
+        return normalize_tipi_multi_code_parts(
+            ncm_query, max_parts=TIPI_MULTI_CODE_MAX_PARTS
+        )
 
     @staticmethod
-    def _prefer_more_specific_posicao_alvo(
-        current: Optional[str], incoming: Optional[str]
-    ) -> Optional[str]:
-        if not incoming:
-            return current
-        if not current:
-            return incoming
-
-        current_clean = ncm_utils.clean_ncm(current)
-        incoming_clean = ncm_utils.clean_ncm(incoming)
-        if len(incoming_clean) > len(current_clean):
-            return incoming
-        return current
+    def _prefer_more_specific_tipi_posicao_alvo(
+        current: str | None, incoming: str | None
+    ) -> str | None:
+        return prefer_more_specific_tipi_posicao_alvo(current, incoming)
 
     @staticmethod
-    def _merge_part_payload_into_chapters(
-        merged: Dict[str, Any], part_resp: Dict[str, Any]
+    def _merge_tipi_multi_code_part_payloads(
+        merged, part_resp: TipiCodeSearchPayload
     ) -> None:
-        source = part_resp.get("resultados") or part_resp.get("results") or {}
-        for cap, cap_data in source.items():
-            if cap not in merged:
-                merged[cap] = {**cap_data, "posicoes": []}
-            merged[cap]["posicao_alvo"] = (
-                TipiService._prefer_more_specific_posicao_alvo(
-                    merged[cap].get("posicao_alvo"),
-                    cap_data.get("posicao_alvo"),
-                )
-            )
-            merged[cap].setdefault("posicoes", [])
-            seen_ncms = {pos.get("ncm") for pos in merged[cap]["posicoes"]}
-            for posicao in cap_data.get("posicoes", []) or []:
-                ncm = posicao.get("ncm")
-                if ncm in seen_ncms:
-                    continue
-                merged[cap]["posicoes"].append(posicao)
-                seen_ncms.add(ncm)
+        merge_tipi_multi_code_part_payloads(merged, part_resp)
 
-    async def _search_multiple_codes(
-        self, ncm_query: str, view_mode: str, parts: List[str]
-    ) -> Dict[str, Any]:
-        merged: Dict[str, Any] = {}
-        for part in parts:
-            part_resp = await self.search_by_code(part, view_mode=view_mode)
-            self._merge_part_payload_into_chapters(merged, part_resp)
-        total_rows = sum(len((cap.get("posicoes") or [])) for cap in merged.values())
-        return {
-            "success": True,
-            "type": "code",
-            "query": ncm_query,
-            "results": merged,
-            "resultados": merged,
-            "total": total_rows,
-            "total_capitulos": len(merged),
-        }
+    async def _search_tipi_multi_code_parts(
+        self, ncm_query: str, view_mode: str, parts: list[str]
+    ) -> TipiCodeSearchPayload:
+        return await search_tipi_multi_code_parts(self, ncm_query, view_mode, parts)
 
-    @staticmethod
-    def _build_ancestor_prefixes(prefix: str) -> set[str]:
-        ancestor_prefixes = set()
-        if len(prefix) >= 4:
-            ancestor_prefixes.add(prefix[:4])
-        if len(prefix) >= 6:
-            ancestor_prefixes.add(prefix[:6])
-        return ancestor_prefixes
-
-    async def _load_rows_for_code(
+    async def _load_tipi_rows_for_code(
         self, cap_num: str, clean_query: str, view_mode: str
-    ) -> Tuple[Dict[str, Any], ...]:
-        if view_mode != "family" or len(clean_query) <= 2:
-            return await self._get_chapter_positions(cap_num)
-        return await self._get_family_positions(
-            cap_num,
-            clean_query,
-            self._build_ancestor_prefixes(clean_query),
-        )
+    ) -> TipiRowBatch:
+        return await load_tipi_rows_for_code(self, cap_num, clean_query, view_mode)
 
     @staticmethod
-    def _resolve_posicao_alvo(
+    def _resolve_tipi_target_position(
         clean_query: str, normalized_query: str, query_part: str
-    ) -> Optional[str]:
-        if len(clean_query) <= 2:
-            return None
-        return (normalized_query or "").strip() or query_part.strip()
+    ) -> str | None:
+        return resolve_tipi_target_position(clean_query, normalized_query, query_part)
 
     @staticmethod
-    def _resolve_cap_posicao_alvo(
-        capitulo: str, posicao_alvo: Optional[str]
-    ) -> Optional[str]:
-        if not posicao_alvo:
-            return None
-        clean_alvo = ncm_utils.clean_ncm(posicao_alvo)
-        return posicao_alvo if clean_alvo.startswith(capitulo) else None
+    def _resolve_tipi_chapter_target_position(
+        capitulo: str, posicao_alvo: str | None
+    ) -> str | None:
+        return resolve_tipi_chapter_target_position(capitulo, posicao_alvo)
 
-    def _build_code_resultados(
-        self, rows: Tuple[Dict[str, Any], ...], posicao_alvo: Optional[str]
-    ) -> Dict[str, Any]:
-        resultados: Dict[str, Any] = {}
-        for row in rows:
-            cap = row["capitulo"]
-            if cap not in resultados:
-                resultados[cap] = {
-                    "capitulo": cap,
-                    "titulo": f"Capítulo {cap}",
-                    "notas_gerais": None,
-                    "posicao_alvo": self._resolve_cap_posicao_alvo(cap, posicao_alvo),
-                    "posicoes": [],
-                }
+    def _build_tipi_code_result_map(self, rows: TipiRowBatch, posicao_alvo: str | None):
+        return build_tipi_code_result_map(rows, posicao_alvo)
 
-            codigo = row["ncm"]
-            resultados[cap]["posicoes"].append(
-                {
-                    "ncm": codigo,
-                    "codigo": codigo,
-                    "descricao": row["descricao"],
-                    "aliquota": row["aliquota"] or "0",
-                    "nivel": row["nivel"],
-                    "anchor_id": generate_anchor_id(codigo),
-                }
-            )
-        return resultados
-
-    async def search_by_code(
+    async def searchTipiByNcmCode(
         self, ncm_query: str, view_mode: str = "family"
-    ) -> Dict[str, Any]:
-        """
-        Busca por código NCM na TIPI (Async).
-        Performance: Cacheia resultados por (query, view_mode) com LRU.
+    ) -> TipiCodeSearchPayload:
+        return await search_tipi_by_ncm_code(self, ncm_query, view_mode=view_mode)
 
-        Args:
-            ncm_query: Código NCM (ex: "85.17" ou "8517")
-            view_mode: 'family' (retorna apenas família NCM) ou 'chapter' (capítulo completo)
-        """
-        cache_key = (ncm_query, view_mode)
-        cached = await self._get_cached_code_result(cache_key)
-        if cached:
-            return cached
-        self._code_search_cache_metrics.record_miss()
+    async def searchTipiByTextQuery(
+        self, query: str, limit: int = 50
+    ) -> TipiTextSearchPayload:
+        return await search_tipi_by_text_query(self, query, limit=limit)
 
-        parts = self._normalize_multi_code_parts(ncm_query)
-        if len(parts) > 1:
-            result = await self._search_multiple_codes(ncm_query, view_mode, parts)
-            await self._store_cached_code_result(cache_key, result)
-            return result
+    async def fetchTipiChapterCatalog(self) -> list[TipiChapterCatalogItem]:
+        return await fetch_tipi_chapter_catalog(self)
 
-        query_part = parts[0] if parts else ""
-        normalized_query = ncm_utils.format_ncm_tipi(query_part)
-        clean_query = ncm_utils.clean_ncm(normalized_query)
-        if not clean_query:
-            return self._empty_code_response(ncm_query)
-
-        cap_num = clean_query[:2].zfill(2)
-        posicao_alvo = self._resolve_posicao_alvo(
-            clean_query, normalized_query, query_part
-        )
-        rows = await self._load_rows_for_code(cap_num, clean_query, view_mode)
-        if not rows:
-            return self._empty_code_response(ncm_query)
-
-        resultados = self._build_code_resultados(rows, posicao_alvo)
-        result = {
-            "success": True,
-            "type": "code",
-            "query": ncm_query,
-            "results": resultados,
-            "resultados": resultados,
-            "total": len(rows),
-            "total_capitulos": len(resultados),
-        }
-        await self._store_cached_code_result(cache_key, result)
-        return result
-
-    async def search_text(self, query: str, limit: int = 50) -> Dict[str, Any]:
-        """
-        Busca textual via FTS5/tsvector (Async).
-        """
-        if self._use_repository:
-            async with self._get_repo() as repo:
-                if repo:
-                    results = await repo.search_fulltext(query, limit)
-                    return {
-                        "success": True,
-                        "type": "text",
-                        "query": query,
-                        "normalized": query,
-                        "match_type": "fts",
-                        "warning": None,
-                        "total": len(results),
-                        "results": results,
-                    }
-
-        conn = await self._get_connection()
-        try:
-            # Busca FTS
-            escaped_query = query.replace('"', '""')
-            fts_query = f'"{escaped_query}"'  # Busca exata primeiro
-            cursor = await conn.execute(
-                """
-                SELECT ncm, capitulo, descricao, aliquota
-                FROM tipi_fts
-                WHERE tipi_fts MATCH ?
-                LIMIT ?
-            """,
-                (fts_query, limit),
-            )
-
-            rows = await cursor.fetchall()
-            results = [dict(row) for row in rows]
-
-            # Se poucos resultados, tentar busca mais flexível
-            if len(results) < 5:
-                words = query.split()
-                if len(words) > 1:
-                    quoted_tokens = [
-                        '"' + word.replace('"', '""') + '"' for word in words
-                    ]
-                    and_query = " AND ".join(quoted_tokens)
-                    cursor = await conn.execute(
-                        """
-                        SELECT ncm, capitulo, descricao, aliquota
-                        FROM tipi_fts
-                        WHERE tipi_fts MATCH ?
-                        LIMIT ?
-                    """,
-                        (and_query, limit),
-                    )
-                    rows = await cursor.fetchall()
-                    results = [dict(row) for row in rows]
-        finally:
-            await self._release_connection(conn)
-
-        return {
-            "success": True,
-            "type": "text",
-            "query": query,
-            "normalized": query,
-            "match_type": "fts",
-            "warning": None,
-            "total": len(results),
-            "results": [
-                {
-                    "ncm": r["ncm"],
-                    "capitulo": r["capitulo"],
-                    "descricao": r["descricao"],
-                    "aliquota": r["aliquota"] or "0",
-                }
-                for r in results
-            ],
-        }
-
-    async def get_all_chapters(self) -> List[Dict[str, str]]:
-        """Retorna lista de todos os capítulos (Async)."""
-        if self._use_repository:
-            async with self._get_repo() as repo:
-                if repo:
-                    return await repo.get_all_chapters()
-
-        conn = await self._get_connection()
-        try:
-            cursor = await conn.execute("""
-                SELECT codigo, titulo, secao
-                FROM tipi_chapters
-                ORDER BY codigo
-            """)
-            rows = await cursor.fetchall()
-            return [dict(row) for row in rows]
-        finally:
-            await self._release_connection(conn)
-
-    async def get_internal_cache_metrics(self) -> Dict[str, Any]:
-        """
-        Snapshot dos caches internos (L1) do serviço TIPI.
-        """
+    async def snapshotTipiInternalCacheMetrics(self):
         async with self._get_cache_lock():
-            code_snapshot = self._code_search_cache_metrics.snapshot(
-                current_size=len(self._code_search_cache),
-                max_size=CacheConfig.TIPI_RESULT_CACHE_SIZE,
-            )
-            chapter_snapshot = self._chapter_positions_cache_metrics.snapshot(
-                current_size=len(self._chapter_positions_cache),
-                max_size=CacheConfig.TIPI_CHAPTER_CACHE_SIZE,
-            )
-
-        return {
-            "code_search_cache": {
-                "name": self._code_search_cache_metrics.name,
-                "hits": code_snapshot.hits,
-                "misses": code_snapshot.misses,
-                "sets": code_snapshot.sets,
-                "evictions": code_snapshot.evictions,
-                "served_gzip": code_snapshot.served_gzip,
-                "served_identity": code_snapshot.served_identity,
-                "current_size": code_snapshot.current_size,
-                "max_size": code_snapshot.max_size,
-                "hit_rate": code_snapshot.hit_rate,
-            },
-            "chapter_positions_cache": {
-                "name": self._chapter_positions_cache_metrics.name,
-                "hits": chapter_snapshot.hits,
-                "misses": chapter_snapshot.misses,
-                "sets": chapter_snapshot.sets,
-                "evictions": chapter_snapshot.evictions,
-                "served_gzip": chapter_snapshot.served_gzip,
-                "served_identity": chapter_snapshot.served_identity,
-                "current_size": chapter_snapshot.current_size,
-                "max_size": chapter_snapshot.max_size,
-                "hit_rate": chapter_snapshot.hit_rate,
-            },
-        }
+            return snapshot_tipi_internal_cache_metrics(self)

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -9,6 +9,7 @@ import styles from './Header.module.css';
 
 const DOC_SUBTITLES: Record<string, string> = {
     nbs: 'Classificação Brasileira de Serviços',
+    nebs: 'Classificação Brasileira de Serviços',
     nesh: 'Notas Explicativas do Sistema Harmonizado',
     tipi: 'Tabela de Incidência do IPI',
 };
@@ -64,7 +65,10 @@ export function Header({
         logout
     } = useAuth();
     const isAdmin = useIsAdmin();
-    const isServiceDoc = doc === 'nbs';
+    const isServiceDoc = doc === 'nbs' || doc === 'nebs';
+    const primaryDocLabel = doc === 'nbs' ? 'NEBS' : doc === 'nebs' ? 'NBS' : 'NESH';
+    const primaryDocTarget = doc === 'nbs' ? 'nebs' : doc === 'nebs' ? 'nbs' : 'nesh';
+    const primaryDocActive = doc !== 'tipi';
     const titleSubtitle = DOC_SUBTITLES[doc] || DOC_SUBTITLES.tipi;
 
     // Close menu when clicking outside
@@ -135,10 +139,10 @@ export function Header({
 
                 <div className={styles.docSelector}>
                     <button
-                        className={`${styles.docButton} ${doc === (isServiceDoc ? 'nbs' : 'nesh') ? styles.docButtonActive : ''}`}
-                        onClick={() => setDoc(isServiceDoc ? 'nbs' : 'nesh')}
+                        className={`${styles.docButton} ${primaryDocActive ? styles.docButtonActive : ''}`}
+                        onClick={() => setDoc(primaryDocTarget)}
                     >
-                        {isServiceDoc ? 'NEBS' : 'NESH'}
+                        {primaryDocLabel}
                     </button>
                     <button
                         className={`${styles.docButton} ${doc === 'tipi' ? styles.docButtonActive : ''}`}
@@ -185,7 +189,7 @@ export function Header({
                                 className={servicesUnavailableReason ? styles.menuButtonDisabled : ''}
                                 title={servicesUnavailableReason ?? undefined}
                             >
-                                <span>🧭</span> {servicesUnavailableReason ? 'Serviços (NEBS) indisponível' : 'Serviços (NEBS)'}
+                                <span>🧭</span> {servicesUnavailableReason ? 'Serviços (NBS) indisponível' : 'Serviços (NBS)'}
                             </button>
                         )}
                         <div className={styles.menuDivider}></div>

--- a/client/src/components/ResultDisplay.tsx
+++ b/client/src/components/ResultDisplay.tsx
@@ -875,7 +875,13 @@ export const ResultDisplay = React.memo(function ResultDisplay({
 
     // Sidebar collapsed state for lateral layout
     const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-    const toggleSidebar = useCallback(() => { if (window.innerWidth <= 1024) { if (onToggleMobileMenu) onToggleMobileMenu(); else if (onCloseMobileMenu && mobileMenuOpen) onCloseMobileMenu(); } else { setSidebarCollapsed(prev => !prev); } }, [onToggleMobileMenu, onCloseMobileMenu, mobileMenuOpen]);
+    const toggleSidebar = useCallback(() => {
+        if (window.innerWidth <= 1024) {
+            if (onToggleMobileMenu) onToggleMobileMenu();
+            else if (onCloseMobileMenu && mobileMenuOpen) onCloseMobileMenu();
+        }
+        setSidebarCollapsed((prev) => !prev);
+    }, [onToggleMobileMenu, onCloseMobileMenu, mobileMenuOpen]);
 
     // ── Sistema de Comentários (Google Docs Style) ─────────────────────────
     const [commentsEnabled, setCommentsEnabled] = useState(false);
@@ -1852,7 +1858,6 @@ export const ResultDisplay = React.memo(function ResultDisplay({
                     <Sidebar
                         results={renderableCodeResults}
                         onNavigate={handleNavigate}
-                        isOpen={mobileMenuOpen}
                         onClose={onCloseMobileMenu}
                         searchQuery={latestTextQuery || data.query || data.ncm}
                         activeAnchorId={activeAnchorId}

--- a/client/src/components/ServicesTabContent.tsx
+++ b/client/src/components/ServicesTabContent.tsx
@@ -417,7 +417,7 @@ export function ServicesTabContent({
             : EMPTY_NEBS_STATE
     ), [data.results, detailStatus, doc, nebsDetail, selectedCode]);
 
-    const title = doc === 'nbs' ? 'Resultados NEBS' : 'Resultados NEBS';
+    const title = doc === 'nbs' ? 'Resultados NBS' : 'Resultados NEBS';
     const countLabel = `${data.total} ${doc === 'nbs' ? 'itens' : 'notas'}`;
     const queryLabel = data.query.trim() || 'catalogo raiz';
     const shellClassName = `${styles.shell} ${isWorkspaceReady ? styles.shellVisible : styles.shellHidden}`;

--- a/client/src/components/ServicesWorkspace.tsx
+++ b/client/src/components/ServicesWorkspace.tsx
@@ -164,7 +164,7 @@ function NbsHierarchySection({
                         <span className={styles.chapterNotesEyebrow}>Explicações</span>
                         <span>{chapterButtonLabel}</span>
                     </button>
-                    Hierarquia NEBS
+                    Hierarquia NBS
                 </div>
                 <span className={styles.sectionBadge}>
                     {activeChapterNumber ? `Capítulo ${activeChapterNumber} ativo` : 'Capítulo ativo'}
@@ -259,6 +259,15 @@ function NbsDetailSection({
     nbsState,
     openCatalogDoc,
 }: Readonly<NbsDetailSectionProps>) {
+    const linkedNebs = nbsState.detail?.nebs ?? null;
+    const linkedNebsCode = linkedNebs?.code ?? null;
+
+    const handleOpenLinkedNebs = () => {
+        if (linkedNebsCode) {
+            openCatalogDoc('nebs', linkedNebsCode);
+        }
+    };
+
     return (
         <section className={styles.rightPanel}>
             {nbsState.isLoadingDetail ? (
@@ -290,7 +299,7 @@ function NbsDetailSection({
                         </div>
                     </section>
 
-                    {nbsState.detail.nebs && (
+                    {linkedNebs && (
                         <section className={styles.notesCard} style={{ marginTop: '1rem' }}>
                             <div className={styles.notesHeader}>
                                 <span className={styles.notesIcon}>i</span>
@@ -302,6 +311,18 @@ function NbsDetailSection({
                                 dangerouslySetInnerHTML={{ __html: nbsNoteBodyHtml }}
                             />
                         </section>
+                    )}
+
+                    {linkedNebsCode && (
+                        <div className={styles.detailActions} style={{ marginTop: '1rem' }}>
+                            <button
+                                type="button"
+                                className={styles.secondaryAction}
+                                onClick={handleOpenLinkedNebs}
+                            >
+                                Ver NEBS
+                            </button>
+                        </div>
                     )}
 
                     
@@ -571,7 +592,7 @@ function NebsDetailSection({
                         </p>
                     </div>
 
-                    <div className={styles.breadcrumbs} aria-label="Hierarquia NEBS">
+                    <div className={styles.breadcrumbs} aria-label="Hierarquia NBS">
                         {nebsState.detail.ancestors.map((ancestor) => (
                             <button
                                 key={ancestor.code}
@@ -614,14 +635,14 @@ function NebsDetailSection({
                     </section>
 
                     <div className={styles.detailActions}>
-                        <button
-                            type="button"
-                            className={styles.secondaryAction}
-                            onClick={() => openCatalogDoc('nbs', nebsState.detail?.item.code)}
-                        >
-                            Abrir item NEBS relacionado
-                        </button>
-                    </div>
+                            <button
+                                type="button"
+                                className={styles.secondaryAction}
+                                onClick={() => openCatalogDoc('nbs', nebsState.detail?.item.code)}
+                            >
+                                Abrir item NBS relacionado
+                            </button>
+                        </div>
                 </>
             ) : (
                 <div className={styles.emptyDetail}>

--- a/client/src/components/ServicesWorkspace.tsx
+++ b/client/src/components/ServicesWorkspace.tsx
@@ -412,7 +412,7 @@ function NbsDetailSection({
                             className={styles.secondaryAction}
                             onClick={() => openCatalogDoc('nebs', linkedNebsCode)}
                         >
-                            Ver NBS
+                            Ver NEBS
                         </button>
                     </div>
                 )}
@@ -500,13 +500,13 @@ interface NbsWorkspaceViewProps {
     readonly chapterNotesDialogRef: React.RefObject<HTMLDialogElement | null>;
     readonly chapterNotesHtml: string;
     readonly currentChapterNotesEntry: ReturnType<typeof getNbsChapterNotesEntry>;
+    readonly openCatalogDoc: OpenCatalogDoc;
     readonly nbsChapterNotesNewTab: boolean;
     readonly nbsNoteBodyHtml: string;
     readonly nbsNotesContentRef: React.RefObject<HTMLDivElement | null>;
     readonly nbsPrefixAutoExpand: boolean;
     readonly nbsState: ServicesWorkspaceNbsState;
     readonly onSelectNbs: (code: string) => void;
-    readonly openCatalogDoc: OpenCatalogDoc;
     readonly setIsChapterNotesOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -515,13 +515,13 @@ function NbsWorkspaceView({
     chapterNotesDialogRef,
     chapterNotesHtml,
     currentChapterNotesEntry,
+    openCatalogDoc,
     nbsChapterNotesNewTab,
     nbsNoteBodyHtml,
     nbsNotesContentRef,
     nbsPrefixAutoExpand,
     nbsState,
     onSelectNbs,
-    openCatalogDoc,
     setIsChapterNotesOpen,
 }: Readonly<NbsWorkspaceViewProps>) {
     const chapterButtonLabel = activeChapterNumber

--- a/client/src/components/ServicesWorkspace.tsx
+++ b/client/src/components/ServicesWorkspace.tsx
@@ -358,8 +358,8 @@ function NbsDetailSection({
     } else if (nbsState.detail) {
         const detail = nbsState.detail;
         const codeParts = detail.item.code.split('.');
-        const linkedNebs = detail.nebs ?? null;
-        const linkedNebsCode = linkedNebs?.code ?? null;
+        const linkedNebs = detail.nebs;
+        const linkedNebsCode = linkedNebs?.code;
 
         detailBody = (
             <>

--- a/client/src/components/Sidebar.Reliability.test.tsx
+++ b/client/src/components/Sidebar.Reliability.test.tsx
@@ -57,7 +57,6 @@ describe('Sidebar Reliability Reproduction', () => {
             <Sidebar
                 results={mockResults}
                 onNavigate={mockNavigate}
-                isOpen={true}
                 onClose={mockClose}
                 searchQuery=""
             />
@@ -73,7 +72,6 @@ describe('Sidebar Reliability Reproduction', () => {
             <Sidebar
                 results={mockResults}
                 onNavigate={mockNavigate}
-                isOpen={true}
                 onClose={mockClose}
                 searchQuery="4908.90.00"
             />
@@ -106,7 +104,6 @@ describe('Sidebar Reliability Reproduction', () => {
             <Sidebar
                 results={mockResults}
                 onNavigate={mockNavigate}
-                isOpen={true}
                 onClose={mockClose}
                 searchQuery=""
             />
@@ -116,7 +113,6 @@ describe('Sidebar Reliability Reproduction', () => {
             <Sidebar
                 results={mockResults}
                 onNavigate={mockNavigate}
-                isOpen={true}
                 onClose={mockClose}
                 searchQuery="9999.00.00" // Non-existent
             />

--- a/client/src/components/Sidebar.test.tsx
+++ b/client/src/components/Sidebar.test.tsx
@@ -63,7 +63,6 @@ describe('Sidebar Autoscroll', () => {
             <Sidebar
                 results={mockResults}
                 onNavigate={mockNavigate}
-                isOpen={true}
                 onClose={mockClose}
                 searchQuery=""
             />
@@ -82,7 +81,6 @@ describe('Sidebar Autoscroll', () => {
             <Sidebar
                 results={mockResults}
                 onNavigate={mockNavigate}
-                isOpen={true}
                 onClose={mockClose}
                 searchQuery="8417"
             />
@@ -105,7 +103,6 @@ describe('Sidebar Autoscroll', () => {
             <Sidebar
                 results={mockResults}
                 onNavigate={mockNavigate}
-                isOpen={true}
                 onClose={mockClose}
                 searchQuery=""
             />
@@ -123,7 +120,6 @@ describe('Sidebar Autoscroll', () => {
             <Sidebar
                 results={mockResults}
                 onNavigate={mockNavigate}
-                isOpen={true}
                 onClose={mockClose}
                 searchQuery="841710" // Unformatted input
             />

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -29,7 +29,6 @@ interface Chapter {
 interface SidebarProps {
   results: Record<string, Chapter> | null;
   onNavigate: (targetId: string) => void;
-  isOpen: boolean;
   onClose: () => void;
   searchQuery?: string;
   activeAnchorId?: string | null;
@@ -127,7 +126,6 @@ function comparePositionCodes(aCode: string, bCode: string): number {
 export const Sidebar = React.memo(function Sidebar({
   results,
   onNavigate,
-  isOpen,
   onClose,
   searchQuery,
   activeAnchorId,

--- a/client/tests/e2e/services-tabs.flow.test.tsx
+++ b/client/tests/e2e/services-tabs.flow.test.tsx
@@ -182,8 +182,8 @@ describe('services tabs flow', () => {
     render(<ServicesTabsHarness initialDoc="nbs" initialQuery="1.0101.11.00" />);
 
     await screen.findByText('Resultados NBS');
-    const verNbsButton = await screen.findByRole('button', { name: 'Ver NBS' });
-    fireEvent.click(verNbsButton);
+    const verNebsButton = await screen.findByRole('button', { name: 'Ver NEBS' });
+    fireEvent.click(verNebsButton);
 
     await waitFor(() => {
       expect(screen.getByTestId('tab-list')).toHaveAttribute('data-count', '1');
@@ -207,15 +207,15 @@ describe('services tabs flow', () => {
       expect(screen.getByTestId('active-tab-meta')).toHaveTextContent('nbs:1.0101.11.00');
     });
     expect(await screen.findByText('Resultados NBS')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Ver NBS' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Ver NEBS' })).toBeInTheDocument();
   });
 
   it('preserves the current query when toggling between NBS and NEBS results', async () => {
     render(<ServicesTabsHarness initialDoc="nbs" initialQuery="1.0101.11.00" />);
 
     await screen.findByText('Resultados NBS');
-    const verNbsButton = await screen.findByRole('button', { name: 'Ver NBS' });
-    fireEvent.click(verNbsButton);
+    const verNebsButton = await screen.findByRole('button', { name: 'Ver NEBS' });
+    fireEvent.click(verNebsButton);
 
     await waitFor(() => {
       expect(screen.getByTestId('active-tab-meta')).toHaveTextContent('nebs:1.0101.11.00');
@@ -248,7 +248,7 @@ describe('services tabs flow', () => {
     expect(onOpenDocInNewTab).toHaveBeenCalledWith('nbs', '1.0101.11.00');
   });
 
-  it('opens NEBS in a new tab when clicking Ver NBS and preference is enabled', async () => {
+  it('opens NEBS in a new tab when clicking Ver NEBS and preference is enabled', async () => {
     const onOpenDocInNewTab = vi.fn();
     refs.openNewTab = true;
 
@@ -261,8 +261,8 @@ describe('services tabs flow', () => {
     );
 
     await screen.findByText('Resultados NBS');
-    const verNbsButton = await screen.findByRole('button', { name: 'Ver NBS' });
-    fireEvent.click(verNbsButton);
+    const verNebsButton = await screen.findByRole('button', { name: 'Ver NEBS' });
+    fireEvent.click(verNebsButton);
 
     expect(onOpenDocInNewTab).toHaveBeenCalledWith('nebs', '1.0101.11.00');
   });

--- a/client/tests/playwright/services-tabs.resilience.spec.ts
+++ b/client/tests/playwright/services-tabs.resilience.spec.ts
@@ -69,7 +69,7 @@ test('shows the NEBS empty/error state after a linked NEBS search fails', async 
 
   await openServicesModal(page);
   await searchServices(page, '1.0101.11.00');
-  const openNebsButton = page.getByRole('button', { name: /Ver NBS/ });
+  const openNebsButton = page.getByRole('button', { name: /Ver NEBS/ });
   await expect(openNebsButton).toBeVisible();
 
   const nebsRequest = page.waitForRequest((request) =>

--- a/client/tests/playwright/services-tabs.spec.ts
+++ b/client/tests/playwright/services-tabs.spec.ts
@@ -57,7 +57,7 @@ test('loads NBS search results and the linked detail panel', async ({ page }) =>
   await expect(page.getByRole('heading', { name: 'Resultados NBS' })).toBeVisible();
   await expect(page.getByRole('button', { name: /Serviços de construção de edificações residenciais/ })).toBeVisible();
   await expect(page.getByText('NOTAS EXPLICATIVAS')).toBeVisible();
-  await expect(page.getByRole('button', { name: /Ver NBS/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Ver NEBS/ })).toBeVisible();
 });
 
 test('switches from an NBS detail to the linked NEBS detail', async ({ page }) => {
@@ -69,7 +69,7 @@ test('switches from an NBS detail to the linked NEBS detail', async ({ page }) =
     && new URL(request.url()).searchParams.get('q') === '1.0101.11.00',
   );
 
-  await page.getByRole('button', { name: /Ver NBS/ }).click();
+  await page.getByRole('button', { name: /Ver NEBS/ }).click();
   await nebsRequest;
 
   await expect(page.getByRole('heading', { name: 'Resultados NEBS' })).toBeVisible();
@@ -80,7 +80,7 @@ test('switches from an NBS detail to the linked NEBS detail', async ({ page }) =
 test('returns from a NEBS detail to the linked NBS detail', async ({ page }) => {
   await openServicesModal(page);
   await searchServices(page, '1.0101.11.00');
-  await page.getByRole('button', { name: /Ver NBS/ }).click();
+  await page.getByRole('button', { name: /Ver NEBS/ }).click();
   await expect(page.getByRole('heading', { name: 'Resultados NEBS' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Abrir item NBS relacionado' })).toBeVisible();
 
@@ -93,7 +93,7 @@ test('returns from a NEBS detail to the linked NBS detail', async ({ page }) => 
   await nbsRequest;
 
   await expect(page.getByRole('heading', { name: 'Resultados NBS' })).toBeVisible();
-  await expect(page.getByRole('button', { name: /Ver NBS/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Ver NEBS/ })).toBeVisible();
 });
 
 test('updates NBS detail when clicking an ancestor in the hierarchy', async ({ page }) => {
@@ -218,7 +218,7 @@ test('opens smart-link target in a new tab with middle-click', async ({ page }) 
 test('navigates from NEBS breadcrumbs back to NBS detail in the same tab', async ({ page }) => {
   await openServicesModal(page);
   await searchServices(page, '1.0101.11.00');
-  await page.getByRole('button', { name: /Ver NBS/ }).click();
+  await page.getByRole('button', { name: /Ver NEBS/ }).click();
   await expect(page.getByRole('heading', { name: 'Resultados NEBS' })).toBeVisible();
 
   const nbsRequest = page.waitForRequest((request) =>
@@ -235,7 +235,7 @@ test('navigates from NEBS breadcrumbs back to NBS detail in the same tab', async
 test('opens NEBS breadcrumb navigation in a new tab when preference is enabled', async ({ page }) => {
   await openServicesModal(page);
   await searchServices(page, '1.0101.11.00');
-  await page.getByRole('button', { name: /Ver NBS/ }).click();
+  await page.getByRole('button', { name: /Ver NEBS/ }).click();
   await expect(page.getByRole('heading', { name: 'Resultados NEBS' })).toBeVisible();
 
   const initialTabCount = await page.locator('div[draggable="true"][data-document]').count();
@@ -256,7 +256,7 @@ test('opens NEBS breadcrumb navigation in a new tab when preference is enabled',
 test('opens linked NBS detail in a new tab when preference is enabled', async ({ page }) => {
   await openServicesModal(page);
   await searchServices(page, '1.0101.11.00');
-  await page.getByRole('button', { name: /Ver NBS/ }).click();
+  await page.getByRole('button', { name: /Ver NEBS/ }).click();
   await expect(page.getByRole('heading', { name: 'Resultados NEBS' })).toBeVisible();
 
   const initialTabCount = await page.locator('div[draggable="true"][data-document]').count();

--- a/test_support.py
+++ b/test_support.py
@@ -85,7 +85,8 @@ def _close_shared_db_engine() -> None:
         try:
             asyncio.run(TipiService.close_all_pools())
         finally:
-            TipiService._pool_lock = None
+            TipiService._tipi_connection_pools = {}
+            TipiService._tipi_connection_pool_locks = {}
     except Exception as exc:
         LOGGER.debug("Failed to close TIPI pools during test bootstrap: %s", exc)
 

--- a/tests/integration/test_search_route_contracts.py
+++ b/tests/integration/test_search_route_contracts.py
@@ -19,7 +19,7 @@ def _vary_tokens(response) -> set[str]:
 
 
 class _FakeNeshServiceCode:
-    async def process_request(self, query: str):
+    async def executeNeshSearchWithVectorWeights(self, query: str):
         return {
             "success": True,
             "type": "code",
@@ -29,15 +29,16 @@ class _FakeNeshServiceCode:
         }
 
 
-def test_search_handler_keeps_legacy_alias_to_canonical_name():
+def test_search_handler_exposes_only_canonical_name():
     assert (
-        search_route.search
-        is search_route.handleGlobalFiscalSearchRequest
+        search_route.handleGlobalFiscalSearchRequest.__name__
+        == "handleGlobalFiscalSearchRequest"
     )
+    assert not hasattr(search_route, "search")
 
 
 class _FakeNeshServiceText:
-    async def process_request(self, query: str):
+    async def executeNeshSearchWithVectorWeights(self, query: str):
         return {
             "success": True,
             "type": "text",
@@ -48,13 +49,13 @@ class _FakeNeshServiceText:
 
 
 class _FakeNeshServiceInvalid:
-    async def process_request(self, _query: str):
+    async def executeNeshSearchWithVectorWeights(self, _query: str):
         await asyncio.sleep(0)
         return []
 
 
 class _FakeNeshChapterService:
-    async def fetch_chapter_data(self, chapter: str):
+    async def fetchNeshChapterData(self, chapter: str):
         await asyncio.sleep(0)
         return {
             "content": f"CAPITULO {chapter}\nConteudo detalhado",
@@ -63,12 +64,12 @@ class _FakeNeshChapterService:
             "sections": {"titulo": "Capitulo 84"},
         }
 
-    def strip_chapter_preamble(self, content: str) -> str:
+    def stripNeshChapterPreamble(self, content: str) -> str:
         return content.split("\n", 1)[1] if "\n" in content else content
 
 
 class _FakeNeshServiceCodeEmptyResults:
-    async def process_request(self, query: str):
+    async def executeNeshSearchWithVectorWeights(self, query: str):
         await asyncio.sleep(0)
         return {
             "success": True,
@@ -81,10 +82,7 @@ class _FakeNeshServiceCodeEmptyResults:
 
 
 class _FakeTipiServiceCode:
-    def is_code_query(self, _query: str) -> bool:
-        return True
-
-    async def search_by_code(self, _query: str, view_mode: str = "family"):
+    async def searchTipiByNcmCode(self, _query: str, view_mode: str = "family"):
         return {
             "success": True,
             "type": "code",
@@ -94,10 +92,7 @@ class _FakeTipiServiceCode:
 
 
 class _FakeTipiServiceText:
-    def is_code_query(self, _query: str) -> bool:
-        return False
-
-    async def search_text(self, query: str):
+    async def searchTipiByTextQuery(self, query: str):
         return {
             "success": True,
             "type": "text",
@@ -121,7 +116,9 @@ def test_search_code_response_keeps_resultados_alias(client, monkeypatch):
     monkeypatch.setattr(
         NeshService,
         "executeNeshSearchWithVectorWeights",
-        AsyncMock(side_effect=_FakeNeshServiceCode().process_request),
+        AsyncMock(
+            side_effect=_FakeNeshServiceCode().executeNeshSearchWithVectorWeights
+        ),
     )
 
     response = client.get("/api/search?ncm=8517")
@@ -141,7 +138,9 @@ def test_search_text_response_does_not_inject_resultados(client, monkeypatch):
     monkeypatch.setattr(
         NeshService,
         "executeNeshSearchWithVectorWeights",
-        AsyncMock(side_effect=_FakeNeshServiceText().process_request),
+        AsyncMock(
+            side_effect=_FakeNeshServiceText().executeNeshSearchWithVectorWeights
+        ),
     )
 
     response = client.get("/api/search?ncm=texto")
@@ -156,7 +155,9 @@ def test_search_code_prefers_results_key_even_when_empty(client, monkeypatch):
     monkeypatch.setattr(
         NeshService,
         "executeNeshSearchWithVectorWeights",
-        AsyncMock(side_effect=_FakeNeshServiceCodeEmptyResults().process_request),
+        AsyncMock(
+            side_effect=_FakeNeshServiceCodeEmptyResults().executeNeshSearchWithVectorWeights
+        ),
     )
 
     response = client.get("/api/search?ncm=8517")
@@ -175,7 +176,9 @@ def test_search_invalid_service_response_returns_500_with_cors_header(
     monkeypatch.setattr(
         NeshService,
         "executeNeshSearchWithVectorWeights",
-        AsyncMock(side_effect=_FakeNeshServiceInvalid().process_request),
+        AsyncMock(
+            side_effect=_FakeNeshServiceInvalid().executeNeshSearchWithVectorWeights
+        ),
     )
 
     response = client.get(
@@ -193,13 +196,13 @@ def test_search_chapter_body_allows_anonymous_access(client, monkeypatch):
     fake_service = _FakeNeshChapterService()
     monkeypatch.setattr(
         NeshService,
-        "fetch_chapter_data",
-        AsyncMock(side_effect=fake_service.fetch_chapter_data),
+        "fetchNeshChapterData",
+        AsyncMock(side_effect=fake_service.fetchNeshChapterData),
     )
     monkeypatch.setattr(
         NeshService,
-        "strip_chapter_preamble",
-        fake_service.strip_chapter_preamble,
+        "stripNeshChapterPreamble",
+        fake_service.stripNeshChapterPreamble,
     )
 
     response = client.get("/api/search/chapter/84/body")
@@ -233,7 +236,7 @@ def test_search_chapters_endpoint_returns_available_chapters(client, monkeypatch
 def test_nesh_chapter_notes_endpoint_returns_notes_payload(client, monkeypatch):
     monkeypatch.setattr(
         NeshService,
-        "fetch_chapter_data",
+        "fetchNeshChapterData",
         AsyncMock(
             return_value={
                 "parsed_notes": {"N1": "Nota 1", "N2": "Nota 2"},
@@ -258,7 +261,7 @@ def test_nesh_chapter_notes_endpoint_returns_404_when_chapter_missing(
 ):
     monkeypatch.setattr(
         NeshService,
-        "fetch_chapter_data",
+        "fetchNeshChapterData",
         AsyncMock(return_value=None),
     )
 
@@ -295,7 +298,7 @@ def test_glossary_endpoint_returns_found_and_not_found_contracts(client, monkeyp
 def test_tipi_chapters_endpoint_returns_available_chapters(client, monkeypatch):
     monkeypatch.setattr(
         TipiService,
-        "get_all_chapters",
+        "fetchTipiChapterCatalog",
         AsyncMock(return_value=["01", "02", "11"]),
     )
 
@@ -310,11 +313,11 @@ def test_tipi_chapters_endpoint_returns_available_chapters(client, monkeypatch):
 
 def test_tipi_code_response_enforces_compatibility_fields(client, monkeypatch):
     fake_service = _FakeTipiServiceCode()
-    monkeypatch.setattr(TipiService, "is_code_query", fake_service.is_code_query)
+    monkeypatch.setattr(tipi_route.ncm_utils, "is_code_query", lambda _query: True)
     monkeypatch.setattr(
         TipiService,
-        "search_by_code",
-        AsyncMock(side_effect=fake_service.search_by_code),
+        "searchTipiByNcmCode",
+        AsyncMock(side_effect=fake_service.searchTipiByNcmCode),
     )
 
     response = client.get("/api/tipi/search?ncm=8517")
@@ -332,11 +335,11 @@ def test_tipi_code_response_enforces_compatibility_fields(client, monkeypatch):
 
 def test_tipi_text_response_sets_route_defaults(client, monkeypatch):
     fake_service = _FakeTipiServiceText()
-    monkeypatch.setattr(TipiService, "is_code_query", fake_service.is_code_query)
+    monkeypatch.setattr(tipi_route.ncm_utils, "is_code_query", lambda _query: False)
     monkeypatch.setattr(
         TipiService,
-        "search_text",
-        AsyncMock(side_effect=fake_service.search_text),
+        "searchTipiByTextQuery",
+        AsyncMock(side_effect=fake_service.searchTipiByTextQuery),
     )
 
     response = client.get("/api/tipi/search?ncm=motor")

--- a/tests/integration/test_services_route_contract.py
+++ b/tests/integration/test_services_route_contract.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.integration
 
 
 class _FakeServicesCatalog:
-    async def search(self, query: str):
+    async def search_nbs_catalog_entries(self, query: str):
         return {
             "success": True,
             "query": query,
@@ -19,7 +19,7 @@ class _FakeServicesCatalog:
             "total": 1,
         }
 
-    async def get_item_details(
+    async def fetch_nbs_catalog_item_details(
         self,
         code: str,
         *,
@@ -54,7 +54,7 @@ class _FakeServicesCatalog:
             "nebs": None,
         }
 
-    async def search_nebs(self, query: str):
+    async def search_nbs_explanatory_entries(self, query: str):
         return {
             "success": True,
             "query": query,
@@ -72,7 +72,7 @@ class _FakeServicesCatalog:
             "total": 1,
         }
 
-    async def get_item_tree_page(
+    async def fetch_nbs_catalog_tree_page(
         self,
         code: str,
         *,
@@ -113,7 +113,7 @@ class _FakeServicesCatalog:
             },
         }
 
-    async def get_nebs_details(self, code: str):
+    async def fetch_nbs_explanatory_entry_details(self, code: str):
         return {
             "success": True,
             "item": {
@@ -165,28 +165,28 @@ def _setup_fake_services_catalog(monkeypatch):
     fake_service = _FakeServicesCatalog()
     monkeypatch.setattr(
         NbsService,
-        "search",
-        AsyncMock(side_effect=fake_service.search),
+        "searchNbsCatalogEntries",
+        AsyncMock(side_effect=fake_service.search_nbs_catalog_entries),
     )
     monkeypatch.setattr(
         NbsService,
-        "get_item_details",
-        AsyncMock(side_effect=fake_service.get_item_details),
+        "fetchNbsCatalogItemDetails",
+        AsyncMock(side_effect=fake_service.fetch_nbs_catalog_item_details),
     )
     monkeypatch.setattr(
         NbsService,
-        "search_nebs",
-        AsyncMock(side_effect=fake_service.search_nebs),
+        "searchNbsExplanatoryEntries",
+        AsyncMock(side_effect=fake_service.search_nbs_explanatory_entries),
     )
     monkeypatch.setattr(
         NbsService,
-        "get_item_tree_page",
-        AsyncMock(side_effect=fake_service.get_item_tree_page),
+        "fetchNbsCatalogTreePage",
+        AsyncMock(side_effect=fake_service.fetch_nbs_catalog_tree_page),
     )
     monkeypatch.setattr(
         NbsService,
-        "get_nebs_details",
-        AsyncMock(side_effect=fake_service.get_nebs_details),
+        "fetchNbsExplanatoryEntryDetails",
+        AsyncMock(side_effect=fake_service.fetch_nbs_explanatory_entry_details),
     )
 
 
@@ -317,9 +317,9 @@ def test_services_routes_document_public_rate_limit_responses():
 @pytest.mark.parametrize(
     ("endpoint", "service_method"),
     [
-        ("/api/services/nbs/{code}", "get_item_details"),
-        ("/api/services/nbs/{code}/tree", "get_item_tree_page"),
-        ("/api/services/nebs/{code}", "get_nebs_details"),
+        ("/api/services/nbs/{code}", "fetchNbsCatalogItemDetails"),
+        ("/api/services/nbs/{code}/tree", "fetchNbsCatalogTreePage"),
+        ("/api/services/nebs/{code}", "fetchNbsExplanatoryEntryDetails"),
     ],
 )
 def test_services_detail_rejects_overly_long_code(

--- a/tests/integration/test_tipi_service_contract.py
+++ b/tests/integration/test_tipi_service_contract.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 from backend.services.tipi_service import TipiService
+from backend.utils import ncm_utils
 
 pytestmark = pytest.mark.integration
 
@@ -110,17 +111,17 @@ class TestTipiServiceContract:
 
     def test_is_code_query_heuristic(self, service):
         """Heurística de detecção de query numérica."""
-        assert service.is_code_query("85") is True
-        assert service.is_code_query("85.17") is True
-        assert service.is_code_query("85-17") is True
-        assert service.is_code_query("85,73") is True
-        assert service.is_code_query("motor eletrico") is False
-        assert service.is_code_query("") is False
+        assert ncm_utils.is_code_query("85") is True
+        assert ncm_utils.is_code_query("85.17") is True
+        assert ncm_utils.is_code_query("85-17") is True
+        assert ncm_utils.is_code_query("85,73") is True
+        assert ncm_utils.is_code_query("motor eletrico") is False
+        assert ncm_utils.is_code_query("") is False
 
     @pytest.mark.asyncio
     async def test_search_by_code_contract_non_empty(self, service):
         """Resposta de busca por código deve seguir contrato."""
-        resp = await service.search_by_code("85")
+        resp = await service.searchTipiByNcmCode("85")
 
         assert resp["success"] is True
         assert resp["type"] == "code"
@@ -144,7 +145,7 @@ class TestTipiServiceContract:
     @pytest.mark.asyncio
     async def test_search_by_code_sets_posicao_alvo(self, service):
         """Deve definir posicao_alvo para auto-scroll."""
-        resp = await service.search_by_code("8517")
+        resp = await service.searchTipiByNcmCode("8517")
         cap = resp["resultados"].get("85")
 
         assert cap is not None
@@ -153,7 +154,7 @@ class TestTipiServiceContract:
     @pytest.mark.asyncio
     async def test_search_by_code_normalizes_8_digit_ncm_for_scroll(self, service):
         """NCM de 8 dígitos deve ser normalizado para scroll."""
-        resp = await service.search_by_code("84139190")
+        resp = await service.searchTipiByNcmCode("84139190")
         cap = resp["resultados"].get("84")
 
         assert cap is not None
@@ -162,7 +163,7 @@ class TestTipiServiceContract:
     @pytest.mark.asyncio
     async def test_search_by_code_contract_empty(self, service):
         """Busca sem resultados deve retornar estrutura vazia."""
-        resp = await service.search_by_code("9999")
+        resp = await service.searchTipiByNcmCode("9999")
 
         assert resp["success"] is True
         assert resp["type"] == "code"
@@ -177,7 +178,7 @@ class TestTipiServiceContract:
         if not test_db["fts"]:
             pytest.skip("SQLite FTS5 não disponível neste ambiente")
 
-        resp = await service.search_text("telefônicos")
+        resp = await service.searchTipiByTextQuery("telefônicos")
 
         assert resp["success"] is True
         assert resp["type"] == "text"
@@ -197,7 +198,7 @@ class TestTipiHierarchy:
         Ao buscar um NCM específico (8 dígitos), deve retornar também
         os NCMs pai (posição 4-dig, subposição 6-dig).
         """
-        resp = await service.search_by_code("39249000", view_mode="family")
+        resp = await service.searchTipiByNcmCode("39249000", view_mode="family")
 
         assert resp["success"] is True
         cap = resp["resultados"].get("39")
@@ -218,7 +219,7 @@ class TestTipiHierarchy:
     @pytest.mark.asyncio
     async def test_family_mode_with_6_digit_query(self, service):
         """Busca com 6 dígitos deve incluir ancestral de 4 dígitos."""
-        resp = await service.search_by_code("392490", view_mode="family")
+        resp = await service.searchTipiByNcmCode("392490", view_mode="family")
 
         cap = resp["resultados"].get("39")
         assert cap is not None
@@ -233,7 +234,7 @@ class TestTipiHierarchy:
     @pytest.mark.asyncio
     async def test_chapter_mode_returns_full_chapter(self, service):
         """Modo chapter deve retornar capítulo completo sem filtro."""
-        resp = await service.search_by_code("39249000", view_mode="chapter")
+        resp = await service.searchTipiByNcmCode("39249000", view_mode="chapter")
 
         cap = resp["resultados"].get("39")
         assert cap is not None
@@ -247,7 +248,7 @@ class TestTipiHierarchy:
     async def test_family_mode_filters_unrelated_positions(self, service):
         """Modo family não deve incluir posições de outras famílias."""
         # Busca específica no cap 84
-        resp = await service.search_by_code("84139190", view_mode="family")
+        resp = await service.searchTipiByNcmCode("84139190", view_mode="family")
 
         cap = resp["resultados"].get("84")
         assert cap is not None

--- a/tests/performance/test_search_timeout_repro.py
+++ b/tests/performance/test_search_timeout_repro.py
@@ -4,8 +4,15 @@ import pytest
 from backend.config import CONFIG
 from backend.infrastructure.database import DatabaseAdapter
 from backend.services.nesh_service import NeshService
+from backend.utils import ncm_utils
 
 pytestmark = pytest.mark.perf
+
+
+async def _run_nesh_query(service, query: str):
+    if ncm_utils.is_code_query(query):
+        return await service.searchNeshByNcmCode(query)
+    return await service.searchNeshByTextQuery(query)
 
 
 @pytest.mark.asyncio
@@ -42,8 +49,8 @@ async def test_search_performance_repro():
         for query in test_queries:
             start_time = time.perf_counter()
 
-            # Call the service method directly to isolate business logic perfermance
-            await service.process_request(query)
+            # Call the canonical service method directly to isolate business logic.
+            await _run_nesh_query(service, query)
 
             duration = time.perf_counter() - start_time
             print(f"Query: '{query}' took {duration:.4f}s")

--- a/tests/unit/test_app_lifespan_additional.py
+++ b/tests/unit/test_app_lifespan_additional.py
@@ -64,8 +64,7 @@ class _FakeTipiService:
         self.created_repo = False
 
     @classmethod
-    async def initializeTipiServiceWithRepositoryFactory(cls):
-        await asyncio.sleep(0)
+    def initializeTipiServiceWithRepositoryFactory(cls):
         obj = cls()
         obj.created_repo = True
         obj.mode = "repo"

--- a/tests/unit/test_cache_key_normalization.py
+++ b/tests/unit/test_cache_key_normalization.py
@@ -16,9 +16,7 @@ from backend.utils.ncm_utils import is_code_query
 
 
 def _normalize_query(ncm: str) -> str:
-    return _normalize_search_query_for_cache_key(
-        ncm, is_code_query=is_code_query(ncm)
-    )
+    return _normalize_search_query_for_cache_key(ncm, is_code_query=is_code_query(ncm))
 
 
 def _build_request_with_accept_encoding(value: str) -> Request:
@@ -113,10 +111,11 @@ class TestSearchPayloadCacheContext:
 
         assert context.is_code_query is True
         assert context.normalized_query == "8517"
-        assert context.build_code_payload_cache_key(shape="full").endswith(
-            ":8517:full"
+        assert context.build_code_payload_cache_key(shape="full").endswith(":8517:full")
+        assert (
+            context.cache_headers["Vary"]
+            == "Authorization, X-Tenant-Id, Accept-Encoding"
         )
-        assert context.cache_headers["Vary"] == "Authorization, X-Tenant-Id, Accept-Encoding"
 
     def test_builds_text_query_context_without_payload_key(self):
         request = _build_request_with_accept_encoding("gzip")

--- a/tests/unit/test_nbs_parser.py
+++ b/tests/unit/test_nbs_parser.py
@@ -37,6 +37,16 @@ def test_iter_nbs_rows_skips_header_and_reads_semicolon_data(tmp_path: Path):
     ]
 
 
+def test_iter_nbs_rows_skips_empty_and_partial_rows(tmp_path: Path):
+    csv_path = tmp_path / "nbs_partial.csv"
+    csv_path.write_text(
+        "NBS 2.0;DESCRIÇÃO\n\n1.01;\n;Sem código\n1.02;Descrição válida\n",
+        encoding="utf-8-sig",
+    )
+
+    assert list(iter_nbs_rows(csv_path)) == [("1.02", "Descrição válida")]
+
+
 def test_build_nbs_items_creates_hierarchy_from_prefix_chain():
     items = build_nbs_items(
         [
@@ -62,3 +72,11 @@ def test_clean_nbs_code_keeps_only_digits():
 
 def test_build_nbs_code_variants_returns_empty_literal_for_blank_code():
     assert build_nbs_code_variants("") == ()
+
+
+def test_build_nbs_code_variants_adds_alias_without_trailing_zero_suffix():
+    assert build_nbs_code_variants("1.0101.11.00") == ("1.0101.11.00", "1.0101.11")
+
+
+def test_build_nbs_code_variants_adds_canonical_leaf_suffix():
+    assert build_nbs_code_variants("1.0101.11") == ("1.0101.11", "1.0101.11.00")

--- a/tests/unit/test_nbs_repository.py
+++ b/tests/unit/test_nbs_repository.py
@@ -47,13 +47,24 @@ async def test_search_public_scope_filters_to_null_tenant():
     session = _FakeSession([_FakeRowsResult([])])
     repo = NbsRepository(session)
 
-    results = await repo.search("construcao")
+    results = await repo.load_nbs_catalog_entries("construcao")
 
     assert results == []
     stmt, params = session.calls[0]
     assert "n.tenant_id IS NULL" in str(stmt)
     assert params is not None
     assert "tenant_id" not in params
+
+
+@pytest.mark.asyncio
+async def test_search_alias_keeps_migration_compatibility():
+    legacy_repo = NbsRepository(_FakeSession([_FakeRowsResult([])]))
+    canonical_repo = NbsRepository(_FakeSession([_FakeRowsResult([])]))
+
+    legacy_results = await legacy_repo.search("construcao")
+    canonical_results = await canonical_repo.load_nbs_catalog_entries("construcao")
+
+    assert legacy_results == canonical_results == []
 
 
 @pytest.mark.asyncio
@@ -67,8 +78,8 @@ async def test_catalog_counts_and_metadata_public_scope_filter_to_null_tenant():
     )
     repo = NbsRepository(session)
 
-    counts = await repo.get_catalog_counts()
-    metadata = await repo.get_catalog_metadata()
+    counts = await repo.snapshot_nbs_catalog_counts()
+    metadata = await repo.snapshot_nbs_catalog_metadata()
 
     assert counts == {"nbs_items": 12, "nebs_entries": 8}
     assert metadata == {"nbs_version": "2026-04"}
@@ -109,7 +120,7 @@ async def test_get_item_details_public_scope_filters_to_null_tenant():
     )
     repo = NbsRepository(session)
 
-    details = await repo.get_item_details("1.01")
+    details = await repo.load_nbs_catalog_item_details("1.01")
 
     assert details["success"] is True
     assert details["item"]["code"] == "1.01"
@@ -162,7 +173,7 @@ async def test_get_nebs_details_public_scope_filters_to_null_tenant():
     )
     repo = NbsRepository(session)
 
-    details = await repo.get_nebs_details("1.0102.61")
+    details = await repo.load_nbs_explanatory_entry_details("1.0102.61")
 
     assert details["success"] is True
     assert details["item"]["code"] == "1.0102.61"

--- a/tests/unit/test_nbs_service.py
+++ b/tests/unit/test_nbs_service.py
@@ -195,6 +195,47 @@ def _seed_services_db(db_path: Path) -> None:
 
 
 class _FakeNbsRepo:
+    async def snapshot_nbs_catalog_counts(self):
+        return await self.get_catalog_counts()
+
+    async def snapshot_nbs_catalog_metadata(self):
+        return await self.get_catalog_metadata()
+
+    async def load_nbs_catalog_entries(self, _query: str, limit: int = 50):
+        return await self.search(_query, limit=limit)
+
+    async def load_nbs_catalog_item_details(
+        self,
+        _code: str,
+        *,
+        include_tree: bool = True,
+        page: int = 1,
+        page_size: int = 50,
+    ):
+        return await self.get_item_details(
+            _code,
+            include_tree=include_tree,
+            page=page,
+            page_size=page_size,
+        )
+
+    async def load_nbs_catalog_tree_page(
+        self, _code: str, *, page: int = 1, page_size: int = 50
+    ):
+        payload = await self.get_item_details(
+            _code,
+            include_tree=True,
+            page=page,
+            page_size=page_size,
+        )
+        return payload["chapter_page"]
+
+    async def load_nbs_explanatory_entries(self, _query: str, limit: int = 50):
+        return await self.search_nebs(_query, limit=limit)
+
+    async def load_nbs_explanatory_entry_details(self, _code: str):
+        return await self.get_nebs_details(_code)
+
     async def get_catalog_counts(self):
         return {"nbs_items": 12, "nebs_entries": 4}
 

--- a/tests/unit/test_ncm_utils.py
+++ b/tests/unit/test_ncm_utils.py
@@ -1,4 +1,61 @@
-from backend.utils.ncm_utils import split_ncm_query
+import pytest
+
+from backend.utils.ncm_utils import (
+    clean_ncm,
+    extract_chapter_from_ncm,
+    format_ncm_tipi,
+    is_code_query,
+    split_ncm_query,
+)
+
+
+def test_clean_ncm_removes_non_digits() -> None:
+    assert clean_ncm("85.17-10") == "851710"
+
+
+def test_extract_chapter_from_ncm_handles_blank_and_short_inputs() -> None:
+    assert extract_chapter_from_ncm("") == (None, None)
+    assert extract_chapter_from_ncm("8") == ("08", None)
+    assert extract_chapter_from_ncm("84") == ("84", None)
+
+
+def test_extract_chapter_from_ncm_preserves_explicit_short_subpositions() -> None:
+    assert extract_chapter_from_ncm("8419.8") == ("84", "8419.8")
+    assert extract_chapter_from_ncm("8419.80") == ("84", "8419.80")
+
+
+def test_extract_chapter_from_ncm_builds_dotted_target_for_compact_codes() -> None:
+    assert extract_chapter_from_ncm("8471.30.19") == ("84", "84.71")
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("84139190", "8413.91.90"),
+        ("8413110", "8413.11.0"),
+        ("841311", "8413.11"),
+        ("84131", "8413.1"),
+        ("8413", "84.13"),
+        ("84", "84"),
+        ("", ""),
+    ],
+)
+def test_format_ncm_tipi_handles_known_lengths(raw: str, expected: str) -> None:
+    assert format_ncm_tipi(raw) == expected
+
+
+def test_format_ncm_tipi_returns_original_text_when_no_digits() -> None:
+    assert format_ncm_tipi("abc") == "abc"
+
+
+def test_format_ncm_tipi_falls_back_for_unexpected_lengths() -> None:
+    assert format_ncm_tipi("123456789") == "123456789"
+
+
+def test_is_code_query_detects_only_numeric_like_queries() -> None:
+    assert is_code_query("85.17-10") is True
+    assert is_code_query("motor eletrico") is False
+    assert is_code_query("") is False
 
 
 def test_split_ncm_query_accepts_spaces_as_separator() -> None:
@@ -7,3 +64,7 @@ def test_split_ncm_query_accepts_spaces_as_separator() -> None:
 
 def test_split_ncm_query_accepts_mixed_separators() -> None:
     assert split_ncm_query("4903.90.00, 8417; 8501") == ["4903.90.00", "8417", "8501"]
+
+
+def test_split_ncm_query_discards_blank_segments() -> None:
+    assert split_ncm_query("   ") == []

--- a/tests/unit/test_nesh_sections.py
+++ b/tests/unit/test_nesh_sections.py
@@ -1,0 +1,113 @@
+import pytest
+
+from backend.utils.nesh_sections import _ChapterSectionParser, clean_markdown, extract_chapter_sections
+
+pytestmark = pytest.mark.unit
+
+
+def test_clean_markdown_removes_common_markup() -> None:
+    assert clean_markdown("**Texto** *itálico* _sub_") == "Texto itálico sub"
+
+
+def test_definition_continuation_detects_supported_patterns() -> None:
+    assert _ChapterSectionParser._is_definition_continuation("continua", False, "") is True
+    assert _ChapterSectionParser._is_definition_continuation("- item", False, "") is True
+    assert _ChapterSectionParser._is_definition_continuation("Linha", False, "prefixo:") is True
+    assert _ChapterSectionParser._is_definition_continuation("Linha", False, "") is False
+
+
+def test_parser_header_and_definition_state_transitions() -> None:
+    parser = _ChapterSectionParser()
+
+    assert parser._consume_headers("Notas.") is True
+    assert parser.current_section == "notas"
+    assert parser.titulo_captured is True
+
+    parser = _ChapterSectionParser()
+    assert parser._consume_headers("CONSIDERAÇÕES GERAIS") is True
+    assert parser.current_section == "consideracoes"
+
+    parser = _ChapterSectionParser()
+    assert parser._consume_definition_start("1) Item") is False
+    parser.current_section = "consideracoes"
+    assert parser._consume_definition_start("1) Item") is True
+    assert parser.current_section == "definicoes"
+    assert parser.section_lines["definicoes"] == ["1) Item"]
+
+
+def test_parser_definition_body_handles_continuation_and_fallback() -> None:
+    parser = _ChapterSectionParser()
+    parser.current_section = "definicoes"
+    parser.last_def_line = "1) Item:"
+    assert parser._consume_definition_body("continua em linha", False) is True
+    assert parser.section_lines["definicoes"] == ["continua em linha"]
+
+    parser.current_section = "definicoes"
+    parser.last_def_line = "1) Item"
+    assert parser._consume_definition_body("2) Outro item", False) is True
+    assert parser.section_lines["definicoes"][-1] == "2) Outro item"
+
+    parser.current_section = "definicoes"
+    parser.last_def_line = "1) Item"
+    assert parser._consume_definition_body("Linha sem continuidade.", False) is False
+    assert parser.current_section == "consideracoes"
+
+
+def test_parser_only_captures_title_once() -> None:
+    parser = _ChapterSectionParser()
+    assert parser._consume_title("Título do capítulo") is True
+    assert parser._consume_title("Outro título") is False
+    assert parser.section_lines["titulo"] == ["Título do capítulo"]
+
+
+def test_consume_line_and_build_cover_structured_sections() -> None:
+    parser = _ChapterSectionParser()
+
+    assert parser.consume_line("Capítulo 01") is False
+    assert parser.consume_line("   ") is False
+    assert parser.consume_line("Título do capítulo") is False
+    assert parser.consume_line("Notas.") is False
+    assert parser.consume_line("1.- Primeira nota.") is False
+    assert parser.consume_line("CONSIDERAÇÕES GERAIS") is False
+    assert parser.consume_line("1) Definição:") is False
+    assert parser.consume_line("continua em linha") is False
+    assert parser.consume_line("01.01 - posição") is True
+
+    sections = parser.build()
+    assert sections["titulo"] == "Título do capítulo"
+    assert "1.- Primeira nota." in sections["notas"]
+    assert "continua em linha" in sections["definicoes"]
+
+
+def test_build_collapses_triple_newlines() -> None:
+    parser = _ChapterSectionParser()
+    parser.section_lines["titulo"] = ["Linha 1", "", "", "Linha 2"]
+
+    assert parser.build()["titulo"] == "Linha 1\n\nLinha 2"
+
+
+def test_extract_chapter_sections_returns_structured_blocks() -> None:
+    content = "\n".join(
+        [
+            "Capítulo 10",
+            "Nome do capítulo",
+            "",
+            "Notas.",
+            "1.- Nota oficial.",
+            "",
+            "CONSIDERAÇÕES GERAIS",
+            "Texto introdutório.",
+            "",
+            "1) Definição:",
+            "continuação da definição",
+            "",
+            "10.01 - posição de corte",
+        ]
+    )
+
+    sections = extract_chapter_sections(content)
+
+    assert sections["titulo"] == "Nome do capítulo"
+    assert "Nota oficial." in sections["notas"]
+    assert "Texto introdutório." in sections["consideracoes"]
+    assert "continuação da definição" in sections["definicoes"]

--- a/tests/unit/test_nesh_sections.py
+++ b/tests/unit/test_nesh_sections.py
@@ -1,6 +1,10 @@
 import pytest
 
-from backend.utils.nesh_sections import _ChapterSectionParser, clean_markdown, extract_chapter_sections
+from backend.utils.nesh_sections import (
+    _ChapterSectionParser,
+    clean_markdown,
+    extract_chapter_sections,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -10,10 +14,19 @@ def test_clean_markdown_removes_common_markup() -> None:
 
 
 def test_definition_continuation_detects_supported_patterns() -> None:
-    assert _ChapterSectionParser._is_definition_continuation("continua", False, "") is True
-    assert _ChapterSectionParser._is_definition_continuation("- item", False, "") is True
-    assert _ChapterSectionParser._is_definition_continuation("Linha", False, "prefixo:") is True
-    assert _ChapterSectionParser._is_definition_continuation("Linha", False, "") is False
+    assert (
+        _ChapterSectionParser._is_definition_continuation("continua", False, "") is True
+    )
+    assert (
+        _ChapterSectionParser._is_definition_continuation("- item", False, "") is True
+    )
+    assert (
+        _ChapterSectionParser._is_definition_continuation("Linha", False, "prefixo:")
+        is True
+    )
+    assert (
+        _ChapterSectionParser._is_definition_continuation("Linha", False, "") is False
+    )
 
 
 def test_parser_header_and_definition_state_transitions() -> None:

--- a/tests/unit/test_nesh_service_additional.py
+++ b/tests/unit/test_nesh_service_additional.py
@@ -414,9 +414,7 @@ async def test_process_request_is_backward_compatible_alias(monkeypatch):
         _canonical,
     )
 
-    assert await service.executeNeshSearchWithVectorWeights("8517") == {
-        "origin": "canonical"
-    }
+    assert await service.process_request("8517") == {"origin": "canonical"}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_nesh_service_additional.py
+++ b/tests/unit/test_nesh_service_additional.py
@@ -43,7 +43,7 @@ def _disable_redis(monkeypatch):
 async def test_create_with_repository_raises_when_repo_is_unavailable(monkeypatch):
     monkeypatch.setattr(nesh_service_module, "_REPO_AVAILABLE", False)
     with pytest.raises(RuntimeError, match="Repository não disponível"):
-        await NeshService.create_with_repository()
+        await NeshService.initializeNeshServiceWithRepositoryFactory()
 
 
 def test_fts_cache_key_is_deterministic():
@@ -76,20 +76,20 @@ async def test_get_repo_supports_repository_factory_and_none():
 
 def test_strip_chapter_preamble_and_parse_notes():
     content = "Capítulo 85\nNotas iniciais\n85.17 - Conteúdo principal"
-    stripped = NeshService._strip_chapter_preamble(content)
+    stripped = NeshService.stripNeshChapterPreamble(content)
     assert stripped.startswith("85.17 -")
 
-    assert NeshService._strip_chapter_preamble("") == ""
+    assert NeshService.stripNeshChapterPreamble("") == ""
     assert (
-        NeshService._strip_chapter_preamble("Sem posição NCM aqui")
+        NeshService.stripNeshChapterPreamble("Sem posição NCM aqui")
         == "Sem posição NCM aqui"
     )
 
     service = NeshService(db=_FakeDb())
-    parsed = service.parse_chapter_notes("1 - Nota um\ncontinua\n2. Nota dois")
+    parsed = service.parseNeshChapterNotes("1 - Nota um\ncontinua\n2. Nota dois")
     assert parsed["1"].startswith("1 - Nota um")
     assert parsed["2"].startswith("2. Nota dois")
-    assert service.parse_chapter_notes("") == {}
+    assert service.parseNeshChapterNotes("") == {}
 
 
 @pytest.mark.asyncio
@@ -109,8 +109,8 @@ async def test_fetch_chapter_data_populates_cache_and_reuses_cached_value(monkey
     )
     service = NeshService(db=db)
 
-    first = await service.fetch_chapter_data("85")
-    second = await service.fetch_chapter_data("85")
+    first = await service.fetchNeshChapterData("85")
+    second = await service.fetchNeshChapterData("85")
 
     assert db.chapter_calls == 1
     assert first == second
@@ -143,8 +143,8 @@ async def test_fetch_chapter_data_uses_precomputed_json_and_fallback_parse(monke
     )
     service = NeshService(db=db)
 
-    chapter_85 = await service.fetch_chapter_data("85")
-    chapter_86 = await service.fetch_chapter_data("86")
+    chapter_85 = await service.fetchNeshChapterData("85")
+    chapter_86 = await service.fetchNeshChapterData("86")
 
     assert chapter_85["parsed_notes"] == {"1": "precomputada"}
     assert chapter_86["parsed_notes"]["1"].startswith("1 - Nota de fallback")
@@ -155,7 +155,7 @@ async def test_fetch_chapter_data_raises_when_db_adapter_is_missing(monkeypatch)
     _disable_redis(monkeypatch)
     service = NeshService(db=None)
     with pytest.raises(RuntimeError, match="DatabaseAdapter não configurado"):
-        await service.fetch_chapter_data("85")
+        await service.fetchNeshChapterData("85")
 
 
 def test_normalize_query_and_normalize_query_raw_apply_filters(monkeypatch):
@@ -165,7 +165,7 @@ def test_normalize_query_and_normalize_query_raw_apply_filters(monkeypatch):
     monkeypatch.setattr(
         service.processor, "process_query_for_fts", lambda _text: f"{tokens} w1*"
     )
-    normalized = service.normalize_query("qualquer")
+    normalized = service.normalizeNeshQuery("qualquer")
     assert len(normalized.split()) == 20
     assert normalized.split()[1] == "w1*"
 
@@ -173,7 +173,7 @@ def test_normalize_query_and_normalize_query_raw_apply_filters(monkeypatch):
         service.processor, "normalize", lambda _text: "de a x motor motor bomba"
     )
     monkeypatch.setattr(service.processor, "stopwords", {"de", "a"})
-    normalized_raw = service.normalize_query_raw("qualquer")
+    normalized_raw = service.normalizeNeshRawQuery("qualquer")
     assert normalized_raw == "motor* bomba*"
 
 
@@ -216,10 +216,10 @@ async def test_search_full_text_returns_none_match_when_query_becomes_empty(
     monkeypatch,
 ):
     service = NeshService(db=_FakeDb())
-    monkeypatch.setattr(service, "normalize_query", lambda _query: "")
-    monkeypatch.setattr(service, "normalize_query_raw", lambda _query: "")
+    monkeypatch.setattr(service, "normalizeNeshQuery", lambda _query: "")
+    monkeypatch.setattr(service, "normalizeNeshRawQuery", lambda _query: "")
 
-    payload = await service.search_full_text("x")
+    payload = await service.searchNeshByTextQuery("x")
 
     assert payload["match_type"] == "none"
     assert payload["results"] == []
@@ -234,8 +234,10 @@ async def test_search_full_text_combines_tiers_and_applies_near_bonus(monkeypatc
     )
     service = NeshService(db=db)
 
-    monkeypatch.setattr(service, "normalize_query", lambda _query: "motor* bomba*")
-    monkeypatch.setattr(service, "normalize_query_raw", lambda _query: "motor* bomba*")
+    monkeypatch.setattr(service, "normalizeNeshQuery", lambda _query: "motor* bomba*")
+    monkeypatch.setattr(
+        service, "normalizeNeshRawQuery", lambda _query: "motor* bomba*"
+    )
     monkeypatch.setattr(
         service.processor, "process_query_exact", lambda _query: "motor bomba"
     )
@@ -294,7 +296,7 @@ async def test_search_full_text_combines_tiers_and_applies_near_bonus(monkeypatc
 
     monkeypatch.setattr(service, "_fts_scored_cached", _fake_fts)
 
-    payload = await service.search_full_text("motor bomba")
+    payload = await service.searchNeshByTextQuery("motor bomba")
 
     assert payload["match_type"] == "exact"
     assert payload["warning"] is None
@@ -305,8 +307,8 @@ async def test_search_full_text_combines_tiers_and_applies_near_bonus(monkeypatc
 @pytest.mark.asyncio
 async def test_search_full_text_returns_warning_when_no_results(monkeypatch):
     service = NeshService(db=_FakeDb())
-    monkeypatch.setattr(service, "normalize_query", lambda _query: "foo*")
-    monkeypatch.setattr(service, "normalize_query_raw", lambda _query: "foo*")
+    monkeypatch.setattr(service, "normalizeNeshQuery", lambda _query: "foo*")
+    monkeypatch.setattr(service, "normalizeNeshRawQuery", lambda _query: "foo*")
     monkeypatch.setattr(service.processor, "process_query_exact", lambda _query: "foo")
     monkeypatch.setattr(service.processor, "process_query_for_fts", lambda _word: None)
 
@@ -315,7 +317,7 @@ async def test_search_full_text_returns_warning_when_no_results(monkeypatch):
 
     monkeypatch.setattr(service, "_fts_scored_cached", _empty_fts)
 
-    payload = await service.search_full_text("foo")
+    payload = await service.searchNeshByTextQuery("foo")
 
     assert payload["match_type"] == "none"
     assert "Nenhum resultado encontrado" in payload["warning"]
@@ -357,9 +359,9 @@ async def test_search_by_code_builds_found_and_not_found_chapters(monkeypatch):
             }
         return None
 
-    monkeypatch.setattr(service, "fetch_chapter_data", _fake_fetch)
+    monkeypatch.setattr(service, "fetchNeshChapterData", _fake_fetch)
 
-    payload = await service.search_by_code("8517,invalido,7301")
+    payload = await service.searchNeshByNcmCode("8517,invalido,7301")
 
     assert payload["type"] == "code"
     assert payload["total_capitulos"] == 2
@@ -381,8 +383,8 @@ async def test_execute_nesh_search_with_vector_weights_dispatches_between_code_a
     async def _search_full_text(_query):
         return {"origin": "text"}
 
-    monkeypatch.setattr(service, "search_by_code", _search_by_code)
-    monkeypatch.setattr(service, "search_full_text", _search_full_text)
+    monkeypatch.setattr(service, "searchNeshByNcmCode", _search_by_code)
+    monkeypatch.setattr(service, "searchNeshByTextQuery", _search_full_text)
 
     monkeypatch.setattr(
         nesh_service_module.ncm_utils, "is_code_query", lambda _query: True
@@ -412,13 +414,15 @@ async def test_process_request_is_backward_compatible_alias(monkeypatch):
         _canonical,
     )
 
-    assert await service.process_request("8517") == {"origin": "canonical"}
+    assert await service.executeNeshSearchWithVectorWeights("8517") == {
+        "origin": "canonical"
+    }
 
 
 @pytest.mark.asyncio
 async def test_prewarm_cache_covers_empty_sources_and_exception_path(monkeypatch):
     service_without_sources = NeshService(db=None)
-    assert await service_without_sources.prewarm_cache() == 0
+    assert await service_without_sources.prewarmNeshChapterCache() == 0
 
     service = NeshService(db=_FakeDb())
     calls = []
@@ -428,8 +432,8 @@ async def test_prewarm_cache_covers_empty_sources_and_exception_path(monkeypatch
         if chapter_num == "02":
             raise RuntimeError("boom")
 
-    monkeypatch.setattr(service, "fetch_chapter_data", _fake_fetch)
-    warmed = await service.prewarm_cache(["01", "02", "03"], concurrency=2)
+    monkeypatch.setattr(service, "fetchNeshChapterData", _fake_fetch)
+    warmed = await service.prewarmNeshChapterCache(["01", "02", "03"], concurrency=2)
 
     assert warmed == 3
     assert calls == ["01", "02", "03"]
@@ -443,7 +447,7 @@ async def test_get_internal_cache_metrics_returns_current_snapshots():
     service._chapter_cache_metrics.record_hit()
     service._fts_cache_metrics.record_miss()
 
-    payload = await service.get_internal_cache_metrics()
+    payload = await service.snapshotNeshInternalCacheMetrics()
 
     assert payload["chapter_cache"]["current_size"] == 1
     assert payload["chapter_cache"]["hits"] >= 1

--- a/tests/unit/test_test_support.py
+++ b/tests/unit/test_test_support.py
@@ -58,9 +58,10 @@ def test_sqlite_test_environment_overrides_and_restores_services_filename():
     assert settings.database.services_filename == original_services_filename
 
 
-def test_close_shared_db_engine_resets_tipi_pool_lock(monkeypatch):
+def test_close_shared_db_engine_resets_tipi_pool_state(monkeypatch):
     class _TipiServiceStub:
-        _pool_lock = object()
+        _tipi_connection_pools = {"pool": object()}
+        _tipi_connection_pool_locks = {1: object()}
 
         @classmethod
         async def close_all_pools(cls):
@@ -79,7 +80,8 @@ def test_close_shared_db_engine_resets_tipi_pool_lock(monkeypatch):
 
     test_support._close_shared_db_engine()
 
-    assert _TipiServiceStub._pool_lock is None
+    assert _TipiServiceStub._tipi_connection_pools == {}
+    assert _TipiServiceStub._tipi_connection_pool_locks == {}
 
 
 async def _async_noop():

--- a/tests/unit/test_tipi_renderer_ids.py
+++ b/tests/unit/test_tipi_renderer_ids.py
@@ -61,7 +61,9 @@ async def test_renderer_outputs_compatible_ids():
         ("abc", "aliquot-zero"),
     ],
 )
-def test_get_aliquot_class_covers_all_ranges(aliquota: str, expected_class: str) -> None:
+def test_get_aliquot_class_covers_all_ranges(
+    aliquota: str, expected_class: str
+) -> None:
     assert TipiRenderer.get_aliquot_class(aliquota) == expected_class
 
 
@@ -76,7 +78,7 @@ def test_render_position_and_chapter_variants() -> None:
         }
     )
     assert 'id="pos-85-17"' in position_html
-    assert 'tipi-nivel-5' in position_html
+    assert "tipi-nivel-5" in position_html
     assert 'data-tooltip="Alíquota Média (6-10%)"' in position_html
     assert ">7%<" in position_html
 
@@ -89,7 +91,7 @@ def test_render_position_and_chapter_variants() -> None:
         }
     )
     assert 'aria-label="NCM 85.18"' in empty_aliquota_html
-    assert 'tipi-nivel-0' in empty_aliquota_html
+    assert "tipi-nivel-0" in empty_aliquota_html
 
     chapter_html = TipiRenderer.render_chapter(
         {"capitulo": "85", "titulo": "Capítulo 85", "posicoes": []}
@@ -99,7 +101,9 @@ def test_render_position_and_chapter_variants() -> None:
 
 
 @pytest.mark.unit
-def test_render_full_response_and_text_results_handle_empty_and_populated_inputs() -> None:
+def test_render_full_response_and_text_results_handle_empty_and_populated_inputs() -> (
+    None
+):
     assert (
         TipiRenderer.render_full_response({})
         == '<p class="empty">Nenhum resultado encontrado na TIPI.</p>'
@@ -126,7 +130,7 @@ def test_render_full_response_and_text_results_handle_empty_and_populated_inputs
         }
     )
     assert 'id="cap-85"' in full_html
-    assert 'aliquot-nt' in full_html
+    assert "aliquot-nt" in full_html
 
     text_html = TipiRenderer.render_text_results(
         [

--- a/tests/unit/test_tipi_renderer_ids.py
+++ b/tests/unit/test_tipi_renderer_ids.py
@@ -5,7 +5,14 @@ from pathlib import Path
 
 import pytest
 from backend.presentation.tipi_renderer import TipiRenderer
+from backend.presentation.renderer import HtmlRenderer
 from backend.services.tipi_service import TipiService
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_renderer_highlights(monkeypatch):
+    monkeypatch.setattr(HtmlRenderer, "inject_exclusion_highlights", lambda text: text)
+    monkeypatch.setattr(HtmlRenderer, "inject_unit_highlights", lambda text: text)
 
 
 @pytest.mark.asyncio
@@ -26,8 +33,8 @@ async def test_renderer_outputs_compatible_ids():
         conn.close()
 
         svc = TipiService(db_path=Path(path))
-        resp = await svc.search_by_code("85")
-        await svc.close()  # Good practice to close
+        resp = await svc.searchTipiByNcmCode("85")
+        await svc.closeTipiConnectionPool()  # Good practice to close
 
         html = TipiRenderer.render_full_response(resp["resultados"])
 
@@ -38,3 +45,99 @@ async def test_renderer_outputs_compatible_ids():
             os.unlink(path)
         except OSError:
             pass
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("aliquota", "expected_class"),
+    [
+        ("", "aliquot-zero"),
+        ("0", "aliquot-zero"),
+        ("0%", "aliquot-zero"),
+        ("NT", "aliquot-nt"),
+        ("3", "aliquot-low"),
+        ("7", "aliquot-med"),
+        ("12", "aliquot-high"),
+        ("abc", "aliquot-zero"),
+    ],
+)
+def test_get_aliquot_class_covers_all_ranges(aliquota: str, expected_class: str) -> None:
+    assert TipiRenderer.get_aliquot_class(aliquota) == expected_class
+
+
+@pytest.mark.unit
+def test_render_position_and_chapter_variants() -> None:
+    position_html = TipiRenderer.render_position(
+        {
+            "codigo": "85.17",
+            "descricao": "Aparelho telefônico",
+            "aliquota": "7",
+            "nivel": 8,
+        }
+    )
+    assert 'id="pos-85-17"' in position_html
+    assert 'tipi-nivel-5' in position_html
+    assert 'data-tooltip="Alíquota Média (6-10%)"' in position_html
+    assert ">7%<" in position_html
+
+    empty_aliquota_html = TipiRenderer.render_position(
+        {
+            "ncm": "85.18",
+            "descricao": "Outro item",
+            "aliquota": "",
+            "nivel": 0,
+        }
+    )
+    assert 'aria-label="NCM 85.18"' in empty_aliquota_html
+    assert 'tipi-nivel-0' in empty_aliquota_html
+
+    chapter_html = TipiRenderer.render_chapter(
+        {"capitulo": "85", "titulo": "Capítulo 85", "posicoes": []}
+    )
+    assert 'id="cap-85"' in chapter_html
+    assert "Capítulo 85" in chapter_html
+
+
+@pytest.mark.unit
+def test_render_full_response_and_text_results_handle_empty_and_populated_inputs() -> None:
+    assert (
+        TipiRenderer.render_full_response({})
+        == '<p class="empty">Nenhum resultado encontrado na TIPI.</p>'
+    )
+    assert (
+        TipiRenderer.render_text_results([])
+        == '<p class="empty">Nenhum resultado encontrado.</p>'
+    )
+
+    full_html = TipiRenderer.render_full_response(
+        {
+            "85": {
+                "capitulo": "85",
+                "titulo": "Capítulo 85",
+                "posicoes": [
+                    {
+                        "codigo": "85.17",
+                        "descricao": "Aparelho telefônico",
+                        "aliquota": "NT",
+                        "nivel": 1,
+                    }
+                ],
+            }
+        }
+    )
+    assert 'id="cap-85"' in full_html
+    assert 'aliquot-nt' in full_html
+
+    text_html = TipiRenderer.render_text_results(
+        [
+            {
+                "ncm": "85.17",
+                "capitulo": "85",
+                "descricao": "Aparelho telefônico",
+                "aliquota": "0",
+            }
+        ]
+    )
+    assert 'class="tipi-results-list"' in text_html
+    assert 'data-ncm="85.17"' in text_html
+    assert ">0%<" in text_html

--- a/tests/unit/test_tipi_route_cache_key_normalization.py
+++ b/tests/unit/test_tipi_route_cache_key_normalization.py
@@ -1,22 +1,22 @@
-"""Tests for search-route cache-key normalization."""
+"""Tests for TIPI-route cache-key normalization and request validation."""
 
 import pytest
 from starlette.requests import Request
 
-from backend.config.constants import SearchConfig
+from backend.config.constants import SearchConfig, ViewMode
 from backend.config.exceptions import ValidationError
-from backend.presentation.routes.search import (
-    _build_search_payload_cache_context,
-    _normalize_search_query_for_cache_key,
-    _request_accepts_gzip_encoding,
-    _validate_public_search_query_input,
+from backend.presentation.routes.tipi import (
+    _build_tipi_payload_cache_context,
+    _normalize_tipi_query_for_cache_key,
+    _request_accepts_tipi_gzip_encoding,
+    _validate_tipi_search_query_input,
 )
 from backend.utils.cache import weak_etag
 from backend.utils.ncm_utils import is_code_query
 
 
 def _normalize_query(ncm: str) -> str:
-    return _normalize_search_query_for_cache_key(
+    return _normalize_tipi_query_for_cache_key(
         ncm, is_code_query=is_code_query(ncm)
     )
 
@@ -25,13 +25,13 @@ def _build_request_with_accept_encoding(value: str) -> Request:
     scope = {
         "type": "http",
         "method": "GET",
-        "path": "/api/search",
+        "path": "/api/tipi/search",
         "headers": [(b"accept-encoding", value.encode("latin-1"))],
     }
     return Request(scope)
 
 
-class TestCodeQueryNormalization:
+class TestTipiCodeQueryNormalization:
     def test_dotted_and_plain_same_key(self):
         assert _normalize_query("85.17") == _normalize_query("8517") == "8517"
 
@@ -51,12 +51,12 @@ class TestCodeQueryNormalization:
 
     def test_etag_differs_for_multi_code_and_single_code(self):
         scope = "public"
-        etag_multi = weak_etag("nesh", scope, _normalize_query("85,17"))
-        etag_single = weak_etag("nesh", scope, _normalize_query("8517"))
+        etag_multi = weak_etag("tipi", scope, _normalize_query("85,17"))
+        etag_single = weak_etag("tipi", scope, _normalize_query("8517"))
         assert etag_multi != etag_single
 
 
-class TestTextQueryNormalization:
+class TestTipiTextQueryNormalization:
     def test_case_insensitive(self):
         assert _normalize_query("Capacitor") == _normalize_query("capacitor")
 
@@ -70,64 +70,67 @@ class TestTextQueryNormalization:
         assert _normalize_query("capacitor") != _normalize_query("resistor")
 
 
-class TestAcceptsGzip:
+class TestTipiAcceptsGzip:
     def test_accepts_plain_gzip(self):
         request = _build_request_with_accept_encoding("gzip")
-        assert _request_accepts_gzip_encoding(request) is True
+        assert _request_accepts_tipi_gzip_encoding(request) is True
 
     def test_rejects_gzip_with_zero_quality(self):
         request = _build_request_with_accept_encoding("gzip;q=0")
-        assert _request_accepts_gzip_encoding(request) is False
+        assert _request_accepts_tipi_gzip_encoding(request) is False
 
     def test_accepts_wildcard_with_positive_quality(self):
         request = _build_request_with_accept_encoding("*;q=1")
-        assert _request_accepts_gzip_encoding(request) is True
+        assert _request_accepts_tipi_gzip_encoding(request) is True
 
     def test_rejects_gzip_and_wildcard_with_zero_quality(self):
         request = _build_request_with_accept_encoding("gzip;q=0,*;q=0")
-        assert _request_accepts_gzip_encoding(request) is False
+        assert _request_accepts_tipi_gzip_encoding(request) is False
 
 
-class TestPublicSearchQueryValidation:
+class TestPublicTipiSearchQueryValidation:
     def test_rejects_empty_query(self):
         with pytest.raises(ValidationError, match="Parâmetro 'ncm' é obrigatório"):
-            _validate_public_search_query_input("")
+            _validate_tipi_search_query_input("")
 
     def test_rejects_query_above_max_length(self):
         too_long = "x" * (SearchConfig.MAX_QUERY_LENGTH + 1)
         with pytest.raises(ValidationError, match="Query muito longa"):
-            _validate_public_search_query_input(too_long)
+            _validate_tipi_search_query_input(too_long)
 
     def test_accepts_non_empty_query_within_limits(self):
-        _validate_public_search_query_input("8517")
+        _validate_tipi_search_query_input("8517")
 
 
-class TestSearchPayloadCacheContext:
+class TestTipiPayloadCacheContext:
     def test_builds_code_query_context(self):
         request = _build_request_with_accept_encoding("gzip")
 
-        context = _build_search_payload_cache_context(
+        context = _build_tipi_payload_cache_context(
             request,
             ncm="85.17",
+            view_mode=ViewMode.FAMILY,
         )
 
         assert context.is_code_query is True
         assert context.normalized_query == "8517"
-        assert context.build_code_payload_cache_key(shape="full").endswith(
-            ":8517:full"
+        assert context.build_code_payload_cache_key().endswith(":family:8517")
+        assert (
+            context.cache_headers["Vary"]
+            == "Authorization, X-Tenant-Id, Accept-Encoding"
         )
-        assert context.cache_headers["Vary"] == "Authorization, X-Tenant-Id, Accept-Encoding"
 
-    def test_builds_text_query_context_without_payload_key(self):
+    def test_builds_text_query_context(self):
         request = _build_request_with_accept_encoding("gzip")
 
-        context = _build_search_payload_cache_context(
+        context = _build_tipi_payload_cache_context(
             request,
             ncm="motor de arranque",
+            view_mode=ViewMode.CHAPTER,
         )
 
         assert context.is_code_query is False
         assert context.normalized_query == "motor de arranque"
-        assert context.build_code_payload_cache_key(shape="summary").endswith(
-            ":motor de arranque:summary"
+        assert context.build_code_payload_cache_key().endswith(
+            ":chapter:motor de arranque"
         )

--- a/tests/unit/test_tipi_route_cache_key_normalization.py
+++ b/tests/unit/test_tipi_route_cache_key_normalization.py
@@ -16,9 +16,7 @@ from backend.utils.ncm_utils import is_code_query
 
 
 def _normalize_query(ncm: str) -> str:
-    return _normalize_tipi_query_for_cache_key(
-        ncm, is_code_query=is_code_query(ncm)
-    )
+    return _normalize_tipi_query_for_cache_key(ncm, is_code_query=is_code_query(ncm))
 
 
 def _build_request_with_accept_encoding(value: str) -> Request:

--- a/tests/unit/test_tipi_route_highlights.py
+++ b/tests/unit/test_tipi_route_highlights.py
@@ -1,12 +1,12 @@
 """
 Testes para validar que a rota TIPI aplica highlights nas descrições antes de retornar JSON.
-Testa a função _apply_highlights_to_descriptions isoladamente.
+Testa a função _apply_tipi_description_highlights isoladamente.
 """
 
-from backend.presentation.routes.tipi import _apply_highlights_to_descriptions
+from backend.presentation.routes.tipi import _apply_tipi_description_highlights
 
 
-class TestApplyHighlightsToDescriptions:
+class TestApplyTipiDescriptionHighlights:
     """Testa a transformação de descrições no resultado da rota TIPI."""
 
     def test_code_search_applies_unit_highlights(self):
@@ -32,7 +32,7 @@ class TestApplyHighlightsToDescriptions:
                 }
             },
         }
-        _apply_highlights_to_descriptions(result)
+        _apply_tipi_description_highlights(result)
         desc1 = result["results"]["85"]["posicoes"][0]["descricao"]
         desc2 = result["results"]["85"]["posicoes"][1]["descricao"]
         assert 'highlight-unit">W</span>' in desc1
@@ -51,7 +51,7 @@ class TestApplyHighlightsToDescriptions:
                 },
             ],
         }
-        _apply_highlights_to_descriptions(result)
+        _apply_tipi_description_highlights(result)
         assert 'highlight-unit">W</span>' in result["results"][0]["descricao"]
         assert 'highlight-unit">kW</span>' in result["results"][1]["descricao"]
 
@@ -72,20 +72,20 @@ class TestApplyHighlightsToDescriptions:
                 }
             },
         }
-        _apply_highlights_to_descriptions(result)
+        _apply_tipi_description_highlights(result)
         desc = result["results"]["84"]["posicoes"][0]["descricao"]
         assert "highlight-exclusion" in desc
 
     def test_empty_results_no_error(self):
         """Resultado vazio não deve causar erro."""
         result = {"type": "code", "results": {}}
-        _apply_highlights_to_descriptions(result)
+        _apply_tipi_description_highlights(result)
         assert result["results"] == {}
 
     def test_none_results_no_error(self):
         """Resultado None não deve causar erro."""
         result = {"type": "code"}
-        _apply_highlights_to_descriptions(result)
+        _apply_tipi_description_highlights(result)
 
     def test_empty_description_no_error(self):
         """Descrição vazia não deve causar erro."""
@@ -99,7 +99,7 @@ class TestApplyHighlightsToDescriptions:
                 }
             },
         }
-        _apply_highlights_to_descriptions(result)
+        _apply_tipi_description_highlights(result)
         assert result["results"]["01"]["posicoes"][0]["descricao"] == ""
 
     def test_no_units_no_highlights(self):
@@ -110,7 +110,7 @@ class TestApplyHighlightsToDescriptions:
                 {"ncm": "0101", "descricao": "Cavalos vivos", "aliquota": "0"},
             ],
         }
-        _apply_highlights_to_descriptions(result)
+        _apply_tipi_description_highlights(result)
         assert result["results"][0]["descricao"] == "Cavalos vivos"
 
     def test_new_units_applied(self):
@@ -127,7 +127,7 @@ class TestApplyHighlightsToDescriptions:
                 {"ncm": "8414", "descricao": "Pressão de 30 psi", "aliquota": "10"},
             ],
         }
-        _apply_highlights_to_descriptions(result)
+        _apply_tipi_description_highlights(result)
         assert 'highlight-unit">dB</span>' in result["results"][0]["descricao"]
         assert 'highlight-unit">kΩ</span>' in result["results"][1]["descricao"]
         assert 'highlight-unit">psi</span>' in result["results"][2]["descricao"]

--- a/tests/unit/test_tipi_service_additional.py
+++ b/tests/unit/test_tipi_service_additional.py
@@ -250,6 +250,38 @@ async def test_close_all_pools_closes_connections_across_paths(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_close_all_pools_warns_about_other_loop_pools(tmp_path, monkeypatch):
+    current_conn = _FakeConn()
+    leftover_conn = _FakeConn()
+    current_loop_id = id(asyncio.get_running_loop())
+    other_loop_id = current_loop_id + 1
+    TipiService._tipi_connection_pools = {
+        (tmp_path / "current.db", current_loop_id): [current_conn],
+        (tmp_path / "leftover.db", other_loop_id): [leftover_conn],
+    }
+    warnings: list[tuple[str, object]] = []
+
+    def _capture_warning(message: str, payload: object) -> None:
+        warnings.append((message, payload))
+
+    monkeypatch.setattr(tipi_module.logger, "warning", _capture_warning)
+
+    await TipiService.close_all_pools()
+
+    assert current_conn.closed is True
+    assert leftover_conn.closed is False
+    assert list(TipiService._tipi_connection_pools) == [
+        (tmp_path / "leftover.db", other_loop_id)
+    ]
+    assert warnings == [
+        (
+            "TIPI connection pools for other event loops were left open: %s",
+            {other_loop_id: 1},
+        )
+    ]
+
+
+@pytest.mark.asyncio
 async def test_check_connection_returns_error_when_db_missing(tmp_path):
     service = TipiService(db_path=tmp_path / "missing-tipi.db")
     payload = await service.check_connection()

--- a/tests/unit/test_tipi_service_additional.py
+++ b/tests/unit/test_tipi_service_additional.py
@@ -12,11 +12,11 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture(autouse=True)
 def _reset_pool_state():
-    TipiService._pool = {}
-    TipiService._pool_lock = None
+    TipiService._tipi_connection_pools = {}
+    TipiService._tipi_connection_pool_lock = None
     yield
-    TipiService._pool = {}
-    TipiService._pool_lock = None
+    TipiService._tipi_connection_pools = {}
+    TipiService._tipi_connection_pool_lock = None
 
 
 class _FakeCursor:
@@ -134,7 +134,7 @@ async def test_create_with_repository_success_uses_factory(monkeypatch):
     monkeypatch.setattr(tipi_module, "TipiRepository", _RepoFromFactory)
 
     service = await TipiService.create_with_repository()
-    async with service._get_repo() as repo:
+    async with service._acquire_tipi_repository() as repo:
         assert isinstance(repo, _RepoFromFactory)
         assert repo.session == "session-1"
 
@@ -142,7 +142,7 @@ async def test_create_with_repository_success_uses_factory(monkeypatch):
 @pytest.mark.asyncio
 async def test_get_repo_handles_direct_factory_and_none():
     direct = TipiService(repository="direct-repo")
-    async with direct._get_repo() as repo:
+    async with direct._acquire_tipi_repository() as repo:
         assert repo == "direct-repo"
 
     @asynccontextmanager
@@ -150,11 +150,11 @@ async def test_get_repo_handles_direct_factory_and_none():
         yield "factory-repo"
 
     from_factory = TipiService(repository_factory=_factory)
-    async with from_factory._get_repo() as repo:
+    async with from_factory._acquire_tipi_repository() as repo:
         assert repo == "factory-repo"
 
     no_repo = TipiService()
-    async with no_repo._get_repo() as repo:
+    async with no_repo._acquire_tipi_repository() as repo:
         assert repo is None
 
 
@@ -168,16 +168,16 @@ async def test_get_connection_raises_database_error_when_connect_fails(monkeypat
     monkeypatch.setattr(tipi_module.aiosqlite, "connect", _boom)
 
     with pytest.raises(DatabaseError, match="TIPI DB connection failed"):
-        await service._get_connection()
+        await service._acquire_tipi_connection()
 
 
 @pytest.mark.asyncio
 async def test_release_connection_closes_when_pool_is_full_and_close_fails(monkeypatch):
     service = TipiService()
     conn = _FakeConn(close_error=RuntimeError("close failed"))
-    monkeypatch.setattr(service, "_pool_max_size", 0)
+    monkeypatch.setattr(service, "_tipi_connection_pool_max_size", 0)
 
-    await service._release_connection(conn)
+    await service._release_tipi_connection(conn)
     assert conn.closed is True
 
 
@@ -185,11 +185,11 @@ async def test_release_connection_closes_when_pool_is_full_and_close_fails(monke
 async def test_close_handles_pool_connection_close_errors():
     service = TipiService()
     failing_conn = _FakeConn(close_error=RuntimeError("boom"))
-    TipiService._pool = {service.db_path: [failing_conn]}
+    TipiService._tipi_connection_pools = {service.db_path: [failing_conn]}
 
     await service.close()
 
-    assert TipiService._pool == {}
+    assert TipiService._tipi_connection_pools == {}
     assert failing_conn.closed is True
 
 
@@ -218,10 +218,10 @@ async def test_connection_pool_is_scoped_by_resolved_db_path(monkeypatch, tmp_pa
     assert first_service.db_path == first_path.resolve()
     assert second_service.db_path == second_path.resolve()
 
-    first_conn = await first_service._get_connection()
-    await first_service._release_connection(first_conn)
+    first_conn = await first_service._acquire_tipi_connection()
+    await first_service._release_tipi_connection(first_conn)
 
-    second_conn = await second_service._get_connection()
+    second_conn = await second_service._acquire_tipi_connection()
 
     assert second_conn is not first_conn
     assert second_conn.path == second_path.resolve()
@@ -234,14 +234,14 @@ async def test_close_all_pools_closes_connections_across_paths(tmp_path):
     second_service = TipiService(db_path=tmp_path / "tipi-b.db")
     first_conn = _FakeConn()
     second_conn = _FakeConn()
-    TipiService._pool = {
+    TipiService._tipi_connection_pools = {
         first_service.db_path: [first_conn],
         second_service.db_path: [second_conn],
     }
 
     await TipiService.close_all_pools()
 
-    assert TipiService._pool == {}
+    assert TipiService._tipi_connection_pools == {}
     assert first_conn.closed is True
     assert second_conn.closed is True
 
@@ -263,7 +263,7 @@ async def test_check_connection_returns_error_when_query_fails(tmp_path, monkeyp
     async def _boom():
         raise RuntimeError("db broken")
 
-    monkeypatch.setattr(service, "_get_connection", _boom)
+    monkeypatch.setattr(service, "_acquire_tipi_connection", _boom)
     payload = await service.check_connection()
 
     assert payload["ok"] is False
@@ -287,8 +287,8 @@ async def test_get_table_columns_uses_cache(monkeypatch):
     service = TipiService()
     conn = _FakeConn(scripted_rows=[[{"name": "ncm_sort"}, {"name": "ncm"}]])
 
-    first = await service._get_table_columns(conn, "tipi_positions")
-    second = await service._get_table_columns(conn, "tipi_positions")
+    first = await service._load_tipi_table_columns(conn, "tipi_positions")
+    second = await service._load_tipi_table_columns(conn, "tipi_positions")
 
     assert first == {"ncm_sort", "ncm"}
     assert second == {"ncm_sort", "ncm"}
@@ -301,7 +301,7 @@ async def test_get_table_columns_rejects_unknown_table():
     conn = _FakeConn()
 
     with pytest.raises(ValueError, match="Tabela não permitida"):
-        await service._get_table_columns(conn, "users")
+        await service._load_tipi_table_columns(conn, "users")
 
 
 @pytest.mark.asyncio
@@ -351,8 +351,8 @@ async def test_get_chapter_positions_sqlite_mode_evicts_cache(monkeypatch):
     async def _fake_release(_conn):
         return None
 
-    monkeypatch.setattr(service, "_get_connection", _fake_get_connection)
-    monkeypatch.setattr(service, "_release_connection", _fake_release)
+    monkeypatch.setattr(service, "_acquire_tipi_connection", _fake_get_connection)
+    monkeypatch.setattr(service, "_release_tipi_connection", _fake_release)
     monkeypatch.setattr(tipi_module.CacheConfig, "TIPI_CHAPTER_CACHE_SIZE", 0)
 
     rows = await service._get_chapter_positions("85")
@@ -398,7 +398,7 @@ async def test_search_by_code_handles_multi_part_merge_with_same_chapter(monkeyp
     monkeypatch.setattr(service, "_get_family_positions", _fake_family)
     monkeypatch.setattr(service, "_get_chapter_positions", _fake_chapter)
 
-    payload = await service.search_by_code("85,8517", view_mode="family")
+    payload = await service.searchTipiByNcmCode("85,8517", view_mode="family")
 
     cap = payload["resultados"]["85"]
     assert payload["total"] == 2
@@ -424,7 +424,7 @@ async def test_search_by_code_cache_returns_isolated_payloads(monkeypatch):
 
     monkeypatch.setattr(service, "_get_chapter_positions", _fake_chapter_positions)
 
-    first = await service.search_by_code("85")
+    first = await service.searchTipiByNcmCode("85")
     first["resultados"]["85"]["posicoes"].append(
         {
             "ncm": "85.99",
@@ -436,7 +436,7 @@ async def test_search_by_code_cache_returns_isolated_payloads(monkeypatch):
         }
     )
 
-    second = await service.search_by_code("85")
+    second = await service.searchTipiByNcmCode("85")
     assert [item["ncm"] for item in second["resultados"]["85"]["posicoes"]] == ["85.17"]
 
     second["resultados"]["85"]["posicoes"].append(
@@ -450,7 +450,7 @@ async def test_search_by_code_cache_returns_isolated_payloads(monkeypatch):
         }
     )
 
-    third = await service.search_by_code("85")
+    third = await service.searchTipiByNcmCode("85")
     assert [item["ncm"] for item in third["resultados"]["85"]["posicoes"]] == ["85.17"]
 
 
@@ -515,9 +515,11 @@ async def test_search_multiple_codes_deduplicates_positions_and_totals(monkeypat
             "total_capitulos": 1,
         }
 
-    monkeypatch.setattr(service, "search_by_code", _fake_search_by_code)
+    monkeypatch.setattr(service, "searchTipiByNcmCode", _fake_search_by_code)
 
-    payload = await service._search_multiple_codes("85,8517", "family", ["85", "8517"])
+    payload = await service._search_tipi_multi_code_parts(
+        "85,8517", "family", ["85", "8517"]
+    )
 
     assert payload["total"] == 2
     assert [item["ncm"] for item in payload["resultados"]["85"]["posicoes"]] == [
@@ -561,9 +563,11 @@ async def test_search_multiple_codes_prefers_more_specific_posicao_alvo(monkeypa
             "total_capitulos": 1,
         }
 
-    monkeypatch.setattr(service, "search_by_code", _fake_search_by_code)
+    monkeypatch.setattr(service, "searchTipiByNcmCode", _fake_search_by_code)
 
-    payload = await service._search_multiple_codes("85,8517", "family", ["85", "8517"])
+    payload = await service._search_tipi_multi_code_parts(
+        "85,8517", "family", ["85", "8517"]
+    )
 
     assert payload["resultados"]["85"]["posicao_alvo"] == "85.17"
 
@@ -590,10 +594,12 @@ async def test_search_by_code_caches_multi_code_payload(monkeypatch):
             "total_capitulos": 1,
         }
 
-    monkeypatch.setattr(service, "_search_multiple_codes", _fake_search_multiple_codes)
+    monkeypatch.setattr(
+        service, "_search_tipi_multi_code_parts", _fake_search_multiple_codes
+    )
 
-    first = await service.search_by_code("85,8517", view_mode="family")
-    second = await service.search_by_code("85,8517", view_mode="family")
+    first = await service.searchTipiByNcmCode("85,8517", view_mode="family")
+    second = await service.searchTipiByNcmCode("85,8517", view_mode="family")
 
     assert calls == 1
     assert first == second
@@ -630,11 +636,13 @@ async def test_search_by_code_deduplicates_multi_code_parts(monkeypatch):
         format_calls.append(value)
         return "85.17"
 
-    monkeypatch.setattr(service, "_search_multiple_codes", _fake_search_multiple_codes)
+    monkeypatch.setattr(
+        service, "_search_tipi_multi_code_parts", _fake_search_multiple_codes
+    )
     monkeypatch.setattr(service, "_get_family_positions", _fake_family_positions)
     monkeypatch.setattr(tipi_module.ncm_utils, "format_ncm_tipi", _fake_format_ncm_tipi)
 
-    payload = await service.search_by_code("85.17,8517", view_mode="family")
+    payload = await service.searchTipiByNcmCode("85.17,8517", view_mode="family")
 
     assert payload["query"] == "85.17,8517"
     assert payload["total"] == 1
@@ -662,9 +670,11 @@ async def test_search_by_code_caps_multi_code_parts(monkeypatch):
             "total_capitulos": 0,
         }
 
-    monkeypatch.setattr(service, "_search_multiple_codes", _fake_search_multiple_codes)
+    monkeypatch.setattr(
+        service, "_search_tipi_multi_code_parts", _fake_search_multiple_codes
+    )
 
-    payload = await service.search_by_code(
+    payload = await service.searchTipiByNcmCode(
         ",".join(f"{number:02d}" for number in range(1, 31)),
         view_mode="family",
     )
@@ -678,7 +688,7 @@ async def test_search_by_code_returns_empty_when_query_has_no_digits(monkeypatch
     monkeypatch.setattr(tipi_module.ncm_utils, "format_ncm_tipi", lambda _value: "")
     monkeypatch.setattr(tipi_module.ncm_utils, "clean_ncm", lambda _value: "")
 
-    payload = await service.search_by_code("abc")
+    payload = await service.searchTipiByNcmCode("abc")
 
     assert payload["total"] == 0
     assert payload["resultados"] == {}
@@ -702,7 +712,7 @@ async def test_search_by_code_evicts_code_cache_when_limit_is_zero(monkeypatch):
     monkeypatch.setattr(service, "_get_chapter_positions", _fake_chapter_positions)
     monkeypatch.setattr(tipi_module.CacheConfig, "TIPI_RESULT_CACHE_SIZE", 0)
 
-    payload = await service.search_by_code("85")
+    payload = await service.searchTipiByNcmCode("85")
     assert payload["total"] == 1
     assert service._code_search_cache == {}
 
@@ -726,17 +736,17 @@ async def test_search_by_code_cache_respects_exact_capacity(monkeypatch):
     monkeypatch.setattr(service, "_get_chapter_positions", _fake_chapter_positions)
     monkeypatch.setattr(tipi_module.CacheConfig, "TIPI_RESULT_CACHE_SIZE", 1)
 
-    await service.search_by_code("85")
+    await service.searchTipiByNcmCode("85")
     assert list(service._code_search_cache.keys()) == [("85", "family")]
 
-    await service.search_by_code("84")
+    await service.searchTipiByNcmCode("84")
     assert list(service._code_search_cache.keys()) == [("84", "family")]
 
 
 @pytest.mark.asyncio
 async def test_search_text_repository_mode_returns_repo_payload():
     service = TipiService(repository=_FakeRepo())
-    payload = await service.search_text("telefone", limit=10)
+    payload = await service.searchTipiByTextQuery("telefone", limit=10)
     assert payload["type"] == "text"
     assert payload["total"] == 1
     assert payload["results"][0]["ncm"] == "85.17"
@@ -778,10 +788,10 @@ async def test_search_text_sqlite_mode_runs_and_query_fallback(monkeypatch):
     async def _fake_release(_conn):
         return None
 
-    monkeypatch.setattr(service, "_get_connection", _fake_get_connection)
-    monkeypatch.setattr(service, "_release_connection", _fake_release)
+    monkeypatch.setattr(service, "_acquire_tipi_connection", _fake_get_connection)
+    monkeypatch.setattr(service, "_release_tipi_connection", _fake_release)
 
-    payload = await service.search_text("motor bomba", limit=10)
+    payload = await service.searchTipiByTextQuery("motor bomba", limit=10)
 
     assert payload["total"] == 2
     assert payload["results"][0]["ncm"] == "84.13"
@@ -801,10 +811,10 @@ async def test_search_text_sqlite_mode_escapes_quotes_in_match_queries(monkeypat
         await asyncio.sleep(0)
         return None
 
-    monkeypatch.setattr(service, "_get_connection", _fake_get_connection)
-    monkeypatch.setattr(service, "_release_connection", _fake_release)
+    monkeypatch.setattr(service, "_acquire_tipi_connection", _fake_get_connection)
+    monkeypatch.setattr(service, "_release_tipi_connection", _fake_release)
 
-    payload = await service.search_text('motor "bomba"', limit=10)
+    payload = await service.searchTipiByTextQuery('motor "bomba"', limit=10)
 
     assert payload["total"] == 0
     assert len(conn.executed) == 2
@@ -820,7 +830,7 @@ async def test_search_text_sqlite_mode_escapes_quotes_in_match_queries(monkeypat
 @pytest.mark.asyncio
 async def test_get_all_chapters_repository_and_sqlite_modes(monkeypatch):
     repo_service = TipiService(repository=_FakeRepo())
-    repo_payload = await repo_service.get_all_chapters()
+    repo_payload = await repo_service.fetchTipiChapterCatalog()
     assert repo_payload == [{"codigo": "85", "titulo": "Capítulo 85", "secao": "XVI"}]
 
     sqlite_service = TipiService()
@@ -834,10 +844,12 @@ async def test_get_all_chapters_repository_and_sqlite_modes(monkeypatch):
     async def _fake_release(_conn):
         return None
 
-    monkeypatch.setattr(sqlite_service, "_get_connection", _fake_get_connection)
-    monkeypatch.setattr(sqlite_service, "_release_connection", _fake_release)
+    monkeypatch.setattr(
+        sqlite_service, "_acquire_tipi_connection", _fake_get_connection
+    )
+    monkeypatch.setattr(sqlite_service, "_release_tipi_connection", _fake_release)
 
-    sqlite_payload = await sqlite_service.get_all_chapters()
+    sqlite_payload = await sqlite_service.fetchTipiChapterCatalog()
     assert sqlite_payload == [{"codigo": "01", "titulo": "Animais", "secao": "I"}]
 
 
@@ -849,7 +861,7 @@ async def test_get_internal_cache_metrics_reports_snapshots():
     service._code_search_cache_metrics.record_hit()
     service._chapter_positions_cache_metrics.record_miss()
 
-    payload = await service.get_internal_cache_metrics()
+    payload = await service.snapshotTipiInternalCacheMetrics()
 
     assert payload["code_search_cache"]["current_size"] == 1
     assert payload["code_search_cache"]["hits"] >= 1

--- a/tests/unit/test_tipi_service_additional.py
+++ b/tests/unit/test_tipi_service_additional.py
@@ -1,4 +1,5 @@
 import asyncio
+import sqlite3
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -13,10 +14,10 @@ pytestmark = pytest.mark.unit
 @pytest.fixture(autouse=True)
 def _reset_pool_state():
     TipiService._tipi_connection_pools = {}
-    TipiService._tipi_connection_pool_lock = None
+    TipiService._tipi_connection_pool_locks = {}
     yield
     TipiService._tipi_connection_pools = {}
-    TipiService._tipi_connection_pool_lock = None
+    TipiService._tipi_connection_pool_locks = {}
 
 
 class _FakeCursor:
@@ -116,7 +117,7 @@ class _FakeHealthRepo:
 async def test_create_with_repository_raises_when_repo_unavailable(monkeypatch):
     monkeypatch.setattr(tipi_module, "_REPO_AVAILABLE", False)
     with pytest.raises(RuntimeError, match="Repository não disponível"):
-        await TipiService.create_with_repository()
+        TipiService.create_with_repository()
 
 
 @pytest.mark.asyncio
@@ -133,7 +134,7 @@ async def test_create_with_repository_success_uses_factory(monkeypatch):
     monkeypatch.setattr(tipi_module, "get_session", _fake_get_session)
     monkeypatch.setattr(tipi_module, "TipiRepository", _RepoFromFactory)
 
-    service = await TipiService.create_with_repository()
+    service = TipiService.create_with_repository()
     async with service._acquire_tipi_repository() as repo:
         assert isinstance(repo, _RepoFromFactory)
         assert repo.session == "session-1"
@@ -185,7 +186,8 @@ async def test_release_connection_closes_when_pool_is_full_and_close_fails(monke
 async def test_close_handles_pool_connection_close_errors():
     service = TipiService()
     failing_conn = _FakeConn(close_error=RuntimeError("boom"))
-    TipiService._tipi_connection_pools = {service.db_path: [failing_conn]}
+    pool_key = service._get_tipi_connection_pool_key()
+    TipiService._tipi_connection_pools = {pool_key: [failing_conn]}
 
     await service.close()
 
@@ -234,9 +236,10 @@ async def test_close_all_pools_closes_connections_across_paths(tmp_path):
     second_service = TipiService(db_path=tmp_path / "tipi-b.db")
     first_conn = _FakeConn()
     second_conn = _FakeConn()
+    current_loop_id = id(asyncio.get_running_loop())
     TipiService._tipi_connection_pools = {
-        first_service.db_path: [first_conn],
-        second_service.db_path: [second_conn],
+        (first_service.db_path, current_loop_id): [first_conn],
+        (second_service.db_path, current_loop_id): [second_conn],
     }
 
     await TipiService.close_all_pools()
@@ -268,6 +271,24 @@ async def test_check_connection_returns_error_when_query_fails(tmp_path, monkeyp
 
     assert payload["ok"] is False
     assert "db broken" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_check_connection_returns_error_when_sqlite_driver_fails(
+    tmp_path, monkeypatch
+):
+    db_file = tmp_path / "tipi.db"
+    db_file.write_text("x", encoding="utf-8")
+    service = TipiService(db_path=db_file)
+
+    async def _boom():
+        raise sqlite3.OperationalError("driver broken")
+
+    monkeypatch.setattr(service, "_acquire_tipi_connection", _boom)
+    payload = await service.check_connection()
+
+    assert payload["ok"] is False
+    assert "driver broken" in payload["error"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Isolates the NBS, NESH, and TIPI domain code from the backend runtime layer so search, catalog, and route behavior can be reviewed independently.

Includes: backend/infrastructure/repositories/nbs*, backend/services/{nbs,nesh,tipi}*, backend/presentation/{routes/search,services,tipi,webhooks,tipi_renderer}, and the related domain tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Searchable NBS catalog and NEBS explanatory entries with item detail views and paginated tree browsing.
  * Two-tier in-memory (+ optional Redis) caching, repository snapshots and health probes.
  * Revamped TIPI and NESH search with improved full-text ranking and chapter handling.

* **Bug Fixes**
  * Sidebar toggle consistently toggles across screen sizes.
  * Improved linked NEBS resolution and updated “Ver NEBS” flows.

* **Performance**
  * Faster response serialization/compression and cache backfill.

* **Tests**
  * Updated tests to match renamed service APIs and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->