### PR TITLE
[codex] refactor renderer smart-link fallback

### DIFF
--- a/backend/infrastructure/database_search.py
+++ b/backend/infrastructure/database_search.py
@@ -90,7 +90,9 @@ class DatabaseSearchQueries:
                 "reason": f"Falha ao inspecionar schema FTS: {exc}",
             }
 
-    async def _get_fts_schema_cached(self, conn: aiosqlite.Connection) -> Dict[str, Any]:
+    async def _get_fts_schema_cached(
+        self, conn: aiosqlite.Connection
+    ) -> Dict[str, Any]:
         return await self._fts_schema_cache.get_or_load(
             load=lambda: self._detect_fts_schema(conn),
             resolve_db_signature=self._get_db_signature,
@@ -105,7 +107,9 @@ class DatabaseSearchQueries:
             logger.warning(f"Falha ao inspecionar chapter_notes: {exc}")
             return set()
 
-    async def _get_chapter_notes_columns_cached(self, conn: aiosqlite.Connection) -> set[str]:
+    async def _get_chapter_notes_columns_cached(
+        self, conn: aiosqlite.Connection
+    ) -> set[str]:
         return await self._chapter_notes_schema_cache.get_or_load(
             load=lambda: self._get_chapter_notes_columns(conn),
             resolve_db_signature=self._get_db_signature,
@@ -120,7 +124,9 @@ class DatabaseSearchQueries:
             logger.warning(f"Falha ao inspecionar positions: {exc}")
             return set()
 
-    async def _get_positions_columns_cached(self, conn: aiosqlite.Connection) -> set[str]:
+    async def _get_positions_columns_cached(
+        self, conn: aiosqlite.Connection
+    ) -> set[str]:
         return await self._positions_schema_cache.get_or_load(
             load=lambda: self._get_positions_columns(conn),
             resolve_db_signature=self._get_db_signature,
@@ -142,7 +148,9 @@ class DatabaseSearchQueries:
             return {"select": "rank", "order": "rank"}
         return {"select": "bm25(search_index) AS rank", "order": "bm25(search_index)"}
 
-    def _build_chapter_sql(self, has_sections: bool, has_parsed_notes_json: bool) -> str:
+    def _build_chapter_sql(
+        self, has_sections: bool, has_parsed_notes_json: bool
+    ) -> str:
         if (
             self._chapter_sql_cache is not None
             and self._chapter_sql_has_sections == has_sections
@@ -308,7 +316,9 @@ class DatabaseSearchQueries:
                 if row["codigo"] is not None
             ]
 
-            logger.debug(f"Capítulo {chapter_num}: {len(positions)} posições (2 queries)")
+            logger.debug(
+                f"Capítulo {chapter_num}: {len(positions)} posições (2 queries)"
+            )
             sections_map: Dict[str, Any] = {
                 col: first_row[col] for col in CHAPTER_NOTES_SECTION_COLUMNS
             }

--- a/backend/presentation/renderer.py
+++ b/backend/presentation/renderer.py
@@ -3,7 +3,7 @@ Renderizador HTML para o Nesh.
 Facade compativel para o pipeline de Markdown/HTML e os helpers usados pelos testes.
 """
 
-from html.parser import HTMLParser
+from html.parser import HTMLParser  # noqa: F401 - re-exported for callers
 from collections.abc import Mapping
 import re
 
@@ -11,7 +11,11 @@ from ..config.constants import RegexPatterns
 from ..config.logging_config import renderer_logger as logger
 from ..data.glossary_manager import glossary_manager as _default_glossary_manager
 from ..domain import SearchResult
-from .renderer_patterns import _MultiTransformParser, _get_fallback_anchor_pattern, _get_position_pattern
+from .renderer_patterns import _MultiTransformParser  # noqa: F401 - re-exported for callers
+from .renderer_patterns import (
+    _get_fallback_anchor_pattern,  # noqa: F401 - re-exported for callers
+    _get_position_pattern,  # noqa: F401 - re-exported for callers
+)
 from .renderer_structure import (
     _get_pending_anchors,
     _inject_fallback_anchors,
@@ -22,7 +26,7 @@ from .renderer_structure import (
     _render_structured_sections,
     _structure_headings,
     _trim_chapter_content,
-    inject_comment_marks,
+    inject_comment_marks,  # noqa: F401 - re-exported for callers
 )
 from .renderer_text import (
     _apply_post_transforms,

--- a/backend/presentation/renderer_patterns.py
+++ b/backend/presentation/renderer_patterns.py
@@ -96,9 +96,7 @@ class _MultiTransformParser(HTMLParser):
         if self._skip_depth > 0:
             self._skip_depth -= 1
 
-    def handle_startendtag(
-        self, tag: str, attrs: list[tuple[str, str | None]]
-    ) -> None:
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         self.out.append(self.get_starttag_text() or "")
 
     def handle_data(self, data: str) -> None:
@@ -152,9 +150,7 @@ class _SmartLinkParser(HTMLParser):
         if self._skip_depth > 0:
             self._skip_depth -= 1
 
-    def handle_startendtag(
-        self, tag: str, attrs: list[tuple[str, str | None]]
-    ) -> None:
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         self.out.append(self.get_starttag_text() or "")
 
     def handle_data(self, data: str) -> None:
@@ -202,9 +198,7 @@ class _UnitHighlighter(HTMLParser):
         if self._skip_depth > 0:
             self._skip_depth -= 1
 
-    def handle_startendtag(
-        self, tag: str, attrs: list[tuple[str, str | None]]
-    ) -> None:
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         self.out.append(self.get_starttag_text() or "")
 
     def handle_data(self, data: str) -> None:

--- a/backend/presentation/renderer_structure.py
+++ b/backend/presentation/renderer_structure.py
@@ -232,9 +232,7 @@ def _normalize_bullet_content(
     return tail.strip()
 
 
-def _normalize_special_line(
-    renderer: _RendererRegexProtocol, line: str
-) -> str | None:
+def _normalize_special_line(renderer: _RendererRegexProtocol, line: str) -> str | None:
     bold_only = renderer.RE_BOLD_ONLY_LINE.match(line)
     if bold_only:
         title = bold_only.group(1).strip()

--- a/backend/presentation/renderer_text.py
+++ b/backend/presentation/renderer_text.py
@@ -181,6 +181,40 @@ def _process_list_block(
     _flush_normal_lines()
 
 
+def _extract_next_fragment(text: str, index: int) -> tuple[str, int]:
+    tag_start = text.find("<", index)
+    if tag_start == -1:
+        return text[index:], len(text)
+    if tag_start > index:
+        return text[index:tag_start], tag_start
+
+    tag_end = text.find(">", tag_start + 1)
+    if tag_end == -1:
+        return text[tag_start:], len(text)
+    return text[tag_start : tag_end + 1], tag_end + 1
+
+
+def _update_anchor_state_or_skip(
+    segment: str,
+    anchor_tag_pattern: re.Pattern[str],
+    in_anchor_depth: int,
+) -> tuple[int, bool]:
+    if not segment.startswith("<"):
+        return in_anchor_depth, False
+
+    tag_match = anchor_tag_pattern.match(segment)
+    if not tag_match or tag_match.group(2).lower() != "a":
+        return in_anchor_depth, True
+
+    if tag_match.group(1):
+        return max(0, in_anchor_depth - 1), True
+
+    if not segment.rstrip().endswith("/>"):
+        return in_anchor_depth + 1, True
+
+    return in_anchor_depth, True
+
+
 def _apply_smart_links_outside_tags(renderer: _RendererRegexProtocol, text: str) -> str:
     def smart_replacer(match: re.Match[str]) -> str:
         ncm = match.group(1)
@@ -191,48 +225,26 @@ def _apply_smart_links_outside_tags(renderer: _RendererRegexProtocol, text: str)
     index = 0
     in_anchor_depth = 0
     size = len(text)
+    anchor_tag_pattern = re.compile(r"^<\s*(/?)\s*([a-zA-Z0-9:_-]+)")
 
     while index < size:
-        tag_start = text.find("<", index)
-        if tag_start == -1:
-            if in_anchor_depth > 0:
-                output.append(text[index:])
-            else:
-                output.append(renderer.RE_NCM_LINK.sub(smart_replacer, text[index:]))
+        segment, next_index = _extract_next_fragment(text, index)
+        if not segment:
             break
 
-        if tag_start > index:
-            segment = text[index:tag_start]
-            if in_anchor_depth > 0:
-                output.append(segment)
-            else:
-                output.append(renderer.RE_NCM_LINK.sub(smart_replacer, segment))
+        in_anchor_depth, skip_linkify = _update_anchor_state_or_skip(
+            segment,
+            anchor_tag_pattern,
+            in_anchor_depth,
+        )
+        if skip_linkify:
+            output.append(segment)
+        elif in_anchor_depth > 0:
+            output.append(segment)
+        else:
+            output.append(renderer.RE_NCM_LINK.sub(smart_replacer, segment))
 
-        tag_end = text.find(">", tag_start + 1)
-        if tag_end == -1:
-            tail = text[tag_start:]
-            if in_anchor_depth > 0:
-                output.append(tail)
-            else:
-                output.append(renderer.RE_NCM_LINK.sub(smart_replacer, tail))
-            break
-
-        tag = text[tag_start : tag_end + 1]
-        output.append(tag)
-
-        tag_body = tag[1:-1].strip()
-        if tag_body:
-            is_closing_tag = tag_body.startswith("/")
-            if is_closing_tag:
-                tag_body = tag_body[1:].lstrip()
-            tag_name = tag_body.split(None, 1)[0].rstrip("/").lower()
-            if tag_name == "a":
-                if is_closing_tag:
-                    in_anchor_depth = max(0, in_anchor_depth - 1)
-                elif not tag.rstrip().endswith("/>"):
-                    in_anchor_depth += 1
-
-        index = tag_end + 1
+        index = next_index
 
     return "".join(output)
 

--- a/backend/presentation/renderer_text.py
+++ b/backend/presentation/renderer_text.py
@@ -8,9 +8,9 @@ from typing import Protocol
 
 from .renderer_patterns import (
     _MultiTransformParser,
+    _RendererRegexProtocol,
     _SmartLinkParser,
     _UnitHighlighter,
-    _RendererRegexProtocol,
 )
 
 logger = logging.getLogger("nesh.renderer.text")

--- a/backend/presentation/routes/search.py
+++ b/backend/presentation/routes/search.py
@@ -199,9 +199,7 @@ def _build_search_cache_request_context(
     cache_key = cache_scope_key(request)
     headers = _build_cache_headers(cache_key, ncm_normalized)
 
-    payload_key = (
-        f"{cache_key}:{ncm_normalized}:{shape}" if is_code_query else None
-    )
+    payload_key = f"{cache_key}:{ncm_normalized}:{shape}" if is_code_query else None
     return SearchCacheRequestContext(
         is_code_query=is_code_query,
         normalized_query=ncm_normalized,
@@ -220,9 +218,7 @@ def _extract_code_results(response_data: Mapping[str, Any]) -> dict[str, Any]:
     return raw_results if isinstance(raw_results, dict) else {}
 
 
-def _prepare_code_search_response(
-    response_data: dict[str, Any], *, shape: str
-) -> None:
+def _prepare_code_search_response(response_data: dict[str, Any], *, shape: str) -> None:
     results = _extract_code_results(response_data)
     if shape == "full":
         response_data["markdown"] = HtmlRenderer.render_full_response(results)

--- a/backend/presentation/routes/system.py
+++ b/backend/presentation/routes/system.py
@@ -12,38 +12,38 @@ from backend.server.rate_limit import status_rate_limiter
 from backend.services import NeshService
 from backend.utils.auth import extract_bearer_token, extract_client_ip, is_admin_payload
 
-from .system_metrics import append_catalog_status_metrics
-from .system_metrics import append_database_latency_metric
-from .system_metrics import append_internal_cache_hit_rate_metrics
-from .system_metrics import append_metric_line
-from .system_metrics import append_payload_cache_metrics
+from .system_metrics import append_catalog_status_metrics  # noqa: F401 - re-exported for callers
+from .system_metrics import append_database_latency_metric  # noqa: F401 - re-exported for callers
+from .system_metrics import append_internal_cache_hit_rate_metrics  # noqa: F401 - re-exported for callers
+from .system_metrics import append_metric_line  # noqa: F401 - re-exported for callers
+from .system_metrics import append_payload_cache_metrics  # noqa: F401 - re-exported for callers
 from .system_metrics import build_prometheus_metrics_payload
-from .system_metrics import metric_value_from_status
-from .system_status import await_status_refresh_snapshot
+from .system_metrics import metric_value_from_status  # noqa: F401 - re-exported for callers
+from .system_status import await_status_refresh_snapshot  # noqa: F401 - re-exported for callers
 from .system_status import build_detailed_status_payload
 from .system_status import build_public_status_payload
-from .system_status import build_status_snapshot
-from .system_status import coerce_int
-from .system_status import collect_db_status
+from .system_status import build_status_snapshot  # noqa: F401 - re-exported for callers
+from .system_status import coerce_int  # noqa: F401 - re-exported for callers
+from .system_status import collect_db_status  # noqa: F401 - re-exported for callers
 from .system_status import collect_nbs_catalog_health
 from .system_status import collect_status_payloads
-from .system_status import collect_status_payloads_uncached
-from .system_status import collect_tipi_status
-from .system_status import extract_prefixed_metadata
-from .system_status import get_status_cache_lock
-from .system_status import get_status_snapshot
-from .system_status import normalize_count_catalog_status
-from .system_status import normalize_db_status
-from .system_status import normalize_tipi_status
-from .system_status import read_l1_status_snapshot
-from .system_status import read_redis_status_snapshot
-from .system_status import read_stale_l1_status_snapshot
-from .system_status import recover_status_snapshot
-from .system_status import refresh_status_snapshot
-from .system_status import reset_status_cache_for_tests
-from .system_status import status_cache_ttl_seconds
-from .system_status import store_status_snapshot
-from .system_status import unpack_status_snapshot
+from .system_status import collect_status_payloads_uncached  # noqa: F401 - re-exported for callers
+from .system_status import collect_tipi_status  # noqa: F401 - re-exported for callers
+from .system_status import extract_prefixed_metadata  # noqa: F401 - re-exported for callers
+from .system_status import get_status_cache_lock  # noqa: F401 - re-exported for callers
+from .system_status import get_status_snapshot  # noqa: F401 - re-exported for callers
+from .system_status import normalize_count_catalog_status  # noqa: F401 - re-exported for callers
+from .system_status import normalize_db_status  # noqa: F401 - re-exported for callers
+from .system_status import normalize_tipi_status  # noqa: F401 - re-exported for callers
+from .system_status import read_l1_status_snapshot  # noqa: F401 - re-exported for callers
+from .system_status import read_redis_status_snapshot  # noqa: F401 - re-exported for callers
+from .system_status import read_stale_l1_status_snapshot  # noqa: F401 - re-exported for callers
+from .system_status import recover_status_snapshot  # noqa: F401 - re-exported for callers
+from .system_status import refresh_status_snapshot  # noqa: F401 - re-exported for callers
+from .system_status import reset_status_cache_for_tests  # noqa: F401 - re-exported for callers
+from .system_status import status_cache_ttl_seconds  # noqa: F401 - re-exported for callers
+from .system_status import store_status_snapshot  # noqa: F401 - re-exported for callers
+from .system_status import unpack_status_snapshot  # noqa: F401 - re-exported for callers
 
 router = APIRouter()
 collect_nbs_status = collect_nbs_catalog_health
@@ -134,9 +134,7 @@ async def _collect_system_cache_metrics_payload(request: Request) -> dict:
         "search_code_payload_cache": (
             search_route.snapshotSearchCodePayloadCacheMetrics()
         ),
-        "tipi_code_payload_cache": (
-            tipi_route.snapshotTipiCodePayloadCacheMetrics()
-        ),
+        "tipi_code_payload_cache": (tipi_route.snapshotTipiCodePayloadCacheMetrics()),
         "nesh_internal_caches": nesh_internal,
         "tipi_internal_caches": tipi_internal,
     }
@@ -257,7 +255,9 @@ async def debug_nesh_anchors(
     html_content = response_data.get("markdown", "") or ""
     id_pattern = re.compile(r'id="([^"]+)"')
     all_ids = id_pattern.findall(html_content)
-    pos_ids = [item for item in all_ids if item.startswith("pos-") or item.startswith("cap-")]
+    pos_ids = [
+        item for item in all_ids if item.startswith("pos-") or item.startswith("cap-")
+    ]
 
     return {
         "query": ncm,

--- a/backend/presentation/routes/system_metrics.py
+++ b/backend/presentation/routes/system_metrics.py
@@ -82,7 +82,9 @@ def append_payload_cache_metrics(
         )
 
 
-def append_internal_cache_hit_rate_metrics(lines: list[str], cache_metrics: dict) -> None:
+def append_internal_cache_hit_rate_metrics(
+    lines: list[str], cache_metrics: dict
+) -> None:
     lines.extend(
         [
             "# HELP nesh_internal_cache_hit_rate Internal service cache hit rate.",

--- a/backend/server/app.py
+++ b/backend/server/app.py
@@ -120,7 +120,7 @@ def _sync_lifecycle_call[**P, R](callback: Callable[P, R]) -> Callable[P, R]:
     return wrapped
 
 
-def _sync_lifecycle_async_call(
+def _sync_lifecycle_async_call[**P, R](
     callback: Callable[P, Awaitable[R]],
 ) -> Callable[P, Awaitable[R]]:
     async def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:

--- a/backend/server/app_lifecycle.py
+++ b/backend/server/app_lifecycle.py
@@ -124,7 +124,9 @@ def _log_runtime_security_warnings() -> None:
         )
 
     if not settings.database.is_postgres:
-        warnings.append("DATABASE__ENGINE não está em postgresql no ambiente de produção.")
+        warnings.append(
+            "DATABASE__ENGINE não está em postgresql no ambiente de produção."
+        )
 
     for warning in warnings:
         logger.warning("Runtime security warning: %s", warning)
@@ -180,7 +182,9 @@ async def _init_nesh_service(app: FastAPI) -> None:
     from backend.services.nesh_service import NeshService
 
     if settings.database.is_postgres:
-        app.state.service = await NeshService.initializeNeshServiceWithRepositoryFactory()
+        app.state.service = (
+            await NeshService.initializeNeshServiceWithRepositoryFactory()
+        )
         logger.info("NeshService initialized in Repository mode (Postgres/RLS)")
         return
 

--- a/backend/server/middleware.py
+++ b/backend/server/middleware.py
@@ -21,50 +21,50 @@ from backend.server.middleware_context import (
     _jwt_failure_reason_ctx,
     _request_id_ctx,
     _schedule_background_task,
-    get_current_request_id,
-    get_current_tenant,
+    get_current_request_id,  # noqa: F401 - re-exported for callers
+    get_current_tenant,  # noqa: F401 - re-exported for callers
     get_last_jwt_failure_reason,
 )
 from backend.server.middleware_jwt_support import (
-    _build_jwt_decode_kwargs,
+    _build_jwt_decode_kwargs,  # noqa: F401 - re-exported for callers
+    _build_temporal_claims_extra,  # noqa: F401 - re-exported for callers
     _build_jwks_url,
-    _build_temporal_claims_extra,
-    _configured_clock_skew_seconds,
+    _configured_clock_skew_seconds,  # noqa: F401 - re-exported for callers
     _decode_jwt_with_signature,
-    _derive_issuer_hint_from_domain,
+    _derive_issuer_hint_from_domain,  # noqa: F401 - re-exported for callers
     _effective_clock_skew_seconds,
-    _get_payload_exp,
+    _get_payload_exp,  # noqa: F401 - re-exported for callers
     _is_payload_expired,
-    _jwt_error_reason,
+    _jwt_error_reason,  # noqa: F401 - re-exported for callers
     _log_jwt_failure,
     _log_jwt_validation_error,
     _log_jwt_validation_success,
-    _normalize_clerk_domain,
-    _normalize_issuer,
-    _normalize_token_audience,
-    _parse_clock_skew_seconds,
+    _normalize_clerk_domain,  # noqa: F401 - re-exported for callers
+    _normalize_issuer,  # noqa: F401 - re-exported for callers
+    _normalize_token_audience,  # noqa: F401 - re-exported for callers
+    _parse_clock_skew_seconds,  # noqa: F401 - re-exported for callers
     _resolve_expected_audience,
     _resolve_expected_azp,
     _resolve_expected_issuer,
-    _resolve_full_name,
+    _resolve_full_name,  # noqa: F401 - re-exported for callers
     _resolve_identity_fields,
     _resolve_user_id,
-    _safe_float_claim,
-    _safe_get_unverified_claims,
-    _safe_get_unverified_header,
+    _safe_float_claim,  # noqa: F401 - re-exported for callers
+    _safe_get_unverified_claims,  # noqa: F401 - re-exported for callers
+    _safe_get_unverified_header,  # noqa: F401 - re-exported for callers
     _token_observability_snapshot,
     _upsert_clerk_entities,
     _validate_expected_audience_claim,
     _validate_expected_azp,
     _validate_expected_issuer,
-    _validate_not_before_like_claim,
+    _validate_not_before_like_claim,  # noqa: F401 - re-exported for callers
     _validate_temporal_claims,
     _is_recently_provisioned,
     _mark_entities_as_provisioned,
 )
 from backend.server.middleware_network import (
     is_loopback_host,
-    origin_looks_like_loopback,
+    origin_looks_like_loopback,  # noqa: F401 - re-exported for callers
 )
 
 logger = logging.getLogger("nesh.middleware.tenant")

--- a/backend/server/middleware_context.py
+++ b/backend/server/middleware_context.py
@@ -7,9 +7,9 @@ import logging
 from contextvars import ContextVar, Token
 from typing import Any, Coroutine, Optional
 
-logger = logging.getLogger("nesh.middleware.context")
-
 from backend.infrastructure.db_engine import tenant_context
+
+logger = logging.getLogger("nesh.middleware.context")
 
 _request_id_ctx: ContextVar[Optional[str]] = ContextVar("request_id", default=None)
 _jwt_failure_reason_ctx: ContextVar[Optional[str]] = ContextVar(
@@ -66,4 +66,3 @@ def _reset_request_id(token: Token[Optional[str]]) -> None:
 
 def _record_jwt_failure_reason(reason: Optional[str]) -> None:
     _jwt_failure_reason_ctx.set(reason)
-

--- a/backend/server/middleware_jwt_support.py
+++ b/backend/server/middleware_jwt_support.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import base64
-import hashlib
 import json
 import logging
 import re
@@ -248,7 +247,17 @@ def _log_jwt_validation_success(
                 "header": token_snapshot.get("header", {}),
                 "claims": {
                     k: payload.get(k)
-                    for k in ("iss", "sub", "sid", "azp", "aud", "org_id", "exp", "iat", "nbf")
+                    for k in (
+                        "iss",
+                        "sub",
+                        "sid",
+                        "azp",
+                        "aud",
+                        "org_id",
+                        "exp",
+                        "iat",
+                        "nbf",
+                    )
                 },
             },
             ensure_ascii=False,
@@ -457,7 +466,10 @@ def _resolve_user_id(payload: dict[str, Any]) -> Optional[str]:
 
 
 def _is_recently_provisioned(
-    cache_key: tuple[str, str], now: float, cache: dict[tuple[str, str], float], ttl: float
+    cache_key: tuple[str, str],
+    now: float,
+    cache: dict[tuple[str, str], float],
+    ttl: float,
 ) -> bool:
     cached_at = cache.get(cache_key)
     return cached_at is not None and (now - cached_at) < ttl
@@ -516,7 +528,10 @@ async def _upsert_clerk_entities(
 
 
 def _mark_entities_as_provisioned(
-    cache_key: tuple[str, str], now: float, cache: dict[tuple[str, str], float], max_size: int
+    cache_key: tuple[str, str],
+    now: float,
+    cache: dict[tuple[str, str], float],
+    max_size: int,
 ) -> None:
     if len(cache) >= max_size:
         oldest = sorted(cache.items(), key=lambda item: item[1])[:100]

--- a/backend/server/middleware_network.py
+++ b/backend/server/middleware_network.py
@@ -31,4 +31,3 @@ def is_loopback_host(host: Optional[str]) -> bool:
 
 def origin_looks_like_loopback(origin: str) -> bool:
     return is_loopback_host(urlparse(origin).hostname)
-

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -138,7 +138,7 @@ export function Header({
                         className={`${styles.docButton} ${doc === (isServiceDoc ? 'nbs' : 'nesh') ? styles.docButtonActive : ''}`}
                         onClick={() => setDoc(isServiceDoc ? 'nbs' : 'nesh')}
                     >
-                        {isServiceDoc ? 'NEBS' : 'NESH'}
+                        {isServiceDoc ? 'NBS' : 'NESH'}
                     </button>
                     <button
                         className={`${styles.docButton} ${doc === 'tipi' ? styles.docButtonActive : ''}`}
@@ -185,7 +185,7 @@ export function Header({
                                 className={servicesUnavailableReason ? styles.menuButtonDisabled : ''}
                                 title={servicesUnavailableReason ?? undefined}
                             >
-                                <span>🧭</span> {servicesUnavailableReason ? 'Serviços (NEBS) indisponível' : 'Serviços (NEBS)'}
+                                <span>🧭</span> {servicesUnavailableReason ? 'Serviços (NBS) indisponível' : 'Serviços (NBS)'}
                             </button>
                         )}
                         <div className={styles.menuDivider}></div>
@@ -273,3 +273,4 @@ export function Header({
         </header>
     );
 }
+

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -9,6 +9,7 @@ import styles from './Header.module.css';
 
 const DOC_SUBTITLES: Record<string, string> = {
     nbs: 'Classificação Brasileira de Serviços',
+    nebs: 'Classificação Brasileira de Serviços',
     nesh: 'Notas Explicativas do Sistema Harmonizado',
     tipi: 'Tabela de Incidência do IPI',
 };
@@ -64,8 +65,18 @@ export function Header({
         logout
     } = useAuth();
     const isAdmin = useIsAdmin();
-    const isServiceDoc = doc === 'nbs';
+    const isServiceDoc = doc === 'nbs' || doc === 'nebs';
     const titleSubtitle = DOC_SUBTITLES[doc] || DOC_SUBTITLES.tipi;
+    const primaryDocButtonLabel = doc === 'nbs'
+        ? 'NEBS'
+        : doc === 'nebs'
+            ? 'NBS'
+            : 'NESH';
+    const primaryDocButtonTarget = doc === 'nbs'
+        ? 'nebs'
+        : doc === 'nebs'
+            ? 'nbs'
+            : 'nesh';
 
     // Close menu when clicking outside
     useEffect(() => {
@@ -135,10 +146,10 @@ export function Header({
 
                 <div className={styles.docSelector}>
                     <button
-                        className={`${styles.docButton} ${doc === (isServiceDoc ? 'nbs' : 'nesh') ? styles.docButtonActive : ''}`}
-                        onClick={() => setDoc(isServiceDoc ? 'nbs' : 'nesh')}
+                        className={`${styles.docButton} ${doc === 'nesh' || doc === 'nbs' || doc === 'nebs' ? styles.docButtonActive : ''}`}
+                        onClick={() => setDoc(primaryDocButtonTarget)}
                     >
-                        {isServiceDoc ? 'NBS' : 'NESH'}
+                        {primaryDocButtonLabel}
                     </button>
                     <button
                         className={`${styles.docButton} ${doc === 'tipi' ? styles.docButtonActive : ''}`}
@@ -273,4 +284,3 @@ export function Header({
         </header>
     );
 }
-

--- a/client/src/components/ResultDisplay.module.css
+++ b/client/src/components/ResultDisplay.module.css
@@ -310,6 +310,11 @@
         visibility: hidden;
         transition: opacity 0.4s ease, visibility 0.4s ease;
         backdrop-filter: blur(4px);
+        border: 0;
+        padding: 0;
+        appearance: none;
+        -webkit-appearance: none;
+        cursor: pointer;
     }
 
     .mobileOverlayOpen {

--- a/client/src/components/ResultDisplay.tsx
+++ b/client/src/components/ResultDisplay.tsx
@@ -1,153 +1,120 @@
-import { TextSearchResults } from './TextSearchResults'
-import React, {
-  startTransition,
-  useEffect,
-  useRef,
-  useState,
-  useCallback,
-  useMemo,
-} from 'react'
-import { marked } from 'marked'
-import { useRobustScroll } from '../hooks/useRobustScroll'
-import { generateAnchorId } from '../utils/id_utils'
-import { SearchResultItem } from './TextSearchResults'
-import styles from './ResultDisplay.module.css'
-import { debug } from '../utils/debug'
-import { NeshRenderer } from '../utils/NeshRenderer'
-import { useSettings } from '../context/SettingsContext'
-import { Sidebar } from './Sidebar'
-import { SearchHighlighter } from './SearchHighlighter'
-import { useTextSelection } from '../hooks/useTextSelection'
-import { HighlightPopover } from './HighlightPopover'
-import { CommentPanel } from './CommentPanel'
-import { CommentDrawer } from './CommentDrawer'
-import type { PendingCommentEntry } from './CommentPanel'
-import { useAuth } from '../context/AuthContext'
-import { useComments } from '../hooks/useComments'
-import toast from 'react-hot-toast'
+import { TextSearchResults } from './TextSearchResults';
+import React, { startTransition, useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import { marked } from 'marked';
+import { useRobustScroll } from '../hooks/useRobustScroll';
+import { generateAnchorId } from '../utils/id_utils';
+import { SearchResultItem } from './TextSearchResults';
+import styles from './ResultDisplay.module.css';
+import { debug } from '../utils/debug';
+import { NeshRenderer } from '../utils/NeshRenderer';
+import { useSettings } from '../context/SettingsContext';
+import { Sidebar } from './Sidebar';
+import { SearchHighlighter } from './SearchHighlighter';
+import { useTextSelection } from '../hooks/useTextSelection';
+import { HighlightPopover } from './HighlightPopover';
+import { CommentPanel } from './CommentPanel';
+import { CommentDrawer } from './CommentDrawer';
+import type { PendingCommentEntry } from './CommentPanel';
+import { useAuth } from '../context/AuthContext';
+import { useComments } from '../hooks/useComments';
+import toast from 'react-hot-toast';
 import {
-  appendTrustedHtmlToElement,
-  replaceElementWithTrustedHtml,
-  sanitizeRichHtml,
-} from '../utils/contentSecurity'
-import { getNeshChapterBody } from '../services/api'
-import type { ChapterBodyResponse } from '../types/api.types'
+    appendTrustedHtmlToElement,
+    replaceElementWithTrustedHtml,
+    sanitizeRichHtml,
+} from '../utils/contentSecurity';
+import { getNeshChapterBody } from '../services/api';
+import type { ChapterBodyResponse } from '../types/api.types';
 
-const LEGACY_MARKDOWN_PATTERN =
-  /(^|\n)\s{0,3}(?:#{1,6}\s|>\s|[-*+]\s|\d+\.\s|---+\s*$)|\*\*[^*\n]+?\*\*/m
+const LEGACY_MARKDOWN_BLOCK_PATTERN = /(^|\n)\s{0,3}(?:#{1,6}\s|>\s|[-*+]\s|\d+\.\s|---+\s*$)/m;
+const LEGACY_MARKDOWN_EMPHASIS_PATTERN = /\*\*[^*\n]+?\*\*/m;
 
 const isLikelyLegacyMarkdown = (value: string) =>
-  LEGACY_MARKDOWN_PATTERN.test(value)
+    LEGACY_MARKDOWN_BLOCK_PATTERN.test(value) || LEGACY_MARKDOWN_EMPHASIS_PATTERN.test(value);
 
-const SHARED_MARKUP_CACHE_MAX = 12
-const sharedRawMarkupCache = new Map<string, string>()
-const sharedSanitizedMarkupCache = new Map<string, string>()
+const SHARED_MARKUP_CACHE_MAX = 12;
+const sharedRawMarkupCache = new Map<string, string>();
+const sharedSanitizedMarkupCache = new Map<string, string>();
 
 function cacheGet(map: Map<string, string>, key: string): string | null {
-  const value = map.get(key)
-  if (value === undefined) return null
-  map.delete(key)
-  map.set(key, value)
-  return value
+    const value = map.get(key);
+    if (value === undefined) return null;
+    map.delete(key);
+    map.set(key, value);
+    return value;
 }
 
 function cacheSet(map: Map<string, string>, key: string, value: string) {
-  if (map.has(key)) {
-    map.delete(key)
-  } else if (map.size >= SHARED_MARKUP_CACHE_MAX) {
-    const oldestKey = map.keys().next().value as string | undefined
-    if (oldestKey !== undefined) {
-      map.delete(oldestKey)
+    if (map.has(key)) {
+        map.delete(key);
+    } else if (map.size >= SHARED_MARKUP_CACHE_MAX) {
+        const oldestKey = map.keys().next().value as string | undefined;
+        if (oldestKey !== undefined) {
+            map.delete(oldestKey);
+        }
     }
-  }
-  map.set(key, value)
+    map.set(key, value);
 }
+
 
 const getAliquotClass = (aliquota: string) => {
-  const normalized = (aliquota || '').toString().trim().toUpperCase()
-  if (!normalized || normalized === '0' || normalized === '0%') {
-    return {
-      className: 'aliquot-zero',
-      tooltip: 'Isento de IPI',
-      display: normalized || '0%',
+    const normalized = (aliquota || '').toString().trim().toUpperCase();
+    if (!normalized || normalized === '0' || normalized === '0%') {
+        return { className: 'aliquot-zero', tooltip: 'Isento de IPI', display: normalized || '0%' };
     }
-  }
-  if (normalized === 'NT') {
-    return { className: 'aliquot-nt', tooltip: 'Não Tributável', display: 'NT' }
-  }
+    if (normalized === 'NT') {
+        return { className: 'aliquot-nt', tooltip: 'Não Tributável', display: 'NT' };
+    }
 
-  const numeric = Number(normalized.replace('%', '').replace(',', '.'))
-  if (!Number.isNaN(numeric)) {
-    if (numeric <= 5) {
-      return {
-        className: 'aliquot-low',
-        tooltip: 'Alíquota Reduzida (1-5%)',
-        display: `${numeric}%`,
-      }
+    const numeric = Number(normalized.replace('%', '').replace(',', '.'));
+    if (!Number.isNaN(numeric)) {
+        if (numeric <= 5) {
+            return { className: 'aliquot-low', tooltip: 'Alíquota Reduzida (1-5%)', display: `${numeric}%` };
+        }
+        if (numeric <= 10) {
+            return { className: 'aliquot-med', tooltip: 'Alíquota Média (6-10%)', display: `${numeric}%` };
+        }
+        return { className: 'aliquot-high', tooltip: 'Alíquota Elevada (>10%)', display: `${numeric}%` };
     }
-    if (numeric <= 10) {
-      return {
-        className: 'aliquot-med',
-        tooltip: 'Alíquota Média (6-10%)',
-        display: `${numeric}%`,
-      }
-    }
-    return {
-      className: 'aliquot-high',
-      tooltip: 'Alíquota Elevada (>10%)',
-      display: `${numeric}%`,
-    }
-  }
 
-  return {
-    className: 'aliquot-zero',
-    tooltip: 'Isento de IPI',
-    display: normalized,
-  }
-}
+    return { className: 'aliquot-zero', tooltip: 'Isento de IPI', display: normalized };
+};
 
 const isTipiResults = (resultados: Record<string, any> | null | undefined) => {
-  if (!resultados || typeof resultados !== 'object') return false
-  const chapters = Object.values(resultados)
-  return chapters.some(
-    (chapter) =>
-      Array.isArray(chapter?.posicoes) &&
-      chapter.posicoes.some((pos: any) => 'aliquota' in pos || 'nivel' in pos)
-  )
-}
+    if (!resultados || typeof resultados !== 'object') return false;
+    const chapters = Object.values(resultados);
+    return chapters.some((chapter) =>
+        Array.isArray(chapter?.posicoes) && chapter.posicoes.some((pos: any) => 'aliquota' in pos || 'nivel' in pos)
+    );
+};
 
 const renderTipiFallback = (resultados: Record<string, any>) => {
-  const chapters = Object.values(resultados).sort(
-    (a: any, b: any) =>
-      parseInt(a?.capitulo || '0', 10) - parseInt(b?.capitulo || '0', 10)
-  )
+    const chapters = Object.values(resultados)
+        .sort((a: any, b: any) => Number.parseInt(a?.capitulo || '0', 10) - Number.parseInt(b?.capitulo || '0', 10));
 
-  return chapters
-    .map((chapter: any) => {
-      const capitulo = chapter?.capitulo || ''
-      const titulo = chapter?.titulo || `Capítulo ${capitulo}`
-      const posicoes = Array.isArray(chapter?.posicoes) ? chapter.posicoes : []
+    return chapters.map((chapter: any) => {
+        const capitulo = chapter?.capitulo || '';
+        const titulo = chapter?.titulo || `Capítulo ${capitulo}`;
+        const posicoes = Array.isArray(chapter?.posicoes) ? chapter.posicoes : [];
 
-      const positionsHtml = posicoes
-        .map((pos: any) => {
-          const codigo = pos?.codigo || pos?.ncm || ''
-          const ncm = pos?.ncm || codigo
-          const descricao = pos?.descricao || ''
-          const nivel = typeof pos?.nivel === 'number' ? pos.nivel : 1
-          const indentClass = `tipi-nivel-${Math.min(nivel, 5)}`
-          const { className, tooltip, display } = getAliquotClass(pos?.aliquota)
-          const elementId = generateAnchorId(codigo)
+        const positionsHtml = posicoes.map((pos: any) => {
+            const codigo = pos?.codigo || pos?.ncm || '';
+            const ncm = pos?.ncm || codigo;
+            const descricao = pos?.descricao || '';
+            const nivel = typeof pos?.nivel === 'number' ? pos.nivel : 1;
+            const indentClass = `tipi-nivel-${Math.min(nivel, 5)}`;
+            const { className, tooltip, display } = getAliquotClass(pos?.aliquota);
+            const elementId = generateAnchorId(codigo);
 
-          return `
+            return `
 <article class="tipi-position ${indentClass}" id="${elementId}" data-ncm="${ncm}" aria-label="NCM ${codigo}">
     <span class="tipi-ncm smart-link" data-ncm="${ncm}" role="link" tabindex="0">${codigo}</span>
     <span class="tipi-desc">${descricao}</span>
     <span class="tipi-aliquota ${className}" data-tooltip="${tooltip}" aria-label="${tooltip}">${display}</span>
-</article>`
-        })
-        .join('')
+</article>`;
+        }).join('');
 
-      return `
+        return `
 <div class="tipi-chapter" id="cap-${capitulo}">
     <h2 class="tipi-chapter-header">
         <span class="tipi-cap-badge">${capitulo}</span>
@@ -156,2056 +123,1747 @@ const renderTipiFallback = (resultados: Record<string, any>) => {
     <div class="tipi-positions">
         ${positionsHtml}
     </div>
-</div>`
-    })
-    .join('\n')
-}
+</div>`;
+    }).join('\n');
+};
 
-type ChapterSectionType = 'titulo' | 'notas' | 'consideracoes' | 'definicoes'
+type ChapterSectionType = 'titulo' | 'notas' | 'consideracoes' | 'definicoes';
 
-const SECTION_TARGET_PATTERN =
-  /^chapter-([^-]+)-(titulo|notas|consideracoes|definicoes)$/i
+const SECTION_TARGET_PATTERN = /^chapter-([^-]+)-(titulo|notas|consideracoes|definicoes)$/i;
 
 const SECTION_SELECTOR_FALLBACKS: Record<ChapterSectionType, string[]> = {
-  titulo: ['.section-titulo'],
-  notas: ['.section-notas', '.regras-gerais'],
-  consideracoes: ['.section-consideracoes'],
-  definicoes: ['.section-definicoes'],
-}
+    titulo: ['.section-titulo'],
+    notas: ['.section-notas', '.regras-gerais'],
+    consideracoes: ['.section-consideracoes'],
+    definicoes: ['.section-definicoes']
+};
 
 const SECTION_TEXT_FALLBACKS: Record<ChapterSectionType, RegExp> = {
-  titulo: /t[ií]tulo do cap[ií]tulo/i,
-  notas: /notas do cap[ií]tulo|regras gerais do cap[ií]tulo/i,
-  consideracoes: /considera[cç][oõ]es gerais/i,
-  definicoes: /defini[cç][oõ]es t[eé]cnicas/i,
-}
+    titulo: /t[ií]tulo do cap[ií]tulo/i,
+    notas: /notas do cap[ií]tulo|regras gerais do cap[ií]tulo/i,
+    consideracoes: /considera[cç][oõ]es gerais/i,
+    definicoes: /defini[cç][oõ]es t[eé]cnicas/i
+};
 
-function getSectionTargetMeta(
-  targetId: string
-): { capitulo: string; sectionType: ChapterSectionType } | null {
-  const match = targetId.match(SECTION_TARGET_PATTERN)
-  if (!match) return null
-  return {
-    capitulo: match[1],
-    sectionType: match[2].toLowerCase() as ChapterSectionType,
-  }
+function getSectionTargetMeta(targetId: string): { capitulo: string; sectionType: ChapterSectionType } | null {
+    const match = targetId.match(SECTION_TARGET_PATTERN);
+    if (!match) return null;
+    return { capitulo: match[1], sectionType: match[2].toLowerCase() as ChapterSectionType };
 }
 
 function getChapterAnchors(container: HTMLElement): HTMLElement[] {
-  return Array.from(container.querySelectorAll('[id]')).filter((node) =>
-    /^(?:cap|chapter)-\d{1,2}$/.test((node as HTMLElement).id)
-  ) as HTMLElement[]
+    return Array.from(container.querySelectorAll('[id]'))
+        .filter((node) => /^(?:cap|chapter)-\d{1,2}$/.test((node as HTMLElement).id)) as HTMLElement[];
 }
 
-function getChapterBounds(
-  container: HTMLElement,
-  capitulo: string
-): { start: HTMLElement | null; next: HTMLElement | null } {
-  const startByCap = container.querySelector(
-    `#${CSS.escape(`cap-${capitulo}`)}`
-  ) as HTMLElement | null
-  const startByChapter = container.querySelector(
-    `#${CSS.escape(`chapter-${capitulo}`)}`
-  ) as HTMLElement | null
-  const start = startByCap || startByChapter
-  if (!start) return { start: null, next: null }
+function getChapterBounds(container: HTMLElement, capitulo: string): { start: HTMLElement | null; next: HTMLElement | null } {
+    const startByCapId = CSS.escape(`cap-${capitulo}`);
+    const startByCap = container.querySelector(`#${startByCapId}`) as HTMLElement | null;
+    const startByChapterId = CSS.escape(`chapter-${capitulo}`);
+    const startByChapter = container.querySelector(`#${startByChapterId}`) as HTMLElement | null;
+    const start = startByCap || startByChapter;
+    if (!start) return { start: null, next: null };
 
-  const anchors = getChapterAnchors(container)
-  const idx = anchors.findIndex((el) => el === start)
-  if (idx < 0) return { start, next: null }
+    const anchors = getChapterAnchors(container);
+    const idx = anchors.indexOf(start);
+    if (idx < 0) return { start, next: null };
 
-  return { start, next: anchors[idx + 1] || null }
+    return { start, next: anchors[idx + 1] || null };
 }
 
-function isElementWithinBounds(
-  element: HTMLElement,
-  start: HTMLElement,
-  next: HTMLElement | null
-): boolean {
-  const isAfterStart =
-    start === element ||
-    Boolean(
-      start.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_FOLLOWING
-    )
-  if (!isAfterStart) return false
-  if (!next) return true
-  return Boolean(
-    element.compareDocumentPosition(next) & Node.DOCUMENT_POSITION_FOLLOWING
-  )
+function isElementWithinBounds(element: HTMLElement, start: HTMLElement, next: HTMLElement | null): boolean {
+    const isAfterStart = start === element
+        || Boolean(start.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_FOLLOWING);
+    if (!isAfterStart) return false;
+    if (!next) return true;
+    return Boolean(element.compareDocumentPosition(next) & Node.DOCUMENT_POSITION_FOLLOWING);
 }
 
-function resolveSectionElement(
-  container: HTMLElement,
-  targetId: string
-): HTMLElement | null {
-  const sectionMeta = getSectionTargetMeta(targetId)
-  if (!sectionMeta) return null
+function resolveSectionElement(container: HTMLElement, targetId: string): HTMLElement | null {
+    const sectionMeta = getSectionTargetMeta(targetId);
+    if (!sectionMeta) return null;
 
-  const { capitulo, sectionType } = sectionMeta
-  const { start, next } = getChapterBounds(container, capitulo)
-  const isInChapter = (candidate: HTMLElement) =>
-    !start || isElementWithinBounds(candidate, start, next)
+    const { capitulo, sectionType } = sectionMeta;
+    const { start, next } = getChapterBounds(container, capitulo);
+    const isInChapter = (candidate: HTMLElement) =>
+        !start || isElementWithinBounds(candidate, start, next);
 
-  for (const selector of SECTION_SELECTOR_FALLBACKS[sectionType]) {
-    const candidate = Array.from(container.querySelectorAll(selector)).find(
-      (node) => node instanceof HTMLElement && isInChapter(node as HTMLElement)
-    ) as HTMLElement | undefined
+    for (const selector of SECTION_SELECTOR_FALLBACKS[sectionType]) {
+        const candidate = Array.from(container.querySelectorAll(selector))
+            .find((node) => node instanceof HTMLElement && isInChapter(node as HTMLElement)) as HTMLElement | undefined;
 
-    if (candidate) {
-      if (!candidate.id) candidate.id = targetId
-      return candidate
+        if (candidate) {
+            if (!candidate.id) candidate.id = targetId;
+            return candidate;
+        }
     }
-  }
 
-  const headingRegex = SECTION_TEXT_FALLBACKS[sectionType]
-  const heading = Array.from(
-    container.querySelectorAll('h2, h3, h4, p, strong')
-  ).find(
-    (node) =>
-      node instanceof HTMLElement &&
-      isInChapter(node as HTMLElement) &&
-      headingRegex.test((node.textContent || '').trim())
-  ) as HTMLElement | undefined
+    const headingRegex = SECTION_TEXT_FALLBACKS[sectionType];
+    const heading = Array.from(container.querySelectorAll('h2, h3, h4, p, strong'))
+        .find((node) =>
+            node instanceof HTMLElement
+            && isInChapter(node as HTMLElement)
+            && headingRegex.test((node.textContent || '').trim())
+        ) as HTMLElement | undefined;
 
-  if (!heading) return null
+    if (!heading) return null;
 
-  const sectionRoot = heading.closest(
-    'div, section, article, blockquote'
-  ) as HTMLElement | null
-  const resolved = sectionRoot || heading
-  if (!resolved.id) resolved.id = targetId
-  return resolved
+    const sectionRoot = heading.closest('div, section, article, blockquote') as HTMLElement | null;
+    const resolved = sectionRoot || heading;
+    if (!resolved.id) resolved.id = targetId;
+    return resolved;
 }
 
-const TERM_MARK_ATTR = 'data-text-query-highlight'
-const TERM_MARK_SELECTOR = `mark[${TERM_MARK_ATTR}="true"]`
-const TERM_HIGHLIGHT_MAX_MATCHES = 250
-const TERM_HIGHLIGHT_MIN_LENGTH = 2
-const MANUAL_NAVIGATION_HIGHLIGHT_LOCK_MS = 900
-const SKIP_HIGHLIGHT_TAGS = new Set([
-  'SCRIPT',
-  'STYLE',
-  'MARK',
-  'NOSCRIPT',
-  'TEXTAREA',
-])
+const TERM_MARK_ATTR = 'data-text-query-highlight';
+const TERM_MARK_SELECTOR = `mark[${TERM_MARK_ATTR}="true"]`;
+const TERM_HIGHLIGHT_MAX_MATCHES = 250;
+const TERM_HIGHLIGHT_MIN_LENGTH = 2;
+const MANUAL_NAVIGATION_HIGHLIGHT_LOCK_MS = 900;
+const SKIP_HIGHLIGHT_TAGS = new Set(['SCRIPT', 'STYLE', 'MARK', 'NOSCRIPT', 'TEXTAREA']);
 
 function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function unwrapQueryHighlights(container: HTMLElement) {
-  const marks = Array.from(
-    container.querySelectorAll<HTMLElement>(TERM_MARK_SELECTOR)
-  )
-  marks.forEach((mark) => {
-    const parent = mark.parentNode
-    if (!parent) return
-    parent.replaceChild(document.createTextNode(mark.textContent || ''), mark)
-    if (parent instanceof HTMLElement) {
-      parent.normalize()
-    }
-  })
+    const marks = Array.from(container.querySelectorAll<HTMLElement>(TERM_MARK_SELECTOR));
+    marks.forEach(mark => {
+        const parent = mark.parentNode;
+        if (!parent) return;
+        parent.replaceChild(document.createTextNode(mark.textContent || ''), mark);
+        if (parent instanceof HTMLElement) {
+            parent.normalize();
+        }
+    });
 }
 
-function collectHighlightableTextNodes(
-  container: HTMLElement,
-  matcher: RegExp
-): Text[] {
-  const textNodes: Text[] = []
-  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
-    acceptNode: (node) => {
-      const value = node.nodeValue || ''
-      if (!value.trim()) return NodeFilter.FILTER_REJECT
+function collectHighlightableTextNodes(container: HTMLElement, matcher: RegExp): Text[] {
+    const textNodes: Text[] = [];
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
+        acceptNode: (node) => {
+            const value = node.nodeValue || '';
+            if (!value.trim()) return NodeFilter.FILTER_REJECT;
 
-      const parentElement = (node as Text).parentElement
-      if (!parentElement) return NodeFilter.FILTER_REJECT
-      if (SKIP_HIGHLIGHT_TAGS.has(parentElement.tagName))
-        return NodeFilter.FILTER_REJECT
-      if (parentElement.closest(TERM_MARK_SELECTOR))
-        return NodeFilter.FILTER_REJECT
-      if (!matcher.test(value)) return NodeFilter.FILTER_REJECT
+            const parentElement = (node as Text).parentElement;
+            if (!parentElement) return NodeFilter.FILTER_REJECT;
+            if (SKIP_HIGHLIGHT_TAGS.has(parentElement.tagName)) return NodeFilter.FILTER_REJECT;
+            if (parentElement.closest(TERM_MARK_SELECTOR)) return NodeFilter.FILTER_REJECT;
+            if (!matcher.test(value)) return NodeFilter.FILTER_REJECT;
 
-      return NodeFilter.FILTER_ACCEPT
-    },
-  })
+            return NodeFilter.FILTER_ACCEPT;
+        },
+    });
 
-  let currentNode = walker.nextNode()
-  while (currentNode) {
-    textNodes.push(currentNode as Text)
-    currentNode = walker.nextNode()
-  }
+    let currentNode = walker.nextNode();
+    while (currentNode) {
+        textNodes.push(currentNode as Text);
+        currentNode = walker.nextNode();
+    }
 
-  return textNodes
+    return textNodes;
 }
 
 function buildHighlightedFragment(
-  parts: string[],
-  normalizedLowerTerm: string,
-  highlightedCount: number
+    parts: string[],
+    normalizedLowerTerm: string,
+    highlightedCount: number,
 ): { fragment: DocumentFragment; replaced: boolean; highlightedCount: number } {
-  const fragment = document.createDocumentFragment()
-  let replaced = false
-  let nextCount = highlightedCount
+    const fragment = document.createDocumentFragment();
+    let replaced = false;
+    let nextCount = highlightedCount;
 
-  for (const part of parts) {
-    if (!part) continue
+    for (const part of parts) {
+        if (!part) continue;
 
-    const canHighlight =
-      nextCount < TERM_HIGHLIGHT_MAX_MATCHES &&
-      part.toLowerCase() === normalizedLowerTerm
-    if (!canHighlight) {
-      fragment.appendChild(document.createTextNode(part))
-      continue
+        const canHighlight = nextCount < TERM_HIGHLIGHT_MAX_MATCHES
+            && part.toLowerCase() === normalizedLowerTerm;
+        if (!canHighlight) {
+            fragment.appendChild(document.createTextNode(part));
+            continue;
+        }
+
+        const mark = document.createElement('mark');
+        mark.setAttribute(TERM_MARK_ATTR, 'true');
+        mark.className = 'search-highlight search-highlight-partial';
+        mark.textContent = part;
+        fragment.appendChild(mark);
+        nextCount += 1;
+        replaced = true;
     }
 
-    const mark = document.createElement('mark')
-    mark.setAttribute(TERM_MARK_ATTR, 'true')
-    mark.className = 'search-highlight search-highlight-partial'
-    mark.textContent = part
-    fragment.appendChild(mark)
-    nextCount += 1
-    replaced = true
-  }
-
-  return { fragment, replaced, highlightedCount: nextCount }
+    return { fragment, replaced, highlightedCount: nextCount };
 }
 
-function highlightTermInContainer(
-  container: HTMLElement,
-  term: string
-): number {
-  const normalizedTerm = term.trim()
-  if (normalizedTerm.length < TERM_HIGHLIGHT_MIN_LENGTH) return 0
+function highlightTermInContainer(container: HTMLElement, term: string): number {
+    const normalizedTerm = term.trim();
+    if (normalizedTerm.length < TERM_HIGHLIGHT_MIN_LENGTH) return 0;
 
-  const matcher = new RegExp(escapeRegex(normalizedTerm), 'i')
-  const splitRegex = new RegExp(`(${escapeRegex(normalizedTerm)})`, 'gi')
-  const textNodes = collectHighlightableTextNodes(container, matcher)
+    const matcher = new RegExp(escapeRegex(normalizedTerm), 'i');
+    const splitRegex = new RegExp(`(${escapeRegex(normalizedTerm)})`, 'gi');
+    const textNodes = collectHighlightableTextNodes(container, matcher);
 
-  let highlightedCount = 0
-  const normalizedLowerTerm = normalizedTerm.toLowerCase()
+    let highlightedCount = 0;
+    const normalizedLowerTerm = normalizedTerm.toLowerCase();
 
-  for (const node of textNodes) {
-    if (highlightedCount >= TERM_HIGHLIGHT_MAX_MATCHES) break
+    for (const node of textNodes) {
+        if (highlightedCount >= TERM_HIGHLIGHT_MAX_MATCHES) break;
 
-    const text = node.nodeValue || ''
-    const parts = text.split(splitRegex)
-    if (parts.length < 3) continue
+        const text = node.nodeValue || '';
+        const parts = text.split(splitRegex);
+        if (parts.length < 3) continue;
 
-    const {
-      fragment,
-      replaced,
-      highlightedCount: nextCount,
-    } = buildHighlightedFragment(parts, normalizedLowerTerm, highlightedCount)
-    highlightedCount = nextCount
+        const { fragment, replaced, highlightedCount: nextCount } = buildHighlightedFragment(
+            parts,
+            normalizedLowerTerm,
+            highlightedCount,
+        );
+        highlightedCount = nextCount;
 
-    if (!replaced || !node.parentNode) continue
-    node.parentNode.replaceChild(fragment, node)
-  }
+        if (!replaced || !node.parentNode) continue;
+        node.parentNode.replaceChild(fragment, node);
+    }
 
-  return highlightedCount
+    return highlightedCount;
 }
 
 interface ResultData {
-  type?: 'text' | 'code'
-  markdown?: string
-  ncm?: string
-  query?: string
-  results?: SearchResultItem[] | Record<string, any>
-  resultados?: any // Complex object passed to Sidebar
+    type?: 'text' | 'code';
+    markdown?: string;
+    ncm?: string;
+    query?: string;
+    results?: SearchResultItem[] | Record<string, any>;
+    resultados?: any; // Complex object passed to Sidebar
 }
 
 interface ResultDisplayProps {
-  data: ResultData | null
-  mobileMenuOpen: boolean
-  onCloseMobileMenu: () => void
-  onToggleMobileMenu?: () => void
-  isActive: boolean
-  tabId: string
-  initialScrollTop?: number
-  onPersistScroll?: (tabId: string, scrollTop: number) => void
-  latestTextQuery?: string
-  /** Flag indicando nova busca - ativa auto-scroll */
-  isNewSearch: boolean
-  /** Callback para consumir flag após auto-scroll, recebendo opcionalmente o scroll final */
-  onConsumeNewSearch: (tabId: string, finalScrollTop?: number) => void
-  /** Callback to notify parent when content is ready (for coordinated loading) */
-  onContentReady?: (tabId: string) => void
-  onHydratedResults?: (tabId: string, results: Record<string, any>) => void
+    data: ResultData | null;
+    mobileMenuOpen: boolean;
+    onCloseMobileMenu: () => void;
+    onToggleMobileMenu?: () => void;
+    isActive: boolean;
+    tabId: string;
+    initialScrollTop?: number;
+    onPersistScroll?: (tabId: string, scrollTop: number) => void;
+    latestTextQuery?: string;
+    /** Flag indicando nova busca - ativa auto-scroll */
+    isNewSearch: boolean;
+    /** Callback para consumir flag após auto-scroll, recebendo opcionalmente o scroll final */
+    onConsumeNewSearch: (tabId: string, finalScrollTop?: number) => void;
+    /** Callback to notify parent when content is ready (for coordinated loading) */
+    onContentReady?: (tabId: string) => void;
+    onHydratedResults?: (tabId: string, results: Record<string, any>) => void;
 }
 
 type MarkupRenderRefs = {
-  contentRef: React.RefObject<HTMLDivElement | null>
-  renderedMarkupKeyRef: React.MutableRefObject<string | null>
-  lastMarkupRef: React.MutableRefObject<string | null>
-  lastHtmlRef: React.MutableRefObject<string | null>
-}
+    contentRef: React.RefObject<HTMLDivElement | null>;
+    renderedMarkupKeyRef: React.MutableRefObject<string | null>;
+    lastMarkupRef: React.MutableRefObject<string | null>;
+    lastHtmlRef: React.MutableRefObject<string | null>;
+};
 
 type MarkupRenderOptions = {
-  rawMarkdown: string
-  markupToRender: string
-  isActive: boolean
-  isContentReady: boolean
-  refs: MarkupRenderRefs
-  setIsContentReady: React.Dispatch<React.SetStateAction<boolean>>
-  setIsFullyRendered: React.Dispatch<React.SetStateAction<boolean>>
-}
+    rawMarkdown: string;
+    markupToRender: string;
+    isActive: boolean;
+    isContentReady: boolean;
+    refs: MarkupRenderRefs;
+    setIsContentReady: React.Dispatch<React.SetStateAction<boolean>>;
+    setIsFullyRendered: React.Dispatch<React.SetStateAction<boolean>>;
+};
 
-const SECTION_TYPES: ChapterSectionType[] = [
-  'titulo',
-  'notas',
-  'consideracoes',
-  'definicoes',
-]
-const CHUNK_SIZE_THRESHOLD = 50_000
+const SECTION_TYPES: ChapterSectionType[] = ['titulo', 'notas', 'consideracoes', 'definicoes'];
+const CHUNK_SIZE_THRESHOLD = 50_000;
 
 function scheduleIdleTask(callback: () => void): number {
-  if (typeof requestIdleCallback === 'function') {
-    return requestIdleCallback(callback, { timeout: 100 })
-  }
-  return setTimeout(callback, 16) as unknown as number
+    if (typeof requestIdleCallback === 'function') {
+        return requestIdleCallback(callback, { timeout: 100 });
+    }
+    return setTimeout(callback, 16) as unknown as number;
 }
 
 function cancelIdleTask(taskId: number) {
-  if (typeof cancelIdleCallback === 'function') {
-    cancelIdleCallback(taskId)
-    return
-  }
-  clearTimeout(taskId)
+    if (typeof cancelIdleCallback === 'function') {
+        cancelIdleCallback(taskId);
+        return;
+    }
+    clearTimeout(taskId);
 }
 
 function appendMarkupChunk(container: HTMLElement, htmlChunk: string) {
-  appendTrustedHtmlToElement(container, htmlChunk)
+    appendTrustedHtmlToElement(container, htmlChunk);
 }
 
 function normalizeDigits(value: string): string {
-  return value.replace(/\D/g, '')
+    return value.replace(/\D/g, '');
 }
 
 function buildAnchorCandidatesFromDigits(digits: string): string[] {
-  if (digits.length < 4) return []
+    if (digits.length < 4) return [];
 
-  const head4 = digits.slice(0, 4)
-  const candidates = [
-    `pos-${head4.slice(0, 2)}-${head4.slice(2)}`,
-    `pos-${head4}`,
-  ]
-  if (digits.length >= 6) {
-    candidates.push(`pos-${digits.slice(0, 4)}-${digits.slice(4, 6)}`)
-  }
-  if (digits.length >= 8) {
-    candidates.push(
-      `pos-${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`
-    )
-  }
-  return candidates
+    const head4 = digits.slice(0, 4);
+    const candidates = [`pos-${head4.slice(0, 2)}-${head4.slice(2)}`, `pos-${head4}`];
+    if (digits.length >= 6) {
+        candidates.push(`pos-${digits.slice(0, 4)}-${digits.slice(4, 6)}`);
+    }
+    if (digits.length >= 8) {
+        candidates.push(`pos-${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`);
+    }
+    return candidates;
 }
 
 function resolveNcmToScroll(data: ResultData | null): string | null {
-  if (!data) return null
-  return data.ncm || data.query || null
+    if (!data) return null;
+    return data.ncm || data.query || null;
 }
 
 function resolveMarkupToRender(
-  rawMarkdown: string,
-  codeResults: Record<string, any> | null
+    rawMarkdown: string,
+    codeResults: Record<string, any> | null,
 ): string {
-  if (rawMarkdown) return rawMarkdown
-  if (!codeResults) return ''
-  if (isTipiResults(codeResults)) {
-    return renderTipiFallback(codeResults)
-  }
+    if (rawMarkdown) return rawMarkdown;
+    if (!codeResults) return '';
+    if (isTipiResults(codeResults)) {
+        return renderTipiFallback(codeResults);
+    }
 
-  console.warn(
-    '[ResultDisplay] Fallback NeshRenderer used - backend should send markdown'
-  )
-  return NeshRenderer.renderFullResponse(codeResults)
+    console.warn('[ResultDisplay] Fallback NeshRenderer used - backend should send markdown');
+    return NeshRenderer.renderFullResponse(codeResults);
 }
 
 function chapterHasRenderableContent(chapter: any): boolean {
-  const content = chapter?.conteudo
-  return typeof content === 'string' && content.trim().length > 0
+    const content = chapter?.conteudo;
+    return typeof content === 'string' && content.trim().length > 0;
 }
 
 function getSectionContent(sectionValue: unknown): string {
-  if (typeof sectionValue === 'string') {
-    return sectionValue.trim()
-  }
-  if (typeof sectionValue === 'number') {
-    return String(sectionValue).trim()
-  }
-  return ''
+    if (typeof sectionValue === 'string') {
+        return sectionValue.trim();
+    }
+    if (typeof sectionValue === 'number') {
+        return String(sectionValue).trim();
+    }
+    return '';
 }
 
 function getAnchorCodeFromNcmValue(value: string): string {
-  if (value.includes('.') || value.length !== 4) {
-    return value
-  }
-  return `${value.slice(0, 2)}.${value.slice(2, 4)}`
+    if (value.includes('.') || value.length !== 4) {
+        return value;
+    }
+    return `${value.slice(0, 2)}.${value.slice(2, 4)}`;
 }
 
 function resolveChapterResultKey(
-  results: Record<string, any>,
-  chapterNumber: string
+    results: Record<string, any>,
+    chapterNumber: string,
 ): string {
-  return (
-    Object.keys(results).find((key) => {
-      const existingChapter = results[key]
-      return existingChapter?.capitulo === chapterNumber
-    }) ?? chapterNumber
-  )
+    return Object.keys(results).find((key) => {
+        const existingChapter = results[key];
+        return existingChapter?.capitulo === chapterNumber;
+    }) ?? chapterNumber;
 }
 
 function mergeHydratedChapterBodies(
-  baseResults: Record<string, any>,
-  chapterBodies: ChapterBodyResponse[]
+    baseResults: Record<string, any>,
+    chapterBodies: ChapterBodyResponse[],
 ): Record<string, any> {
-  const nextResults = { ...baseResults }
+    const nextResults = { ...baseResults };
 
-  for (const chapterBody of chapterBodies) {
-    const chapterKey = resolveChapterResultKey(
-      nextResults,
-      chapterBody.capitulo
-    )
-    const existingChapter = nextResults[chapterKey]
-    if (!existingChapter || typeof existingChapter !== 'object') {
-      continue
+    for (const chapterBody of chapterBodies) {
+        const chapterKey = resolveChapterResultKey(nextResults, chapterBody.capitulo);
+        const existingChapter = nextResults[chapterKey];
+        if (!existingChapter || typeof existingChapter !== 'object') {
+            continue;
+        }
+
+        nextResults[chapterKey] = {
+            ...existingChapter,
+            conteudo: chapterBody.conteudo,
+            notas_parseadas: chapterBody.notas_parseadas ?? existingChapter.notas_parseadas ?? {},
+            notas_gerais: chapterBody.notas_gerais ?? existingChapter.notas_gerais ?? null,
+            secoes: chapterBody.secoes ?? existingChapter.secoes,
+        };
     }
 
-    nextResults[chapterKey] = {
-      ...existingChapter,
-      conteudo: chapterBody.conteudo,
-      notas_parseadas:
-        chapterBody.notas_parseadas ?? existingChapter.notas_parseadas ?? {},
-      notas_gerais:
-        chapterBody.notas_gerais ?? existingChapter.notas_gerais ?? null,
-      secoes: chapterBody.secoes ?? existingChapter.secoes,
-    }
-  }
-
-  return nextResults
+    return nextResults;
 }
 
 type ChapterHydrationResult = {
-  chapterBodies: ChapterBodyResponse[]
-  failedChapters: string[]
-}
+    chapterBodies: ChapterBodyResponse[];
+    failedChapters: string[];
+};
 
 function createFailedChapterBodiesUpdater(failedChapters: string[]) {
-  return (current: string[]) =>
-    Array.from(new Set([...current, ...failedChapters]))
+    return (current: string[]) => Array.from(new Set([...current, ...failedChapters]));
 }
 
-function createRecoveredChapterBodiesUpdater(
-  chapterBodies: ChapterBodyResponse[]
-) {
-  const recoveredChapters = new Set(chapterBodies.map((body) => body.capitulo))
-  return (current: string[]) =>
-    current.filter((chapter) => !recoveredChapters.has(chapter))
+function createRecoveredChapterBodiesUpdater(chapterBodies: ChapterBodyResponse[]) {
+    const recoveredChapters = new Set(chapterBodies.map((body) => body.capitulo));
+    return (current: string[]) => current.filter((chapter) => !recoveredChapters.has(chapter));
 }
 
-async function fetchChapterBodies(
-  chapters: string[]
-): Promise<ChapterHydrationResult> {
-  const settledBodies = await Promise.allSettled(
-    chapters.map((chapter) => getNeshChapterBody(chapter))
-  )
-  const fulfilledBodies: ChapterBodyResponse[] = []
-  const failedChapters: string[] = []
+async function fetchChapterBodies(chapters: string[]): Promise<ChapterHydrationResult> {
+    const settledBodies = await Promise.allSettled(
+        chapters.map((chapter) => getNeshChapterBody(chapter)),
+    );
+    const fulfilledBodies: ChapterBodyResponse[] = [];
+    const failedChapters: string[] = [];
 
-  settledBodies.forEach((result, index) => {
-    if (result.status === 'fulfilled') {
-      fulfilledBodies.push(result.value)
-      return
-    }
+    settledBodies.forEach((result, index) => {
+        if (result.status === 'fulfilled') {
+            fulfilledBodies.push(result.value);
+            return;
+        }
 
-    failedChapters.push(chapters[index])
-    console.error('[ResultDisplay] Failed to fetch chapter body', {
-      chapter: chapters[index],
-      error: result.reason,
-    })
-  })
+        failedChapters.push(chapters[index]);
+        console.error('[ResultDisplay] Failed to fetch chapter body', {
+            chapter: chapters[index],
+            error: result.reason,
+        });
+    });
 
-  return {
-    chapterBodies: fulfilledBodies,
-    failedChapters,
-  }
+    return {
+        chapterBodies: fulfilledBodies,
+        failedChapters,
+    };
 }
 
 function getCachedRawMarkup(
-  cacheKey: string,
-  shouldParseMarkdown: boolean,
-  markupToRender: string,
-  lastMarkupRef: React.MutableRefObject<string | null>,
-  lastHtmlRef: React.MutableRefObject<string | null>
+    cacheKey: string,
+    shouldParseMarkdown: boolean,
+    markupToRender: string,
+    lastMarkupRef: React.MutableRefObject<string | null>,
+    lastHtmlRef: React.MutableRefObject<string | null>,
 ): string {
-  const cachedRawMarkup = cacheGet(sharedRawMarkupCache, cacheKey)
-  if (cachedRawMarkup) return cachedRawMarkup
+    const cachedRawMarkup = cacheGet(sharedRawMarkupCache, cacheKey);
+    if (cachedRawMarkup) return cachedRawMarkup;
 
-  const reusableMarkup =
-    lastMarkupRef.current === cacheKey ? lastHtmlRef.current : null
-  if (reusableMarkup) {
-    cacheSet(sharedRawMarkupCache, cacheKey, reusableMarkup)
-    return reusableMarkup
-  }
+    const reusableMarkup = lastMarkupRef.current === cacheKey ? lastHtmlRef.current : null;
+    if (reusableMarkup) {
+        cacheSet(sharedRawMarkupCache, cacheKey, reusableMarkup);
+        return reusableMarkup;
+    }
 
-  let nextRawMarkup = markupToRender
-  if (shouldParseMarkdown) {
-    // @ts-ignore - marked types might mismatch slightly depending on version
-    nextRawMarkup = marked.parse(markupToRender) as string
-  }
+    let nextRawMarkup = markupToRender;
+    if (shouldParseMarkdown) {
+        // @ts-ignore - marked types might mismatch slightly depending on version
+        nextRawMarkup = marked.parse(markupToRender) as string;
+    }
 
-  cacheSet(sharedRawMarkupCache, cacheKey, nextRawMarkup)
-  return nextRawMarkup
+    cacheSet(sharedRawMarkupCache, cacheKey, nextRawMarkup);
+    return nextRawMarkup;
 }
 
 function getFinalMarkup(rawMarkup: string, cacheKey: string): string {
-  const cachedSanitizedMarkup = cacheGet(sharedSanitizedMarkupCache, cacheKey)
-  if (cachedSanitizedMarkup) return cachedSanitizedMarkup
+    const cachedSanitizedMarkup = cacheGet(sharedSanitizedMarkupCache, cacheKey);
+    if (cachedSanitizedMarkup) return cachedSanitizedMarkup;
 
-  const sanitizedMarkup = sanitizeRichHtml(rawMarkup)
-  cacheSet(sharedSanitizedMarkupCache, cacheKey, sanitizedMarkup)
-  return sanitizedMarkup
+    const sanitizedMarkup = sanitizeRichHtml(rawMarkup);
+    cacheSet(sharedSanitizedMarkupCache, cacheKey, sanitizedMarkup);
+    return sanitizedMarkup;
 }
 
 function renderSmallMarkup(
-  contentRef: React.RefObject<HTMLDivElement | null>,
-  finalMarkup: string,
-  cacheKey: string,
-  renderedMarkupKeyRef: React.MutableRefObject<string | null>,
-  setIsContentReady: React.Dispatch<React.SetStateAction<boolean>>,
-  setIsFullyRendered: React.Dispatch<React.SetStateAction<boolean>>
+    contentRef: React.RefObject<HTMLDivElement | null>,
+    finalMarkup: string,
+    cacheKey: string,
+    renderedMarkupKeyRef: React.MutableRefObject<string | null>,
+    setIsContentReady: React.Dispatch<React.SetStateAction<boolean>>,
+    setIsFullyRendered: React.Dispatch<React.SetStateAction<boolean>>,
 ): () => void {
-  const frameId = requestAnimationFrame(() => {
-    if (!contentRef.current) return
-    replaceElementWithTrustedHtml(contentRef.current, finalMarkup)
-    renderedMarkupKeyRef.current = cacheKey
-    setIsContentReady(true)
-    setIsFullyRendered(true)
-  })
+    const frameId = requestAnimationFrame(() => {
+        if (!contentRef.current) return;
+        replaceElementWithTrustedHtml(contentRef.current, finalMarkup);
+        renderedMarkupKeyRef.current = cacheKey;
+        setIsContentReady(true);
+        setIsFullyRendered(true);
+    });
 
-  return () => cancelAnimationFrame(frameId)
+    return () => cancelAnimationFrame(frameId);
 }
 
 function renderChunkedMarkup(
-  contentRef: React.RefObject<HTMLDivElement | null>,
-  finalMarkup: string,
-  cacheKey: string,
-  renderedMarkupKeyRef: React.MutableRefObject<string | null>,
-  setIsContentReady: React.Dispatch<React.SetStateAction<boolean>>,
-  setIsFullyRendered: React.Dispatch<React.SetStateAction<boolean>>
+    contentRef: React.RefObject<HTMLDivElement | null>,
+    finalMarkup: string,
+    cacheKey: string,
+    renderedMarkupKeyRef: React.MutableRefObject<string | null>,
+    setIsContentReady: React.Dispatch<React.SetStateAction<boolean>>,
+    setIsFullyRendered: React.Dispatch<React.SetStateAction<boolean>>,
 ): () => void {
-  const chunks = finalMarkup.split(/(?=<hr\s*\/?>)/i)
-  const pendingIdleIds: number[] = []
-  let cancelled = false
+    const chunks = finalMarkup.split(/(?=<hr\s*\/?>)/i);
+    const pendingIdleIds: number[] = [];
+    let cancelled = false;
 
-  const frameId = requestAnimationFrame(() => {
-    if (cancelled || !contentRef.current) return
+    const frameId = requestAnimationFrame(() => {
+        if (cancelled || !contentRef.current) return;
 
-    contentRef.current.textContent = ''
-    if (chunks.length > 0) {
-      appendMarkupChunk(contentRef.current, chunks[0])
-    }
+        contentRef.current.textContent = '';
+        if (chunks.length > 0) {
+            appendMarkupChunk(contentRef.current, chunks[0]);
+        }
 
-    // Marca o conteúdo como pronto após o primeiro chunk para liberar auto-scroll cedo.
-    renderedMarkupKeyRef.current = cacheKey
-    setIsContentReady(true)
+        // Marca o conteúdo como pronto após o primeiro chunk para liberar auto-scroll cedo.
+        renderedMarkupKeyRef.current = cacheKey;
+        setIsContentReady(true);
 
-    const enqueueChunk = (index: number) => {
-      if (index >= chunks.length) {
-        setIsFullyRendered(true)
-        return
-      }
+        const enqueueChunk = (index: number) => {
+            if (index >= chunks.length) {
+                setIsFullyRendered(true);
+                return;
+            }
 
-      const idleId = scheduleIdleTask(() => {
-        if (cancelled || !contentRef.current) return
-        appendMarkupChunk(contentRef.current, chunks[index])
-        enqueueChunk(index + 1)
-      })
-      pendingIdleIds.push(idleId)
-    }
+            const idleId = scheduleIdleTask(() => {
+                if (cancelled || !contentRef.current) return;
+                appendMarkupChunk(contentRef.current, chunks[index]);
+                enqueueChunk(index + 1);
+            });
+            pendingIdleIds.push(idleId);
+        };
 
-    enqueueChunk(1)
-  })
+        enqueueChunk(1);
+    });
 
-  return () => {
-    cancelled = true
-    cancelAnimationFrame(frameId)
-    pendingIdleIds.forEach(cancelIdleTask)
-  }
+    return () => {
+        cancelled = true;
+        cancelAnimationFrame(frameId);
+        pendingIdleIds.forEach(cancelIdleTask);
+    };
 }
 
-function renderMarkupContent(
-  options: MarkupRenderOptions
-): (() => void) | undefined {
-  const {
-    rawMarkdown,
-    markupToRender,
-    isActive,
-    isContentReady,
-    refs,
-    setIsContentReady,
-    setIsFullyRendered,
-  } = options
-  const container = refs.contentRef.current
-  if (!container) return undefined
+function renderMarkupContent(options: MarkupRenderOptions): (() => void) | undefined {
+    const { rawMarkdown, markupToRender, isActive, isContentReady, refs, setIsContentReady, setIsFullyRendered } = options;
+    const container = refs.contentRef.current;
+    if (!container) return undefined;
 
-  const shouldParseMarkdown =
-    !!rawMarkdown && isLikelyLegacyMarkdown(markupToRender)
-  const cacheKey = `${shouldParseMarkdown ? 'md' : 'html'}:${markupToRender}`
+    const shouldParseMarkdown = !!rawMarkdown && isLikelyLegacyMarkdown(markupToRender);
+    const cacheKey = `${shouldParseMarkdown ? 'md' : 'html'}:${markupToRender}`;
 
-  // Aba inativa: preservar o DOM existente para restauração de scroll.
-  // TabPanel já esconde com display:none; não precisa limpar.
-  if (!isActive) {
-    return undefined
-  }
+    // Aba inativa: preservar o DOM existente para restauração de scroll.
+    // TabPanel já esconde com display:none; não precisa limpar.
+    if (!isActive) {
+        return undefined;
+    }
 
-  const isAlreadyRendered =
-    refs.renderedMarkupKeyRef.current === cacheKey &&
-    container.childNodes.length > 0
-  if (isAlreadyRendered) {
-    if (!isContentReady) setIsContentReady(true)
-    setIsFullyRendered(true)
-    return undefined
-  }
+    const isAlreadyRendered = refs.renderedMarkupKeyRef.current === cacheKey && container.childNodes.length > 0;
+    if (isAlreadyRendered) {
+        if (!isContentReady) setIsContentReady(true);
+        setIsFullyRendered(true);
+        return undefined;
+    }
 
-  setIsContentReady(false)
-  setIsFullyRendered(false)
-  const rawMarkup = getCachedRawMarkup(
-    cacheKey,
-    shouldParseMarkdown,
-    markupToRender,
-    refs.lastMarkupRef,
-    refs.lastHtmlRef
-  )
-  refs.lastMarkupRef.current = cacheKey
-  refs.lastHtmlRef.current = rawMarkup
+    setIsContentReady(false);
+    setIsFullyRendered(false);
+    const rawMarkup = getCachedRawMarkup(
+        cacheKey,
+        shouldParseMarkdown,
+        markupToRender,
+        refs.lastMarkupRef,
+        refs.lastHtmlRef,
+    );
+    refs.lastMarkupRef.current = cacheKey;
+    refs.lastHtmlRef.current = rawMarkup;
 
-  const finalMarkup = getFinalMarkup(rawMarkup, cacheKey)
-  if (finalMarkup.length <= CHUNK_SIZE_THRESHOLD) {
-    return renderSmallMarkup(
-      refs.contentRef,
-      finalMarkup,
-      cacheKey,
-      refs.renderedMarkupKeyRef,
-      setIsContentReady,
-      setIsFullyRendered
-    )
-  }
+    const finalMarkup = getFinalMarkup(rawMarkup, cacheKey);
+    if (finalMarkup.length <= CHUNK_SIZE_THRESHOLD) {
+        return renderSmallMarkup(refs.contentRef, finalMarkup, cacheKey, refs.renderedMarkupKeyRef, setIsContentReady, setIsFullyRendered);
+    }
 
-  return renderChunkedMarkup(
-    refs.contentRef,
-    finalMarkup,
-    cacheKey,
-    refs.renderedMarkupKeyRef,
-    setIsContentReady,
-    setIsFullyRendered
-  )
+    return renderChunkedMarkup(refs.contentRef, finalMarkup, cacheKey, refs.renderedMarkupKeyRef, setIsContentReady, setIsFullyRendered);
 }
 
 function getWrapperClasses(
-  stylesMap: typeof styles,
-  sidebarCollapsed: boolean,
-  mobileMenuOpen: boolean,
-  sidebarPosition: 'left' | 'right'
+    stylesMap: typeof styles,
+    sidebarCollapsed: boolean,
+    mobileMenuOpen: boolean,
+    sidebarPosition: 'left' | 'right',
 ): string {
-  return [
-    stylesMap.wrapper,
-    sidebarCollapsed ? stylesMap.sidebarCollapsed : '',
-    mobileMenuOpen ? stylesMap.sidebarOpen : '',
-    sidebarPosition === 'left' ? stylesMap.sidebarLeft : '',
-  ]
-    .filter(Boolean)
-    .join(' ')
+    return [
+        stylesMap.wrapper,
+        sidebarCollapsed ? stylesMap.sidebarCollapsed : '',
+        mobileMenuOpen ? stylesMap.sidebarOpen : '',
+        sidebarPosition === 'left' ? stylesMap.sidebarLeft : '',
+    ].filter(Boolean).join(' ');
 }
 
-function getSidebarToggleIcon(
-  sidebarPosition: 'left' | 'right',
-  sidebarCollapsed: boolean
-): string {
-  if (sidebarPosition === 'left') {
-    return sidebarCollapsed ? '▶' : '◀'
-  }
-  return sidebarCollapsed ? '◀' : '▶'
+function getSidebarToggleIcon(sidebarPosition: 'left' | 'right', sidebarCollapsed: boolean): string {
+    if (sidebarPosition === 'left') {
+        return sidebarCollapsed ? '▶' : '◀';
+    }
+    return sidebarCollapsed ? '◀' : '▶';
 }
 
 function getSidebarToggleLabel(sidebarCollapsed: boolean): string {
-  return sidebarCollapsed ? 'Expandir navegação' : 'Recolher navegação'
+    return sidebarCollapsed ? 'Expandir navegação' : 'Recolher navegação';
 }
 
-function getContentVisibilityClass(
-  stylesMap: typeof styles,
-  isContentReady: boolean
-): string {
-  return isContentReady ? stylesMap.contentVisible : stylesMap.contentHidden
+function getContentVisibilityClass(stylesMap: typeof styles, isContentReady: boolean): string {
+    return isContentReady ? stylesMap.contentVisible : stylesMap.contentHidden;
 }
 
-function getCommentToggleClassName(
-  stylesMap: typeof styles,
-  commentsEnabled: boolean
-): string {
-  if (!commentsEnabled) return stylesMap.commentToggle
-  return `${stylesMap.commentToggle} ${stylesMap.commentToggleActive}`
+function getCommentToggleClassName(stylesMap: typeof styles, commentsEnabled: boolean): string {
+    if (!commentsEnabled) return stylesMap.commentToggle;
+    return `${stylesMap.commentToggle} ${stylesMap.commentToggleActive}`;
 }
 
 function getCommentToggleLabel(commentsEnabled: boolean): string {
-  return commentsEnabled ? 'Desativar comentários' : 'Ativar comentários'
+    return commentsEnabled ? 'Desativar comentários' : 'Ativar comentários';
 }
 
 function findAnchorIdInChapter(
-  chapter: any,
-  normalizedQuery: string,
-  existingPrefix: string | null
+    chapter: any,
+    normalizedQuery: string,
+    existingPrefix: string | null,
 ): { exactMatch: string | null; prefixMatch: string | null } {
-  const positions = Array.isArray(chapter?.posicoes) ? chapter.posicoes : []
-  let prefixMatch = existingPrefix
+    const positions = Array.isArray(chapter?.posicoes) ? chapter.posicoes : [];
+    let prefixMatch = existingPrefix;
 
-  for (const pos of positions) {
-    const codigo = (pos?.codigo || pos?.ncm || '').toString()
-    if (!codigo) continue
+    for (const pos of positions) {
+        const codigo = (pos?.codigo || pos?.ncm || '').toString();
+        if (!codigo) continue;
 
-    const normalizedCodigo = normalizeDigits(codigo)
-    if (normalizedCodigo === normalizedQuery) {
-      return {
-        exactMatch: pos?.anchor_id || generateAnchorId(codigo),
-        prefixMatch,
-      }
+        const normalizedCodigo = normalizeDigits(codigo);
+        if (normalizedCodigo === normalizedQuery) {
+            return {
+                exactMatch: pos?.anchor_id || generateAnchorId(codigo),
+                prefixMatch,
+            };
+        }
+
+        if (!prefixMatch && normalizedCodigo.startsWith(normalizedQuery)) {
+            prefixMatch = pos?.anchor_id || generateAnchorId(codigo);
+        }
     }
 
-    if (!prefixMatch && normalizedCodigo.startsWith(normalizedQuery)) {
-      prefixMatch = pos?.anchor_id || generateAnchorId(codigo)
-    }
-  }
-
-  return { exactMatch: null, prefixMatch }
+    return { exactMatch: null, prefixMatch };
 }
 
-function getStructuredSectionIds(
-  capitulo: string,
-  secoes: Record<string, unknown>
-): string[] {
-  const ids: string[] = []
-  for (const sectionType of SECTION_TYPES) {
-    const sectionValue = secoes[sectionType]
-    const sectionContent = getSectionContent(sectionValue)
-    if (!sectionContent) continue
-    ids.push(`chapter-${capitulo}-${sectionType}`)
-  }
-  return ids
+function getStructuredSectionIds(capitulo: string, secoes: Record<string, unknown>): string[] {
+    const ids: string[] = [];
+    for (const sectionType of SECTION_TYPES) {
+        const sectionValue = secoes[sectionType];
+        const sectionContent = getSectionContent(sectionValue);
+        if (!sectionContent) continue;
+        ids.push(`chapter-${capitulo}-${sectionType}`);
+    }
+    return ids;
 }
 
 function resolveAutoScrollCandidates(
-  ncmToScroll: string,
-  codeResults: Record<string, any> | null,
-  findAnchorIdForQuery: (resultados: any, query: string) => string | null,
-  getPosicaoAlvoFromResultados: (resultados: any) => string | null
+    ncmToScroll: string,
+    codeResults: Record<string, any> | null,
+    findAnchorIdForQuery: (resultados: any, query: string) => string | null,
+    getPosicaoAlvoFromResultados: (resultados: any) => string | null,
 ): string[] {
-  const posicaoAlvo = codeResults
-    ? getPosicaoAlvoFromResultados(codeResults)
-    : null
-  const anchorFromResultados = codeResults
-    ? findAnchorIdForQuery(codeResults, ncmToScroll)
-    : null
-  const exactId =
-    anchorFromResultados ||
-    (posicaoAlvo ? generateAnchorId(posicaoAlvo) : null) ||
-    generateAnchorId(ncmToScroll)
+    const posicaoAlvo = codeResults ? getPosicaoAlvoFromResultados(codeResults) : null;
+    const anchorFromResultados = codeResults ? findAnchorIdForQuery(codeResults, ncmToScroll) : null;
+    const exactId = anchorFromResultados
+        || (posicaoAlvo ? generateAnchorId(posicaoAlvo) : null)
+        || generateAnchorId(ncmToScroll);
 
-  const candidates = [exactId]
-  candidates.push(
-    ...buildAnchorCandidatesFromDigits(normalizeDigits(ncmToScroll))
-  )
-  return Array.from(new Set(candidates))
+    const candidates = [exactId];
+    candidates.push(...buildAnchorCandidatesFromDigits(normalizeDigits(ncmToScroll)));
+    return Array.from(new Set(candidates));
 }
 
-function findExistingTargetElement(
-  container: HTMLElement,
-  targets: string[]
-): HTMLElement | null {
-  for (const id of targets) {
-    const element = container.querySelector(
-      `#${CSS.escape(id)}`
-    ) as HTMLElement | null
-    if (element) return element
-  }
-  return null
+function findExistingTargetElement(container: HTMLElement, targets: string[]): HTMLElement | null {
+    for (const id of targets) {
+        const element = container.querySelector(`#${CSS.escape(id)}`) as HTMLElement | null;
+        if (element) return element;
+    }
+    return null;
 }
 
 function buildDataNcmTargetValues(candidateNcm: string): string[] {
-  const normalized = normalizeDigits(candidateNcm)
-  if (!normalized) return []
+    const normalized = normalizeDigits(candidateNcm);
+    if (!normalized) return [];
 
-  const values = new Set<string>([normalized])
-  if (normalized.length >= 6) {
-    values.add(`${normalized.slice(0, 4)}.${normalized.slice(4, 6)}`)
-  }
-  if (normalized.length >= 8) {
-    values.add(
-      `${normalized.slice(0, 4)}.${normalized.slice(4, 6)}.${normalized.slice(6, 8)}`
-    )
-  }
-  if (normalized.length >= 4) {
-    const positionDigits = normalized.slice(0, 4)
-    values.add(positionDigits)
-    values.add(`${positionDigits.slice(0, 2)}.${positionDigits.slice(2, 4)}`)
-  }
+    const values = new Set<string>([normalized]);
+    if (normalized.length >= 6) {
+        values.add(`${normalized.slice(0, 4)}.${normalized.slice(4, 6)}`);
+    }
+    if (normalized.length >= 8) {
+        values.add(`${normalized.slice(0, 4)}.${normalized.slice(4, 6)}.${normalized.slice(6, 8)}`);
+    }
+    if (normalized.length >= 4) {
+        const positionDigits = normalized.slice(0, 4);
+        values.add(positionDigits);
+        values.add(`${positionDigits.slice(0, 2)}.${positionDigits.slice(2, 4)}`);
+    }
 
-  return Array.from(values)
+    return Array.from(values);
 }
 
 function ensureTargetAnchorFromDataNcm(
-  container: HTMLElement,
-  candidateNcm: string | null | undefined
+    container: HTMLElement,
+    candidateNcm: string | null | undefined,
 ): HTMLElement | null {
-  for (const value of buildDataNcmTargetValues(candidateNcm || '')) {
-    const element = container.querySelector(
-      `[data-ncm="${value}"]`
-    ) as HTMLElement | null
-    if (!element) continue
+    for (const value of buildDataNcmTargetValues(candidateNcm || '')) {
+        const element = container.querySelector(`[data-ncm="${value}"]`) as HTMLElement | null;
+        if (!element) continue;
 
-    const anchorCode = getAnchorCodeFromNcmValue(value)
-    if (!element.id) {
-      element.id = generateAnchorId(anchorCode)
+        const anchorCode = getAnchorCodeFromNcmValue(value);
+        if (!element.id) {
+            element.id = generateAnchorId(anchorCode);
+        }
+        return element;
     }
-    return element
-  }
 
-  return null
+    return null;
 }
 
-function getNextVisibleAnchorId(
-  entries: IntersectionObserverEntry[]
-): string | null {
-  const visible = entries
-    .filter((entry) => entry.isIntersecting)
-    .sort(
-      (left, right) =>
-        left.boundingClientRect.top - right.boundingClientRect.top
-    )
-  return visible[0]?.target?.id || null
+function getNextVisibleAnchorId(entries: IntersectionObserverEntry[]): string | null {
+    const visible = entries
+        .filter(entry => entry.isIntersecting)
+        .sort((left, right) => left.boundingClientRect.top - right.boundingClientRect.top);
+    return visible[0]?.target?.id || null;
 }
 
 function scheduleActiveAnchorUpdate(
-  nextAnchorId: string,
-  activeAnchorIdRef: React.MutableRefObject<string | null>,
-  anchorRafRef: React.MutableRefObject<number | null>,
-  setActiveAnchorId: React.Dispatch<React.SetStateAction<string | null>>
+    nextAnchorId: string,
+    activeAnchorIdRef: React.MutableRefObject<string | null>,
+    anchorRafRef: React.MutableRefObject<number | null>,
+    setActiveAnchorId: React.Dispatch<React.SetStateAction<string | null>>,
 ) {
-  if (nextAnchorId === activeAnchorIdRef.current) return
+    if (nextAnchorId === activeAnchorIdRef.current) return;
 
-  if (anchorRafRef.current !== null) {
-    cancelAnimationFrame(anchorRafRef.current)
-  }
+    if (anchorRafRef.current !== null) {
+        cancelAnimationFrame(anchorRafRef.current);
+    }
 
-  anchorRafRef.current = requestAnimationFrame(() => {
-    anchorRafRef.current = null
-    setActiveAnchorId((prev) => (prev === nextAnchorId ? prev : nextAnchorId))
-  })
+    anchorRafRef.current = requestAnimationFrame(() => {
+        anchorRafRef.current = null;
+        setActiveAnchorId(prev => (prev === nextAnchorId ? prev : nextAnchorId));
+    });
 }
 
 export const ResultDisplay = React.memo(function ResultDisplay({
-  data,
-  mobileMenuOpen,
-  onCloseMobileMenu,
-  onToggleMobileMenu,
-  isActive,
-  tabId,
-  initialScrollTop,
-  onPersistScroll,
-  latestTextQuery,
-  isNewSearch,
-  onConsumeNewSearch,
-  onContentReady,
-  onHydratedResults,
-}: ResultDisplayProps) {
-  const { sidebarPosition } = useSettings()
-  const {
-    userName,
-    userImageUrl,
-    isSignedIn,
-    isLoading: isAuthLoading,
-    userId,
-    canUseRestrictedUi,
-  } = useAuth()
-  const containerRef = useRef<HTMLDivElement>(null)
-  const latestScrollTopRef = useRef(initialScrollTop ?? 0)
-  const hasScrollSnapshotRef = useRef(typeof initialScrollTop === 'number')
-  const lastPersistedScrollRef = useRef<number | null>(null)
-  const [isContentReady, setIsContentReady] = useState(false)
-  const [isFullyRendered, setIsFullyRendered] = useState(false)
-  const [isTargetReady, setIsTargetReady] = useState(false)
-  const [activeTerm, setActiveTerm] = useState('')
-  const [activeAnchorId, setActiveAnchorId] = useState<string | null>(null)
-  const containerId = `results-content-${tabId}`
-  const lastMarkupRef = useRef<string | null>(null)
-  const lastHtmlRef = useRef<string | null>(null)
-  const renderedMarkupKeyRef = useRef<string | null>(null)
-  const activeAnchorIdRef = useRef<string | null>(null)
-  const anchorRafRef = useRef<number | null>(null)
-  const manualNavigationLockRef = useRef<{
-    anchorId: string
-    expiresAt: number
-  } | null>(null)
-  const onContentReadyRef = useRef(onContentReady)
-
-  // Sidebar collapsed state for lateral layout
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
-  const toggleSidebar = useCallback(() => {
-    if (window.innerWidth <= 1024) {
-      if (onToggleMobileMenu) {
-        onToggleMobileMenu()
-      } else if (onCloseMobileMenu && mobileMenuOpen) {
-        onCloseMobileMenu()
-      }
-    }
-
-    setSidebarCollapsed((prev) => !prev)
-  }, [onToggleMobileMenu, onCloseMobileMenu, mobileMenuOpen])
-
-  // ── Sistema de Comentários (Google Docs Style) ─────────────────────────
-  const [commentsEnabled, setCommentsEnabled] = useState(false)
-  const toggleComments = useCallback(() => {
-    if (isAuthLoading) {
-      toast.error('Aguarde a autenticação carregar e tente novamente.')
-      return
-    }
-    if (!isSignedIn) {
-      toast.error('Faça login para usar comentários.')
-      return
-    }
-    if (!canUseRestrictedUi) {
-      toast.error('Seu usuário não tem acesso a comentários.')
-      return
-    }
-    if (import.meta.env.DEV && typeof window !== 'undefined') {
-      const host = window.location.hostname
-      const isLanHost = host !== 'localhost' && host !== '127.0.0.1'
-      if (isLanHost) {
-        toast.error('Comentários não estão disponíveis neste ambiente agora.')
-        return
-      }
-    }
-    setCommentsEnabled((prev) => !prev)
-  }, [canUseRestrictedUi, isSignedIn, isAuthLoading])
-
-  const contentRef = useRef<HTMLDivElement>(null)
-  const { selection, clearSelection, onPopoverMouseDown } =
-    useTextSelection(contentRef)
-
-  const [pendingComment, setPendingComment] =
-    useState<PendingCommentEntry | null>(null)
-  const {
-    comments: localComments,
-    addComment,
-    editComment,
-    removeComment,
-    commentedAnchors,
-    loadCommentedAnchors,
-    loadComments,
-    resetFetchedAnchors,
-  } = useComments()
-  const commentedAnchorsLoadedRef = useRef(false)
-
-  // Drawer state for responsive screens < 1280px
-  const [drawerOpen, setDrawerOpen] = useState(false)
-  const toggleDrawer = useCallback(() => setDrawerOpen((prev) => !prev), [])
-  const [hydratedCodeResults, setHydratedCodeResults] = useState<Record<
-    string,
-    any
-  > | null>(null)
-  const [isHydratingCodeResults, setIsHydratingCodeResults] = useState(false)
-  const [failedChapterBodies, setFailedChapterBodies] = useState<string[]>([])
-
-  /** Abre o formulário no painel direito ancorado ao trecho selecionado. */
-  const handleOpenComment = useCallback(() => {
-    if (!selection?.anchorKey) {
-      if (selection)
-        toast.error('Selecione texto dentro de um elemento NCM para comentar.')
-      return
-    }
-    if (!selection) return
-    const container = containerRef.current
-    if (!container) return
-    const containerRect = container.getBoundingClientRect()
-    // anchorTop = posição Y relativa ao topo do scroll container
-    const anchorTop =
-      selection.rect.top - containerRect.top + container.scrollTop
-    setPendingComment({
-      anchorTop,
-      anchorKey: selection.anchorKey,
-      selectedText: selection.text,
-    })
-    clearSelection()
-    // Em telas estreitas, abre o drawer automaticamente
-    if (window.matchMedia('(max-width: 1280px)').matches) {
-      setDrawerOpen(true)
-    }
-  }, [selection, containerRef, clearSelection])
-
-  /** Confirma o comentário via API (otimista). */
-  const handleCommentSubmit = useCallback(
-    async (body: string, isPrivate: boolean): Promise<boolean> => {
-      if (!pendingComment) return false
-      const success = await addComment(
-        pendingComment,
-        body,
-        isPrivate,
-        userName || 'Usuário',
-        userImageUrl || null
-      )
-      if (success) {
-        setPendingComment(null)
-      }
-      return success
-    },
-    [pendingComment, userName, userImageUrl, addComment]
-  )
-
-  const handleDismissComment = useCallback(() => {
-    setPendingComment(null)
-  }, [])
-
-  useEffect(() => {
-    if (canUseRestrictedUi) return
-    setCommentsEnabled(false)
-    setPendingComment(null)
-    setDrawerOpen(false)
-  }, [canUseRestrictedUi])
-
-  // ── Carregar anchors com comentários quando ativado ────────────────────
-  useEffect(() => {
-    if (!canUseRestrictedUi || !commentsEnabled) {
-      commentedAnchorsLoadedRef.current = false
-      return
-    }
-
-    if (!isSignedIn || isAuthLoading) return
-    if (commentedAnchorsLoadedRef.current) return
-
-    commentedAnchorsLoadedRef.current = true
-    void loadCommentedAnchors()
-  }, [
-    canUseRestrictedUi,
-    commentsEnabled,
-    loadCommentedAnchors,
-    isSignedIn,
-    isAuthLoading,
-  ])
-
-  // ── Aplicar/remover classe .has-comment nos elementos do DOM ──────────
-  useEffect(() => {
-    const container = contentRef.current
-    if (!container) return
-
-    // Sempre limpa marcações anteriores
-    container.querySelectorAll('.has-comment').forEach((el) => {
-      el.classList.remove('has-comment')
-    })
-
-    // Só aplica quando comments estão ativos e há anchors
-    if (
-      !canUseRestrictedUi ||
-      !commentsEnabled ||
-      commentedAnchors.length === 0
-    )
-      return
-
-    commentedAnchors.forEach((anchorKey) => {
-      const el = container.querySelector(`[id="${CSS.escape(anchorKey)}"]`)
-      if (el) {
-        el.classList.add('has-comment')
-      }
-    })
-  }, [canUseRestrictedUi, commentsEnabled, commentedAnchors, isContentReady])
-
-  // ── Carregar comentários ao clicar em elemento com .has-comment ───────
-  useEffect(() => {
-    const container = contentRef.current
-    if (!container || !canUseRestrictedUi || !commentsEnabled) return
-
-    const handleHasCommentClick = (e: Event) => {
-      const target = (e.target as HTMLElement).closest('.has-comment')
-      if (!target) return
-      const anchorKey = target.id
-      if (!anchorKey) return
-
-      // Busca os comentários deste anchor
-      void loadComments(anchorKey, target.getBoundingClientRect().top)
-
-      // Em telas estreitas, abre o drawer
-      if (window.matchMedia('(max-width: 1280px)').matches) {
-        setDrawerOpen(true)
-      }
-    }
-
-    container.addEventListener('click', handleHasCommentClick)
-    return () => container.removeEventListener('click', handleHasCommentClick)
-  }, [canUseRestrictedUi, commentsEnabled, loadComments])
-
-  // ── Reset ao mudar de conteúdo ────────────────────────────────────────
-  useEffect(() => {
-    resetFetchedAnchors()
-  }, [data?.markdown, data?.ncm, data?.query, resetFetchedAnchors])
-
-  // ───────────────────────────────────────────────────────────────────────
-  const codeResults = useMemo(() => {
-    if (!data || data.type === 'text') return null
-    if (data.resultados && typeof data.resultados === 'object') {
-      return data.resultados as Record<string, any>
-    }
-    if (
-      data.results &&
-      !Array.isArray(data.results) &&
-      typeof data.results === 'object'
-    ) {
-      return data.results as Record<string, any>
-    }
-    return null
-  }, [data?.type, data?.resultados, data?.results])
-
-  useEffect(() => {
-    startTransition(() => {
-      setHydratedCodeResults(null)
-      setIsHydratingCodeResults(false)
-      setFailedChapterBodies([])
-    })
-  }, [data?.markdown, data?.ncm, data?.query, tabId])
-
-  const shouldHydrateCodeResults = useMemo(() => {
-    return (
-      !!codeResults &&
-      data?.type === 'code' &&
-      !data?.markdown &&
-      !isTipiResults(codeResults)
-    )
-  }, [codeResults, data?.markdown, data?.type])
-
-  const renderableCodeResults = useMemo(() => {
-    return hydratedCodeResults ?? codeResults
-  }, [codeResults, hydratedCodeResults])
-
-  const missingChapterBodies = useMemo(() => {
-    if (!shouldHydrateCodeResults || !renderableCodeResults)
-      return [] as string[]
-
-    return Object.entries(renderableCodeResults)
-      .filter(([, chapter]) => !chapterHasRenderableContent(chapter))
-      .map(([chapterKey, chapter]) => {
-        const capitulo = (chapter as { capitulo?: unknown })?.capitulo
-        return typeof capitulo === 'string' && capitulo.trim()
-          ? capitulo.trim()
-          : chapterKey
-      })
-      .filter((chapter) => !failedChapterBodies.includes(chapter))
-  }, [failedChapterBodies, renderableCodeResults, shouldHydrateCodeResults])
-
-  useEffect(() => {
-    if (
-      !isActive ||
-      !shouldHydrateCodeResults ||
-      !renderableCodeResults ||
-      missingChapterBodies.length === 0
-    ) {
-      return
-    }
-
-    let cancelled = false
-    setIsHydratingCodeResults(true)
-
-    const applyHydrationResult = ({
-      chapterBodies,
-      failedChapters,
-    }: ChapterHydrationResult) => {
-      if (cancelled) return
-
-      if (failedChapters.length > 0) {
-        startTransition(() => {
-          setFailedChapterBodies(
-            createFailedChapterBodiesUpdater(failedChapters)
-          )
-        })
-      }
-
-      if (chapterBodies.length === 0) return
-
-      const mergedResults = mergeHydratedChapterBodies(
-        renderableCodeResults,
-        chapterBodies
-      )
-
-      startTransition(() => {
-        setHydratedCodeResults(mergedResults)
-        setFailedChapterBodies(
-          createRecoveredChapterBodiesUpdater(chapterBodies)
-        )
-        onHydratedResults?.(tabId, mergedResults)
-      })
-    }
-
-    void fetchChapterBodies(missingChapterBodies)
-      .then(applyHydrationResult)
-      .catch((error) => {
-        console.error('[ResultDisplay] Failed to hydrate chapter bodies', error)
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setIsHydratingCodeResults(false)
-        }
-      })
-
-    return () => {
-      cancelled = true
-    }
-  }, [
-    isActive,
-    missingChapterBodies,
-    onHydratedResults,
-    renderableCodeResults,
-    shouldHydrateCodeResults,
-    tabId,
-  ])
-
-  const findAnchorIdForQuery = useCallback((resultados: any, query: string) => {
-    if (!resultados || typeof resultados !== 'object') return null
-
-    const normalizedQuery = normalizeDigits(query)
-    if (!normalizedQuery) return null
-
-    const chapters = Object.values(resultados) as any[]
-    let exactMatch: string | null = null
-    let prefixMatch: string | null = null
-
-    for (const chapter of chapters) {
-      const match = findAnchorIdInChapter(chapter, normalizedQuery, prefixMatch)
-      if (match.exactMatch) {
-        exactMatch = match.exactMatch
-        break
-      }
-      prefixMatch = match.prefixMatch
-    }
-
-    return exactMatch || prefixMatch
-  }, [])
-
-  const getPosicaoAlvoFromResultados = useCallback((resultados: any) => {
-    if (!resultados || typeof resultados !== 'object')
-      return null as string | null
-    const chapters = Object.values(resultados) as any[]
-    if (chapters.length !== 1) return null
-    const posicaoAlvo = (
-      chapters[0]?.posicao_alvo ||
-      chapters[0]?.posicaoAlvo ||
-      ''
-    )
-      .toString()
-      .trim()
-    return posicaoAlvo || null
-  }, [])
-
-  const getSectionAnchorIdsFromResultados = useCallback((resultados: any) => {
-    if (!resultados || typeof resultados !== 'object') return [] as string[]
-
-    const ids: string[] = []
-    const chapters = Object.values(resultados) as any[]
-    for (const chapter of chapters) {
-      const capitulo = (chapter?.capitulo || '').toString().trim()
-      if (!capitulo) continue
-
-      const secoes = chapter?.secoes
-      if (secoes && typeof secoes === 'object') {
-        const structuredSectionIds = getStructuredSectionIds(
-          capitulo,
-          secoes as Record<string, unknown>
-        )
-        ids.push(...structuredSectionIds)
-        if (structuredSectionIds.length > 0) continue
-      }
-
-      if ((chapter?.notas_gerais || '').toString().trim()) {
-        ids.push(`chapter-${capitulo}-notas`)
-      }
-    }
-
-    return ids
-  }, [])
-
-  const getAnchorIdsFromResultados = useCallback(
-    (resultados: any) => {
-      if (!resultados || typeof resultados !== 'object') return [] as string[]
-
-      const ids = getSectionAnchorIdsFromResultados(resultados)
-      const chapters = Object.values(resultados) as any[]
-      for (const chapter of chapters) {
-        const positions = Array.isArray(chapter?.posicoes)
-          ? chapter.posicoes
-          : []
-        for (const pos of positions) {
-          const codigo = (pos?.codigo || pos?.ncm || '').toString()
-          if (!codigo) continue
-          ids.push(pos?.anchor_id || generateAnchorId(codigo))
-        }
-      }
-      return Array.from(new Set(ids))
-    },
-    [getSectionAnchorIdsFromResultados]
-  )
-
-  const ensureSectionAnchors = useCallback(
-    (resultados: any, container: HTMLElement) => {
-      const sectionIds = getSectionAnchorIdsFromResultados(resultados)
-      for (const sectionId of sectionIds) {
-        const existing = container.querySelector(
-          `#${CSS.escape(sectionId)}`
-        ) as HTMLElement | null
-        if (existing) continue
-        resolveSectionElement(container, sectionId)
-      }
-    },
-    [getSectionAnchorIdsFromResultados]
-  )
-
-  const searchHighlighterQuery = useMemo(() => {
-    const candidate = (latestTextQuery || '').trim()
-    return candidate || null
-  }, [latestTextQuery])
-  const searchHighlighterOwnsScroll =
-    data?.type === 'text' && !!searchHighlighterQuery
-  const consumeNewSearchKey = useMemo(
-    () =>
-      `${tabId}|${isNewSearch ? '1' : '0'}|${data?.query ?? ''}|${data?.ncm ?? ''}|${latestTextQuery ?? ''}`,
-    [data?.ncm, data?.query, isNewSearch, latestTextQuery, tabId]
-  )
-
-  // Sidebar Navigation Handler
-  const handleNavigate = useCallback((targetId: string) => {
-    const container = containerRef.current
-    if (!container) return
-
-    // Try direct ID first (backend should provide correct anchor_id)
-    let element = container.querySelector(
-      `#${CSS.escape(targetId)}`
-    ) as HTMLElement | null
-
-    // Fallback: generate anchor ID from codigo (e.g., "84.13" -> "pos-84-13")
-    if (!element) {
-      const generatedId = generateAnchorId(targetId)
-      element = container.querySelector(
-        `#${CSS.escape(generatedId)}`
-      ) as HTMLElement | null
-    }
-
-    // Section fallback: backend HTML may provide section classes without stable IDs.
-    if (!element) {
-      element = resolveSectionElement(container, targetId)
-    }
-
-    if (element) {
-      element.scrollIntoView({ behavior: 'smooth', block: 'start' })
-      element.classList.add('flash-highlight')
-      setTimeout(() => element.classList.remove('flash-highlight'), 2000)
-      const nextAnchor = element.id || targetId
-      manualNavigationLockRef.current = {
-        anchorId: nextAnchor,
-        expiresAt: Date.now() + MANUAL_NAVIGATION_HIGHLIGHT_LOCK_MS,
-      }
-      setActiveAnchorId((prev) => (prev === nextAnchor ? prev : nextAnchor))
-    } else {
-      debug.warn('[Navigate] target not found:', targetId)
-    }
-  }, []) // Empty dependency array as it only uses refs or DOM APIs
-
-  const targetCandidates = useMemo(() => {
-    if (!data) return null
-
-    const ncmToScroll = resolveNcmToScroll(data)
-    if (!ncmToScroll) return null
-
-    return resolveAutoScrollCandidates(
-      ncmToScroll,
-      renderableCodeResults,
-      findAnchorIdForQuery,
-      getPosicaoAlvoFromResultados
-    )
-  }, [
     data,
-    findAnchorIdForQuery,
-    getPosicaoAlvoFromResultados,
-    renderableCodeResults,
-  ])
-
-  const resolveAutoScrollTargetReadiness = useCallback(
-    (container: HTMLElement) => {
-      if (renderableCodeResults) {
-        ensureSectionAnchors(renderableCodeResults, container)
-      }
-
-      if (!targetCandidates || targetCandidates.length === 0) {
-        return false
-      }
-
-      if (findExistingTargetElement(container, targetCandidates)) {
-        return true
-      }
-
-      const posicaoAlvo = renderableCodeResults
-        ? getPosicaoAlvoFromResultados(renderableCodeResults)
-        : null
-      const candidateNcm = posicaoAlvo || data?.ncm || data?.query || ''
-      if (!candidateNcm) {
-        return false
-      }
-
-      const fallback = ensureTargetAnchorFromDataNcm(container, candidateNcm)
-      if (!fallback) {
-        return false
-      }
-
-      return !!findExistingTargetElement(container, targetCandidates)
-    },
-    [
-      renderableCodeResults,
-      data?.ncm,
-      data?.query,
-      ensureSectionAnchors,
-      getPosicaoAlvoFromResultados,
-      targetCandidates,
-    ]
-  )
-
-  // Stabilize onConsumeNewSearch callback to prevent AutoScroll effect loop
-  const onConsumeNewSearchRef = useRef(onConsumeNewSearch)
-  useEffect(() => {
-    onConsumeNewSearchRef.current = onConsumeNewSearch
-  }, [onConsumeNewSearch])
-
-  const onPersistScrollRef = useRef(onPersistScroll)
-  const hasConsumedNewSearchRef = useRef(false)
-  const isActiveRef = useRef(isActive)
-  const isNewSearchRef = useRef(isNewSearch)
-  useEffect(() => {
-    onPersistScrollRef.current = onPersistScroll
-  }, [onPersistScroll])
-  useEffect(() => {
-    hasConsumedNewSearchRef.current = false
-  }, [consumeNewSearchKey])
-  useEffect(() => {
-    isActiveRef.current = isActive
-  }, [isActive])
-  useEffect(() => {
-    isNewSearchRef.current = isNewSearch
-  }, [isNewSearch])
-  useEffect(() => {
-    onContentReadyRef.current = onContentReady
-  }, [onContentReady])
-  useEffect(() => {
-    activeAnchorIdRef.current = activeAnchorId
-  }, [activeAnchorId])
-  useEffect(() => {
-    return () => {
-      if (anchorRafRef.current !== null) {
-        cancelAnimationFrame(anchorRafRef.current)
-      }
-    }
-  }, [])
-  useEffect(() => {
-    if (isContentReady) {
-      onContentReadyRef.current?.(tabId)
-    }
-  }, [isContentReady, tabId])
-
-  // Keep active term in sync with the latest text query for this tab.
-  useEffect(() => {
-    const normalizedLatestTextQuery = (latestTextQuery || '').trim()
-    setActiveTerm((prev) =>
-      prev === normalizedLatestTextQuery ? prev : normalizedLatestTextQuery
-    )
-  }, [latestTextQuery, data?.query, tabId])
-
-  const consumeNewSearchScroll = useCallback(
-    (scrollTop?: number, force = false) => {
-      if (hasConsumedNewSearchRef.current) return
-      if (!force && (!isActiveRef.current || !isNewSearchRef.current)) return
-      hasConsumedNewSearchRef.current = true
-      onConsumeNewSearchRef.current(tabId, scrollTop)
-    },
-    [tabId]
-  )
-
-  const handleAutoScrollComplete = useCallback(
-    (success?: boolean) => {
-      if (!success) return
-      // Wrap in RAF to ensure DOM has updated/painted the scroll action
-      // before we capture the final position and update app state.
-      requestAnimationFrame(() => {
-        if (!isActiveRef.current || !isNewSearchRef.current) return
-        const currentScroll = containerRef.current?.scrollTop || 0
-        consumeNewSearchScroll(currentScroll)
-      })
-    },
-    [consumeNewSearchScroll]
-  )
-
-  const handleHighlightScrollComplete = useCallback(
-    (scrollTop: number) => {
-      if (!isActiveRef.current || !isNewSearchRef.current) return
-      consumeNewSearchScroll(scrollTop)
-    },
-    [consumeNewSearchScroll]
-  )
-
-  // `isContentReady` means the tab can render, but auto-scroll only starts
-  // once at least one candidate anchor is actually present in the DOM.
-  // Only auto-scroll when:
-  // 1. Tab is active
-  // 2. This is a NEW search (not returning to existing tab)
-  // 3. Let SearchHighlighter take precedence for text-result tabs, but keep anchor scroll as fallback elsewhere
-  const shouldAutoScroll =
-    !!targetCandidates?.length &&
-    isActive &&
-    isNewSearch &&
-    isContentReady &&
-    !searchHighlighterOwnsScroll &&
-    isTargetReady
-  useRobustScroll({
-    targetId: targetCandidates,
-    shouldScroll: shouldAutoScroll,
-    containerRef,
-    onComplete: handleAutoScrollComplete,
-    expectedTags: ['H1', 'H2', 'H3', 'H4', 'ARTICLE', 'SECTION', 'DIV'],
-  })
-
-  // Track scroll position for persistence
-  useEffect(() => {
-    const element = containerRef.current
-    if (!element) return
-
-    const handleScroll = () => {
-      const currentScroll = element.scrollTop
-      latestScrollTopRef.current = currentScroll
-      hasScrollSnapshotRef.current = true
-
-      if (!isActive) return
-
-      const persist = onPersistScrollRef.current
-      if (!persist) return
-      if (lastPersistedScrollRef.current === currentScroll) return
-
-      lastPersistedScrollRef.current = currentScroll
-      persist(tabId, currentScroll)
-    }
-
-    element.addEventListener('scroll', handleScroll, { passive: true })
-    return () => element.removeEventListener('scroll', handleScroll)
-  }, [data?.type, data?.markdown, renderableCodeResults, isActive, tabId])
-
-  useEffect(() => {
-    if (isActive) return
-
-    const persist = onPersistScrollRef.current
-    if (!persist) return
-    if (!hasScrollSnapshotRef.current) return
-
-    const currentScroll = latestScrollTopRef.current
-    if (isNewSearchRef.current && !hasConsumedNewSearchRef.current) {
-      consumeNewSearchScroll(currentScroll, true)
-      return
-    }
-    if (lastPersistedScrollRef.current === currentScroll) return
-
-    lastPersistedScrollRef.current = currentScroll
-    persist(tabId, currentScroll)
-  }, [consumeNewSearchScroll, isActive, tabId])
-
-  // Restore scroll when tab becomes active (only if NOT a new search)
-  const hasRestoredInitialScrollRef = useRef(false)
-  useEffect(() => {
-    // Skip restore if this is a new search - auto-scroll will handle positioning
-    if (!isActive || isNewSearch) return
-    // Wait until content is rendered before restoring scroll
-    if (!isContentReady) return
-    const element = containerRef.current
-    if (!element) return
-
-    if (typeof initialScrollTop !== 'number') return
-    const targetScrollTop = initialScrollTop
-
-    if (hasRestoredInitialScrollRef.current) return
-    if (Math.abs(element.scrollTop - targetScrollTop) < 1) return
-
-    let cancelled = false
-    let attempts = 0
-    let frameId = 0
-    const maxAttempts = 20
-
-    const tryRestore = () => {
-      if (cancelled) return
-
-      const currentContainer = containerRef.current
-      if (!currentContainer) return
-
-      if (Math.abs(currentContainer.scrollTop - targetScrollTop) < 1) {
-        latestScrollTopRef.current = targetScrollTop
-        hasScrollSnapshotRef.current = true
-        lastPersistedScrollRef.current = targetScrollTop
-        hasRestoredInitialScrollRef.current = true
-        return
-      }
-
-      const hasScrollableContent =
-        currentContainer.scrollHeight > currentContainer.clientHeight
-      if (!hasScrollableContent && attempts < maxAttempts) {
-        attempts += 1
-        frameId = requestAnimationFrame(tryRestore)
-        return
-      }
-
-      currentContainer.scrollTop = targetScrollTop
-      latestScrollTopRef.current = targetScrollTop
-      hasScrollSnapshotRef.current = true
-      lastPersistedScrollRef.current = targetScrollTop
-
-      if (Math.abs(currentContainer.scrollTop - targetScrollTop) < 1) {
-        hasRestoredInitialScrollRef.current = true
-        return
-      }
-
-      if (attempts < maxAttempts) {
-        attempts += 1
-        frameId = requestAnimationFrame(tryRestore)
-        return
-      }
-
-      hasRestoredInitialScrollRef.current = true
-    }
-
-    frameId = requestAnimationFrame(tryRestore)
-
-    return () => {
-      cancelled = true
-      cancelAnimationFrame(frameId)
-    }
-  }, [isActive, initialScrollTop, isNewSearch, isContentReady])
-
-  // Reset restored flag when inactive so it can restore again when returning
-  useEffect(() => {
-    if (!isActive) {
-      hasRestoredInitialScrollRef.current = false
-    }
-  }, [isActive])
-
-  // Render backend content (prefer HTML; parse markdown only as legacy fallback)
-  useEffect(() => {
-    if (data?.type === 'text') {
-      renderedMarkupKeyRef.current = null
-      setIsContentReady(true)
-      setIsFullyRendered(true)
-      return
-    }
-    if (!contentRef.current) return
-
-    const rawMarkdown =
-      typeof data?.markdown === 'string' ? data.markdown.trim() : ''
-    const markupToRender = resolveMarkupToRender(
-      rawMarkdown,
-      renderableCodeResults
-    )
-
-    if (!markupToRender) {
-      if (shouldHydrateCodeResults && missingChapterBodies.length > 0) {
-        renderedMarkupKeyRef.current = null
-        setIsContentReady(true)
-        setIsFullyRendered(false)
-        return
-      }
-      contentRef.current.textContent = ''
-      renderedMarkupKeyRef.current = null
-      setIsContentReady(true)
-      setIsFullyRendered(true)
-      return
-    }
-
-    try {
-      return renderMarkupContent({
-        rawMarkdown,
-        markupToRender,
-        isActive,
-        isContentReady,
-        refs: {
-          contentRef,
-          renderedMarkupKeyRef,
-          lastMarkupRef,
-          lastHtmlRef,
-        },
-        setIsContentReady,
-        setIsFullyRendered,
-      })
-    } catch (e) {
-      console.error('Content render error:', e)
-      if (contentRef.current)
-        contentRef.current.textContent = 'Error rendering content.'
-      renderedMarkupKeyRef.current = null
-      setIsContentReady(true)
-      setIsFullyRendered(true)
-    }
-  }, [
-    data?.markdown,
-    data?.type,
-    isActive,
-    missingChapterBodies.length,
-    renderableCodeResults,
-    shouldHydrateCodeResults,
-  ])
-
-  useEffect(() => {
-    if (!isContentReady || !containerRef.current || !targetCandidates?.length) {
-      setIsTargetReady(false)
-      return
-    }
-
-    let cancelled = false
-    let observer: MutationObserver | null = null
-    const container = containerRef.current
-
-    const syncReadiness = () => {
-      const ready = resolveAutoScrollTargetReadiness(container)
-      if (!cancelled) {
-        setIsTargetReady(ready)
-      }
-      return ready
-    }
-
-    if (syncReadiness()) {
-      return () => {
-        cancelled = true
-      }
-    }
-
-    if (!isFullyRendered) {
-      observer = new MutationObserver(() => {
-        if (syncReadiness()) {
-          observer?.disconnect()
-          observer = null
-        }
-      })
-      observer.observe(container, {
-        childList: true,
-        subtree: true,
-      })
-    }
-
-    return () => {
-      cancelled = true
-      observer?.disconnect()
-    }
-  }, [
-    isContentReady,
-    isFullyRendered,
-    resolveAutoScrollTargetReadiness,
-    targetCandidates,
-  ])
-
-  // Ensure structured section anchors exist for sidebar navigation/highlight syncing.
-  useEffect(() => {
-    if (!isContentReady || !renderableCodeResults || !containerRef.current)
-      return
-    ensureSectionAnchors(renderableCodeResults, containerRef.current)
-  }, [ensureSectionAnchors, isContentReady, renderableCodeResults])
-
-  // Query-term highlighting for code results.
-  // Always clean previous wrappers first to avoid nested/duplicated marks after query changes.
-  useEffect(() => {
-    const contentContainer = contentRef.current
-    if (!contentContainer || data?.type === 'text') return
-
-    unwrapQueryHighlights(contentContainer)
-
-    if (!isActive || !isContentReady || !activeTerm || searchHighlighterQuery) {
-      return () => {
-        const current = contentRef.current
-        if (current) unwrapQueryHighlights(current)
-      }
-    }
-
-    highlightTermInContainer(contentContainer, activeTerm)
-
-    return () => {
-      const current = contentRef.current
-      if (current) unwrapQueryHighlights(current)
-    }
-  }, [
-    activeTerm,
-    isActive,
-    isContentReady,
-    searchHighlighterQuery,
-    tabId,
-    data?.type,
-    data?.markdown,
-  ])
-
-  // Sync Sidebar to current visible anchor
-  useEffect(() => {
-    if (
-      !isActive ||
-      !isContentReady ||
-      !renderableCodeResults ||
-      !containerRef.current
-    )
-      return
-
-    const ids = getAnchorIdsFromResultados(renderableCodeResults)
-    if (ids.length === 0) return
-
-    const elements = ids
-      .map(
-        (id) =>
-          containerRef.current?.querySelector(
-            `#${CSS.escape(id)}`
-          ) as HTMLElement | null
-      )
-      .filter(Boolean) as HTMLElement[]
-
-    if (elements.length === 0) return
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const nextAnchorId = getNextVisibleAnchorId(entries)
-        if (!nextAnchorId) return
-
-        const manualNavigationLock = manualNavigationLockRef.current
-        if (manualNavigationLock) {
-          const now = Date.now()
-          if (now < manualNavigationLock.expiresAt) {
-            if (nextAnchorId !== manualNavigationLock.anchorId) {
-              return
-            }
-            manualNavigationLockRef.current = null
-          } else {
-            manualNavigationLockRef.current = null
-          }
-        }
-
-        scheduleActiveAnchorUpdate(
-          nextAnchorId,
-          activeAnchorIdRef,
-          anchorRafRef,
-          setActiveAnchorId
-        )
-      },
-      {
-        root: containerRef.current,
-        rootMargin: '0px 0px -60% 0px',
-        threshold: 0.1,
-      }
-    )
-
-    elements.forEach((el) => observer.observe(el))
-
-    return () => observer.disconnect()
-  }, [
-    getAnchorIdsFromResultados,
-    isActive,
-    isContentReady,
-    renderableCodeResults,
-  ])
-
-  if (!data) {
-    return <p className={styles.emptyMessage}>Sem resultados para exibir.</p>
-  }
-
-  // Text Search Rendering
-  if (data.type === 'text') {
-    return (
-      <div
-        className={`${styles.content} ${styles.textSearchContent}`}
-        ref={containerRef}
-        id={containerId}
-      >
-        <TextSearchResults
-          results={(data.results as SearchResultItem[]) || null}
-          query={latestTextQuery || data.query || ''}
-          onResultClick={(ncm: string) =>
-            globalThis.nesh.openTextResultInNewTab(
-              ncm,
-              latestTextQuery || data.query || ''
-            )
-          }
-          scrollParentRef={containerRef}
-        />
-      </div>
-    )
-  }
-
-  // Default: Code View (Markdown + Sidebar)
-  // Layout: Grid with content and sidebar (position from settings)
-  const wrapperClasses = getWrapperClasses(
-    styles,
-    sidebarCollapsed,
     mobileMenuOpen,
-    sidebarPosition
-  )
-  const sidebarToggleLabel = getSidebarToggleLabel(sidebarCollapsed)
-  const sidebarToggleIcon = getSidebarToggleIcon(
-    sidebarPosition,
-    sidebarCollapsed
-  )
-  const contentVisibilityClass = getContentVisibilityClass(
-    styles,
-    isContentReady
-  )
-  const commentToggleLabel = getCommentToggleLabel(commentsEnabled)
-  const commentToggleClasses = getCommentToggleClassName(
-    styles,
-    commentsEnabled
-  )
-  const shouldRenderSidebar = isActive && !!renderableCodeResults
+    onCloseMobileMenu,
+    onToggleMobileMenu,
+    isActive,
+    tabId,
+    initialScrollTop,
+    onPersistScroll,
+    latestTextQuery,
+    isNewSearch,
+    onConsumeNewSearch,
+    onContentReady,
+    onHydratedResults
+}: ResultDisplayProps) {
+    const { sidebarPosition } = useSettings();
+    const {
+        userName,
+        userImageUrl,
+        isSignedIn,
+        isLoading: isAuthLoading,
+        userId,
+        canUseRestrictedUi,
+    } = useAuth();
+    const containerRef = useRef<HTMLDivElement>(null);
+    const latestScrollTopRef = useRef(initialScrollTop ?? 0);
+    const hasScrollSnapshotRef = useRef(typeof initialScrollTop === 'number');
+    const lastPersistedScrollRef = useRef<number | null>(null);
+    const [isContentReady, setIsContentReady] = useState(false);
+    const [isFullyRendered, setIsFullyRendered] = useState(false);
+    const [isTargetReady, setIsTargetReady] = useState(false);
+    const [activeTerm, setActiveTerm] = useState('');
+    const [activeAnchorId, setActiveAnchorId] = useState<string | null>(null);
+    const containerId = `results-content-${tabId}`;
+    const lastMarkupRef = useRef<string | null>(null);
+    const lastHtmlRef = useRef<string | null>(null);
+    const renderedMarkupKeyRef = useRef<string | null>(null);
+    const activeAnchorIdRef = useRef<string | null>(null);
+    const anchorRafRef = useRef<number | null>(null);
+    const manualNavigationLockRef = useRef<{ anchorId: string; expiresAt: number } | null>(null);
+    const onContentReadyRef = useRef(onContentReady);
 
-  return (
-    <div className={wrapperClasses}>
-      {/* Toggle Button */}
-      <button
-        className={styles.sidebarToggle}
-        onClick={toggleSidebar}
-        aria-label={sidebarToggleLabel}
-      >
-        {sidebarToggleIcon}
-      </button>
+    // Sidebar collapsed state for lateral layout
+    const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+    const toggleSidebar = useCallback(() => { if (window.innerWidth <= 1024) { if (onToggleMobileMenu) onToggleMobileMenu(); else if (onCloseMobileMenu && mobileMenuOpen) onCloseMobileMenu(); } else { setSidebarCollapsed(prev => !prev); } }, [onToggleMobileMenu, onCloseMobileMenu, mobileMenuOpen]);
 
-      {/* Content scroll container - Coluna 1 */}
-      <div
-        className={`${styles.content} ${contentVisibilityClass} markdown-body`}
-        ref={(el) => {
-          // containerRef = scroll container (para scroll tracking e texto selection)
-          ;(
-            containerRef as React.MutableRefObject<HTMLDivElement | null>
-          ).current = el
-        }}
-        id={containerId}
-      >
-        {/* O container interno organiza o conteúdo da esquerda verticalmente (mensagens + texto) */}
-        <div
-          style={{
-            flex: 1,
-            minWidth: 0,
-            display: 'flex',
-            flexDirection: 'column',
-          }}
-        >
-          {shouldHydrateCodeResults &&
-            (isHydratingCodeResults || missingChapterBodies.length > 0) && (
-              <div className={styles.loadingSpinnerContainer}>
-                <svg className={styles.spinner} viewBox="0 0 50 50">
-                  <circle
-                    className={styles.spinnerPath}
-                    cx="25"
-                    cy="25"
-                    r="20"
-                    fill="none"
-                    strokeWidth="5"
-                  ></circle>
-                </svg>
-                <p className={styles.loadingText}>
-                  Carregando conteúdo detalhado...
-                </p>
-              </div>
+    // ── Sistema de Comentários (Google Docs Style) ─────────────────────────
+    const [commentsEnabled, setCommentsEnabled] = useState(false);
+    const toggleComments = useCallback(() => {
+        if (isAuthLoading) {
+            toast.error('Aguarde a autenticação carregar e tente novamente.');
+            return;
+        }
+        if (!isSignedIn) {
+            toast.error('Faça login para usar comentários.');
+            return;
+        }
+        if (!canUseRestrictedUi) {
+            toast.error('Seu usuário não tem acesso a comentários.');
+            return;
+        }
+        if (import.meta.env.DEV && typeof window !== 'undefined') {
+            const host = window.location.hostname;
+            const isLanHost = host !== 'localhost' && host !== '127.0.0.1';
+            if (isLanHost) {
+                toast.error('Comentários não estão disponíveis neste ambiente agora.');
+                return;
+            }
+        }
+        setCommentsEnabled(prev => !prev);
+    }, [canUseRestrictedUi, isSignedIn, isAuthLoading]);
+
+    const contentRef = useRef<HTMLDivElement>(null);
+    const { selection, clearSelection, onPopoverMouseDown } = useTextSelection(contentRef);
+
+    const [pendingComment, setPendingComment] = useState<PendingCommentEntry | null>(null);
+    const {
+        comments: localComments,
+        addComment,
+        editComment,
+        removeComment,
+        commentedAnchors,
+        loadCommentedAnchors,
+        loadComments,
+        resetFetchedAnchors,
+    } = useComments();
+    const commentedAnchorsLoadedRef = useRef(false);
+
+    // Drawer state for responsive screens < 1280px
+    const [drawerOpen, setDrawerOpen] = useState(false);
+    const toggleDrawer = useCallback(() => setDrawerOpen(prev => !prev), []);
+    const [hydratedCodeResults, setHydratedCodeResults] = useState<Record<string, any> | null>(null);
+    const [isHydratingCodeResults, setIsHydratingCodeResults] = useState(false);
+    const [failedChapterBodies, setFailedChapterBodies] = useState<string[]>([]);
+
+    /** Abre o formulário no painel direito ancorado ao trecho selecionado. */
+    const handleOpenComment = useCallback(() => {
+        if (!selection?.anchorKey) {
+            if (selection) toast.error('Selecione texto dentro de um elemento NCM para comentar.');
+            return;
+        }
+        if (!selection) return;
+        const container = containerRef.current;
+        if (!container) return;
+        const containerRect = container.getBoundingClientRect();
+        // anchorTop = posição Y relativa ao topo do scroll container
+        const anchorTop = selection.rect.top - containerRect.top + container.scrollTop;
+        setPendingComment({
+            anchorTop,
+            anchorKey: selection.anchorKey,
+            selectedText: selection.text,
+        });
+        clearSelection();
+        // Em telas estreitas, abre o drawer automaticamente
+        if (window.matchMedia('(max-width: 1280px)').matches) {
+            setDrawerOpen(true);
+        }
+    }, [selection, containerRef, clearSelection]);
+
+    /** Confirma o comentário via API (otimista). */
+    const handleCommentSubmit = useCallback(async (body: string, isPrivate: boolean): Promise<boolean> => {
+        if (!pendingComment) return false;
+        const success = await addComment(
+            pendingComment,
+            body,
+            isPrivate,
+            userName || 'Usuário',
+            userImageUrl || null,
+        );
+        if (success) {
+            setPendingComment(null);
+        }
+        return success;
+    }, [pendingComment, userName, userImageUrl, addComment]);
+
+    const handleDismissComment = useCallback(() => {
+        setPendingComment(null);
+    }, []);
+
+    useEffect(() => {
+        if (canUseRestrictedUi) return;
+        setCommentsEnabled(false);
+        setPendingComment(null);
+        setDrawerOpen(false);
+    }, [canUseRestrictedUi]);
+
+    // ── Carregar anchors com comentários quando ativado ────────────────────
+    useEffect(() => {
+        if (!canUseRestrictedUi || !commentsEnabled) {
+            commentedAnchorsLoadedRef.current = false;
+            return;
+        }
+
+        if (!isSignedIn || isAuthLoading) return;
+        if (commentedAnchorsLoadedRef.current) return;
+
+        commentedAnchorsLoadedRef.current = true;
+        void loadCommentedAnchors();
+    }, [canUseRestrictedUi, commentsEnabled, loadCommentedAnchors, isSignedIn, isAuthLoading]);
+
+    // ── Aplicar/remover classe .has-comment nos elementos do DOM ──────────
+    useEffect(() => {
+        const container = contentRef.current;
+        if (!container) return;
+
+        // Sempre limpa marcações anteriores
+        container.querySelectorAll('.has-comment').forEach(el => {
+            el.classList.remove('has-comment');
+        });
+
+        // Só aplica quando comments estão ativos e há anchors
+        if (!canUseRestrictedUi || !commentsEnabled || commentedAnchors.length === 0) return;
+
+        commentedAnchors.forEach(anchorKey => {
+            const el = container.querySelector(`[id="${CSS.escape(anchorKey)}"]`);
+            if (el) {
+                el.classList.add('has-comment');
+            }
+        });
+    }, [canUseRestrictedUi, commentsEnabled, commentedAnchors, isContentReady]);
+
+    // ── Carregar comentários ao clicar em elemento com .has-comment ───────
+    useEffect(() => {
+        const container = contentRef.current;
+        if (!container || !canUseRestrictedUi || !commentsEnabled) return;
+
+        const handleHasCommentClick = (e: Event) => {
+            const target = (e.target as HTMLElement).closest('.has-comment');
+            if (!target) return;
+            const anchorKey = target.id;
+            if (!anchorKey) return;
+
+            // Busca os comentários deste anchor
+            void loadComments(anchorKey, target.getBoundingClientRect().top);
+
+            // Em telas estreitas, abre o drawer
+            if (window.matchMedia('(max-width: 1280px)').matches) {
+                setDrawerOpen(true);
+            }
+        };
+
+        container.addEventListener('click', handleHasCommentClick);
+        return () => container.removeEventListener('click', handleHasCommentClick);
+    }, [canUseRestrictedUi, commentsEnabled, loadComments]);
+
+    // ── Reset ao mudar de conteúdo ────────────────────────────────────────
+    useEffect(() => {
+        resetFetchedAnchors();
+    }, [data?.markdown, data?.ncm, data?.query, resetFetchedAnchors]);
+
+    // ───────────────────────────────────────────────────────────────────────
+    const codeResults = useMemo(() => {
+        if (!data || data.type === 'text') return null;
+        if (data.resultados && typeof data.resultados === 'object') {
+            return data.resultados as Record<string, any>;
+        }
+        if (data.results && !Array.isArray(data.results) && typeof data.results === 'object') {
+            return data.results as Record<string, any>;
+        }
+        return null;
+    }, [data?.type, data?.resultados, data?.results]);
+
+    useEffect(() => {
+        startTransition(() => {
+            setHydratedCodeResults(null);
+            setIsHydratingCodeResults(false);
+            setFailedChapterBodies([]);
+        });
+    }, [data?.markdown, data?.ncm, data?.query, tabId]);
+
+    const shouldHydrateCodeResults = useMemo(() => {
+        return !!codeResults
+            && data?.type === 'code'
+            && !data?.markdown
+            && !isTipiResults(codeResults);
+    }, [codeResults, data?.markdown, data?.type]);
+
+    const renderableCodeResults = useMemo(() => {
+        return hydratedCodeResults ?? codeResults;
+    }, [codeResults, hydratedCodeResults]);
+
+    const missingChapterBodies = useMemo(() => {
+        if (!shouldHydrateCodeResults || !renderableCodeResults) return [] as string[];
+
+        return Object.entries(renderableCodeResults)
+            .filter(([, chapter]) => !chapterHasRenderableContent(chapter))
+            .map(([chapterKey, chapter]) => {
+                const capitulo = (chapter as { capitulo?: unknown })?.capitulo;
+                return typeof capitulo === 'string' && capitulo.trim()
+                    ? capitulo.trim()
+                    : chapterKey;
+            })
+            .filter((chapter) => !failedChapterBodies.includes(chapter));
+    }, [failedChapterBodies, renderableCodeResults, shouldHydrateCodeResults]);
+
+    useEffect(() => {
+        if (!isActive || !shouldHydrateCodeResults || !renderableCodeResults || missingChapterBodies.length === 0) {
+            return;
+        }
+
+        let cancelled = false;
+        setIsHydratingCodeResults(true);
+
+        const applyHydrationResult = ({
+            chapterBodies,
+            failedChapters,
+        }: ChapterHydrationResult) => {
+            if (cancelled) return;
+
+            if (failedChapters.length > 0) {
+                startTransition(() => {
+                    setFailedChapterBodies(createFailedChapterBodiesUpdater(failedChapters));
+                });
+            }
+
+            if (chapterBodies.length === 0) return;
+
+            const mergedResults = mergeHydratedChapterBodies(
+                renderableCodeResults,
+                chapterBodies,
+            );
+
+            startTransition(() => {
+                setHydratedCodeResults(mergedResults);
+                setFailedChapterBodies(
+                    createRecoveredChapterBodiesUpdater(chapterBodies),
+                );
+                onHydratedResults?.(tabId, mergedResults);
+            });
+        };
+
+        void fetchChapterBodies(missingChapterBodies)
+            .then(applyHydrationResult)
+            .catch((error) => {
+                console.error('[ResultDisplay] Failed to hydrate chapter bodies', error);
+            })
+            .finally(() => {
+                if (!cancelled) {
+                    setIsHydratingCodeResults(false);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [
+        isActive,
+        missingChapterBodies,
+        onHydratedResults,
+        renderableCodeResults,
+        shouldHydrateCodeResults,
+        tabId,
+    ]);
+
+    const findAnchorIdForQuery = useCallback((resultados: any, query: string) => {
+        if (!resultados || typeof resultados !== 'object') return null;
+
+        const normalizedQuery = normalizeDigits(query);
+        if (!normalizedQuery) return null;
+
+        const chapters = Object.values(resultados) as any[];
+        let exactMatch: string | null = null;
+        let prefixMatch: string | null = null;
+
+        for (const chapter of chapters) {
+            const match = findAnchorIdInChapter(chapter, normalizedQuery, prefixMatch);
+            if (match.exactMatch) {
+                exactMatch = match.exactMatch;
+                break;
+            }
+            prefixMatch = match.prefixMatch;
+        }
+
+        return exactMatch || prefixMatch;
+    }, []);
+
+    const getPosicaoAlvoFromResultados = useCallback((resultados: any) => {
+        if (!resultados || typeof resultados !== 'object') return null as string | null;
+        const chapters = Object.values(resultados) as any[];
+        if (chapters.length !== 1) return null;
+        const posicaoAlvo = (chapters[0]?.posicao_alvo || chapters[0]?.posicaoAlvo || '').toString().trim();
+        return posicaoAlvo || null;
+    }, []);
+
+    const getSectionAnchorIdsFromResultados = useCallback((resultados: any) => {
+        if (!resultados || typeof resultados !== 'object') return [] as string[];
+
+        const ids: string[] = [];
+        const chapters = Object.values(resultados) as any[];
+        for (const chapter of chapters) {
+            const capitulo = (chapter?.capitulo || '').toString().trim();
+            if (!capitulo) continue;
+
+            const secoes = chapter?.secoes;
+            if (secoes && typeof secoes === 'object') {
+                const structuredSectionIds = getStructuredSectionIds(capitulo, secoes as Record<string, unknown>);
+                ids.push(...structuredSectionIds);
+                if (structuredSectionIds.length > 0) continue;
+            }
+
+            if ((chapter?.notas_gerais || '').toString().trim()) {
+                ids.push(`chapter-${capitulo}-notas`);
+            }
+        }
+
+        return ids;
+    }, []);
+
+    const getAnchorIdsFromResultados = useCallback((resultados: any) => {
+        if (!resultados || typeof resultados !== 'object') return [] as string[];
+
+        const ids = getSectionAnchorIdsFromResultados(resultados);
+        const chapters = Object.values(resultados) as any[];
+        for (const chapter of chapters) {
+            const positions = Array.isArray(chapter?.posicoes) ? chapter.posicoes : [];
+            for (const pos of positions) {
+                const codigo = (pos?.codigo || pos?.ncm || '').toString();
+                if (!codigo) continue;
+                ids.push(pos?.anchor_id || generateAnchorId(codigo));
+            }
+        }
+        return Array.from(new Set(ids));
+    }, [getSectionAnchorIdsFromResultados]);
+
+    const ensureSectionAnchors = useCallback((resultados: any, container: HTMLElement) => {
+        const sectionIds = getSectionAnchorIdsFromResultados(resultados);
+        for (const sectionId of sectionIds) {
+            const existing = container.querySelector(`#${CSS.escape(sectionId)}`) as HTMLElement | null;
+            if (existing) continue;
+            resolveSectionElement(container, sectionId);
+        }
+    }, [getSectionAnchorIdsFromResultados]);
+
+    const searchHighlighterQuery = useMemo(() => {
+        const candidate = (latestTextQuery || '').trim();
+        return candidate || null;
+    }, [latestTextQuery]);
+    const searchHighlighterOwnsScroll = data?.type === 'text' && !!searchHighlighterQuery;
+    const consumeNewSearchKey = useMemo(
+        () => `${tabId}|${isNewSearch ? '1' : '0'}|${data?.query ?? ''}|${data?.ncm ?? ''}|${latestTextQuery ?? ''}`,
+        [data?.ncm, data?.query, isNewSearch, latestTextQuery, tabId],
+    );
+
+    // Sidebar Navigation Handler
+    const handleNavigate = useCallback((targetId: string) => {
+        const container = containerRef.current;
+        if (!container) return;
+
+        // Try direct ID first (backend should provide correct anchor_id)
+        let element = container.querySelector(`#${CSS.escape(targetId)}`) as HTMLElement | null;
+
+        // Fallback: generate anchor ID from codigo (e.g., "84.13" -> "pos-84-13")
+        if (!element) {
+            const generatedId = generateAnchorId(targetId);
+            element = container.querySelector(`#${CSS.escape(generatedId)}`) as HTMLElement | null;
+        }
+
+        // Section fallback: backend HTML may provide section classes without stable IDs.
+        if (!element) {
+            element = resolveSectionElement(container, targetId);
+        }
+
+        if (element) {
+            element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            element.classList.add('flash-highlight');
+            setTimeout(() => element.classList.remove('flash-highlight'), 2000);
+            const nextAnchor = element.id || targetId;
+            manualNavigationLockRef.current = {
+                anchorId: nextAnchor,
+                expiresAt: Date.now() + MANUAL_NAVIGATION_HIGHLIGHT_LOCK_MS,
+            };
+            setActiveAnchorId(prev => (prev === nextAnchor ? prev : nextAnchor));
+        } else {
+            debug.warn('[Navigate] target not found:', targetId);
+        }
+    }, []); // Empty dependency array as it only uses refs or DOM APIs
+
+    const targetCandidates = useMemo(() => {
+        if (!data) return null;
+
+        const ncmToScroll = resolveNcmToScroll(data);
+        if (!ncmToScroll) return null;
+
+        return resolveAutoScrollCandidates(
+            ncmToScroll,
+            renderableCodeResults,
+            findAnchorIdForQuery,
+            getPosicaoAlvoFromResultados,
+        );
+    }, [data, findAnchorIdForQuery, getPosicaoAlvoFromResultados, renderableCodeResults]);
+
+    const resolveAutoScrollTargetReadiness = useCallback((container: HTMLElement) => {
+        if (renderableCodeResults) {
+            ensureSectionAnchors(renderableCodeResults, container);
+        }
+
+        if (!targetCandidates || targetCandidates.length === 0) {
+            return false;
+        }
+
+        if (findExistingTargetElement(container, targetCandidates)) {
+            return true;
+        }
+
+        const posicaoAlvo = renderableCodeResults ? getPosicaoAlvoFromResultados(renderableCodeResults) : null;
+        const candidateNcm = posicaoAlvo || (data?.ncm || data?.query || '');
+        if (!candidateNcm) {
+            return false;
+        }
+
+        const fallback = ensureTargetAnchorFromDataNcm(container, candidateNcm);
+        if (!fallback) {
+            return false;
+        }
+
+        return !!findExistingTargetElement(container, targetCandidates);
+    }, [
+        renderableCodeResults,
+        data?.ncm,
+        data?.query,
+        ensureSectionAnchors,
+        getPosicaoAlvoFromResultados,
+        targetCandidates,
+    ]);
+
+    // Stabilize onConsumeNewSearch callback to prevent AutoScroll effect loop
+    const onConsumeNewSearchRef = useRef(onConsumeNewSearch);
+    useEffect(() => {
+        onConsumeNewSearchRef.current = onConsumeNewSearch;
+    }, [onConsumeNewSearch]);
+
+    const onPersistScrollRef = useRef(onPersistScroll);
+    const hasConsumedNewSearchRef = useRef(false);
+    const isActiveRef = useRef(isActive);
+    const isNewSearchRef = useRef(isNewSearch);
+    useEffect(() => {
+        onPersistScrollRef.current = onPersistScroll;
+    }, [onPersistScroll]);
+    useEffect(() => {
+        hasConsumedNewSearchRef.current = false;
+    }, [consumeNewSearchKey]);
+    useEffect(() => {
+        isActiveRef.current = isActive;
+    }, [isActive]);
+    useEffect(() => {
+        isNewSearchRef.current = isNewSearch;
+    }, [isNewSearch]);
+    useEffect(() => {
+        onContentReadyRef.current = onContentReady;
+    }, [onContentReady]);
+    useEffect(() => {
+        activeAnchorIdRef.current = activeAnchorId;
+    }, [activeAnchorId]);
+    useEffect(() => {
+        return () => {
+            if (anchorRafRef.current !== null) {
+                cancelAnimationFrame(anchorRafRef.current);
+            }
+        };
+    }, []);
+    useEffect(() => {
+        if (isContentReady) {
+            onContentReadyRef.current?.(tabId);
+        }
+    }, [isContentReady, tabId]);
+
+    // Keep active term in sync with the latest text query for this tab.
+    useEffect(() => {
+        const normalizedLatestTextQuery = (latestTextQuery || '').trim();
+        setActiveTerm(prev => (prev === normalizedLatestTextQuery ? prev : normalizedLatestTextQuery));
+    }, [latestTextQuery, data?.query, tabId]);
+
+    const consumeNewSearchScroll = useCallback((scrollTop?: number, force = false) => {
+        if (hasConsumedNewSearchRef.current) return;
+        if (!force && (!isActiveRef.current || !isNewSearchRef.current)) return;
+        hasConsumedNewSearchRef.current = true;
+        onConsumeNewSearchRef.current(tabId, scrollTop);
+    }, [tabId]);
+
+    const handleAutoScrollComplete = useCallback((success?: boolean) => {
+        if (!success) return;
+        // Wrap in RAF to ensure DOM has updated/painted the scroll action
+        // before we capture the final position and update app state.
+        requestAnimationFrame(() => {
+            if (!isActiveRef.current || !isNewSearchRef.current) return;
+            const currentScroll = containerRef.current?.scrollTop || 0;
+            consumeNewSearchScroll(currentScroll);
+        });
+    }, [consumeNewSearchScroll]);
+
+    const handleHighlightScrollComplete = useCallback((scrollTop: number) => {
+        if (!isActiveRef.current || !isNewSearchRef.current) return;
+        consumeNewSearchScroll(scrollTop);
+    }, [consumeNewSearchScroll]);
+
+    // `isContentReady` means the tab can render, but auto-scroll only starts
+    // once at least one candidate anchor is actually present in the DOM.
+    // Only auto-scroll when:
+    // 1. Tab is active
+    // 2. This is a NEW search (not returning to existing tab)
+    // 3. Let SearchHighlighter take precedence for text-result tabs, but keep anchor scroll as fallback elsewhere
+    const shouldAutoScroll = !!targetCandidates?.length
+        && isActive
+        && isNewSearch
+        && isContentReady
+        && !searchHighlighterOwnsScroll
+        && isTargetReady;
+    useRobustScroll({
+        targetId: targetCandidates,
+        shouldScroll: shouldAutoScroll,
+        containerRef,
+        onComplete: handleAutoScrollComplete,
+        expectedTags: ['H1', 'H2', 'H3', 'H4', 'ARTICLE', 'SECTION', 'DIV']
+    });
+
+    // Track scroll position for persistence
+    useEffect(() => {
+        const element = containerRef.current;
+        if (!element) return;
+
+        const handleScroll = () => {
+            const currentScroll = element.scrollTop;
+            latestScrollTopRef.current = currentScroll;
+            hasScrollSnapshotRef.current = true;
+
+            if (!isActive) return;
+
+            const persist = onPersistScrollRef.current;
+            if (!persist) return;
+            if (lastPersistedScrollRef.current === currentScroll) return;
+
+            lastPersistedScrollRef.current = currentScroll;
+            persist(tabId, currentScroll);
+        };
+
+        element.addEventListener('scroll', handleScroll, { passive: true });
+        return () => element.removeEventListener('scroll', handleScroll);
+    }, [data?.type, data?.markdown, renderableCodeResults, isActive, tabId]);
+
+    useEffect(() => {
+        if (isActive) return;
+
+        const persist = onPersistScrollRef.current;
+        if (!persist) return;
+        if (!hasScrollSnapshotRef.current) return;
+
+        const currentScroll = latestScrollTopRef.current;
+        if (isNewSearchRef.current && !hasConsumedNewSearchRef.current) {
+            consumeNewSearchScroll(currentScroll, true);
+            return;
+        }
+        if (lastPersistedScrollRef.current === currentScroll) return;
+
+        lastPersistedScrollRef.current = currentScroll;
+        persist(tabId, currentScroll);
+    }, [consumeNewSearchScroll, isActive, tabId]);
+
+    // Restore scroll when tab becomes active (only if NOT a new search)
+    const hasRestoredInitialScrollRef = useRef(false);
+    useEffect(() => {
+        // Skip restore if this is a new search - auto-scroll will handle positioning
+        if (!isActive || isNewSearch) return;
+        // Wait until content is rendered before restoring scroll
+        if (!isContentReady) return;
+        const element = containerRef.current;
+        if (!element) return;
+
+        if (typeof initialScrollTop !== 'number') return;
+        const targetScrollTop = initialScrollTop;
+
+        if (hasRestoredInitialScrollRef.current) return;
+        if (Math.abs(element.scrollTop - targetScrollTop) < 1) return;
+
+        let cancelled = false;
+        let attempts = 0;
+        let frameId = 0;
+        const maxAttempts = 20;
+
+        const tryRestore = () => {
+            if (cancelled) return;
+
+            const currentContainer = containerRef.current;
+            if (!currentContainer) return;
+
+            if (Math.abs(currentContainer.scrollTop - targetScrollTop) < 1) {
+                latestScrollTopRef.current = targetScrollTop;
+                hasScrollSnapshotRef.current = true;
+                lastPersistedScrollRef.current = targetScrollTop;
+                hasRestoredInitialScrollRef.current = true;
+                return;
+            }
+
+            const hasScrollableContent = currentContainer.scrollHeight > currentContainer.clientHeight;
+            if (!hasScrollableContent && attempts < maxAttempts) {
+                attempts += 1;
+                frameId = requestAnimationFrame(tryRestore);
+                return;
+            }
+
+            currentContainer.scrollTop = targetScrollTop;
+            latestScrollTopRef.current = targetScrollTop;
+            hasScrollSnapshotRef.current = true;
+            lastPersistedScrollRef.current = targetScrollTop;
+
+            if (Math.abs(currentContainer.scrollTop - targetScrollTop) < 1) {
+                hasRestoredInitialScrollRef.current = true;
+                return;
+            }
+
+            if (attempts < maxAttempts) {
+                attempts += 1;
+                frameId = requestAnimationFrame(tryRestore);
+                return;
+            }
+
+            hasRestoredInitialScrollRef.current = true;
+        };
+
+        frameId = requestAnimationFrame(tryRestore);
+
+        return () => {
+            cancelled = true;
+            cancelAnimationFrame(frameId);
+        };
+    }, [isActive, initialScrollTop, isNewSearch, isContentReady]);
+
+    // Reset restored flag when inactive so it can restore again when returning
+    useEffect(() => {
+        if (!isActive) {
+            hasRestoredInitialScrollRef.current = false;
+        }
+    }, [isActive]);
+
+
+
+    // Render backend content (prefer HTML; parse markdown only as legacy fallback)
+    useEffect(() => {
+        if (data?.type === 'text') {
+            renderedMarkupKeyRef.current = null;
+            setIsContentReady(true);
+            setIsFullyRendered(true);
+            return;
+        }
+        if (!contentRef.current) return;
+
+        const rawMarkdown = typeof data?.markdown === 'string' ? data.markdown.trim() : '';
+        const markupToRender = resolveMarkupToRender(rawMarkdown, renderableCodeResults);
+
+        if (!markupToRender) {
+            if (shouldHydrateCodeResults && missingChapterBodies.length > 0) {
+                renderedMarkupKeyRef.current = null;
+                setIsContentReady(true);
+                setIsFullyRendered(false);
+                return;
+            }
+            contentRef.current.textContent = '';
+            renderedMarkupKeyRef.current = null;
+            setIsContentReady(true);
+            setIsFullyRendered(true);
+            return;
+        }
+
+        try {
+            return renderMarkupContent({
+                rawMarkdown,
+                markupToRender,
+                isActive,
+                isContentReady,
+                refs: {
+                    contentRef,
+                    renderedMarkupKeyRef,
+                    lastMarkupRef,
+                    lastHtmlRef,
+                },
+                setIsContentReady,
+                setIsFullyRendered,
+            });
+        } catch (e) {
+            console.error("Content render error:", e);
+            if (contentRef.current) contentRef.current.textContent = 'Error rendering content.';
+            renderedMarkupKeyRef.current = null;
+            setIsContentReady(true);
+            setIsFullyRendered(true);
+        }
+    }, [
+        data?.markdown,
+        data?.type,
+        isActive,
+        missingChapterBodies.length,
+        renderableCodeResults,
+        shouldHydrateCodeResults,
+    ]);
+
+    useEffect(() => {
+        if (!isContentReady || !containerRef.current || !targetCandidates?.length) {
+            setIsTargetReady(false);
+            return;
+        }
+
+        let cancelled = false;
+        let observer: MutationObserver | null = null;
+        const container = containerRef.current;
+
+        const syncReadiness = () => {
+            const ready = resolveAutoScrollTargetReadiness(container);
+            if (!cancelled) {
+                setIsTargetReady(ready);
+            }
+            return ready;
+        };
+
+        if (syncReadiness()) {
+            return () => {
+                cancelled = true;
+            };
+        }
+
+        if (!isFullyRendered) {
+            observer = new MutationObserver(() => {
+                if (syncReadiness()) {
+                    observer?.disconnect();
+                    observer = null;
+                }
+            });
+            observer.observe(container, {
+                childList: true,
+                subtree: true,
+            });
+        }
+
+        return () => {
+            cancelled = true;
+            observer?.disconnect();
+        };
+    }, [
+        isContentReady,
+        isFullyRendered,
+        resolveAutoScrollTargetReadiness,
+        targetCandidates,
+    ]);
+
+    // Ensure structured section anchors exist for sidebar navigation/highlight syncing.
+    useEffect(() => {
+        if (!isContentReady || !renderableCodeResults || !containerRef.current) return;
+        ensureSectionAnchors(renderableCodeResults, containerRef.current);
+    }, [ensureSectionAnchors, isContentReady, renderableCodeResults]);
+
+    // Query-term highlighting for code results.
+    // Always clean previous wrappers first to avoid nested/duplicated marks after query changes.
+    useEffect(() => {
+        const contentContainer = contentRef.current;
+        if (!contentContainer || data?.type === 'text') return;
+
+        unwrapQueryHighlights(contentContainer);
+
+        if (!isActive || !isContentReady || !activeTerm || searchHighlighterQuery) {
+            return () => {
+                const current = contentRef.current;
+                if (current) unwrapQueryHighlights(current);
+            };
+        }
+
+        highlightTermInContainer(contentContainer, activeTerm);
+
+        return () => {
+            const current = contentRef.current;
+            if (current) unwrapQueryHighlights(current);
+        };
+    }, [activeTerm, isActive, isContentReady, searchHighlighterQuery, tabId, data?.type, data?.markdown]);
+
+    // Sync Sidebar to current visible anchor
+    useEffect(() => {
+        if (!isActive || !isContentReady || !renderableCodeResults || !containerRef.current) return;
+
+        const ids = getAnchorIdsFromResultados(renderableCodeResults);
+        if (ids.length === 0) return;
+
+        const elements = ids
+            .map(id => containerRef.current?.querySelector(`#${CSS.escape(id)}`) as HTMLElement | null)
+            .filter(Boolean) as HTMLElement[];
+
+        if (elements.length === 0) return;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                const nextAnchorId = getNextVisibleAnchorId(entries);
+                if (!nextAnchorId) return;
+
+                const manualNavigationLock = manualNavigationLockRef.current;
+                if (manualNavigationLock) {
+                    const now = Date.now();
+                    if (now < manualNavigationLock.expiresAt) {
+                        if (nextAnchorId !== manualNavigationLock.anchorId) {
+                            return;
+                        }
+                        manualNavigationLockRef.current = null;
+                    } else {
+                        manualNavigationLockRef.current = null;
+                    }
+                }
+
+                scheduleActiveAnchorUpdate(nextAnchorId, activeAnchorIdRef, anchorRafRef, setActiveAnchorId);
+            },
+            {
+                root: containerRef.current,
+                rootMargin: '0px 0px -60% 0px',
+                threshold: 0.1
+            }
+        );
+
+        elements.forEach(el => observer.observe(el));
+
+        return () => observer.disconnect();
+    }, [getAnchorIdsFromResultados, isActive, isContentReady, renderableCodeResults]);
+
+
+    if (!data) {
+        return <p className={styles.emptyMessage}>Sem resultados para exibir.</p>;
+    }
+
+    // Text Search Rendering
+    if (data.type === 'text') {
+        return (
+            <div className={`${styles.content} ${styles.textSearchContent}`} ref={containerRef} id={containerId}>
+                <TextSearchResults
+                    results={(data.results as SearchResultItem[]) || null}
+                    query={latestTextQuery || data.query || ""}
+                    onResultClick={(ncm: string) => globalThis.nesh.openTextResultInNewTab(ncm, latestTextQuery || data.query || '')}
+                    scrollParentRef={containerRef}
+                />
+            </div>
+        );
+    }
+
+    // Default: Code View (Markdown + Sidebar)
+    // Layout: Grid with content and sidebar (position from settings)
+    const wrapperClasses = getWrapperClasses(styles, sidebarCollapsed, mobileMenuOpen, sidebarPosition);
+    const sidebarToggleLabel = getSidebarToggleLabel(sidebarCollapsed);
+    const sidebarToggleIcon = getSidebarToggleIcon(sidebarPosition, sidebarCollapsed);
+    const contentVisibilityClass = getContentVisibilityClass(styles, isContentReady);
+    const commentToggleLabel = getCommentToggleLabel(commentsEnabled);
+    const commentToggleClasses = getCommentToggleClassName(styles, commentsEnabled);
+    const shouldRenderSidebar = isActive && !!renderableCodeResults;
+
+    return (
+        <div className={wrapperClasses}>
+            {/* Toggle Button */}
+            <button
+                className={styles.sidebarToggle}
+                onClick={toggleSidebar}
+                aria-label={sidebarToggleLabel}
+            >
+                {sidebarToggleIcon}
+            </button>
+
+            {/* Content scroll container - Coluna 1 */}
+            <div
+                className={`${styles.content} ${contentVisibilityClass} markdown-body`}
+                ref={(el) => {
+                    // containerRef = scroll container (para scroll tracking e texto selection)
+                    (containerRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+                }}
+                id={containerId}
+            >
+                {/* O container interno organiza o conteúdo da esquerda verticalmente (mensagens + texto) */}
+                <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+                    {shouldHydrateCodeResults && (isHydratingCodeResults || missingChapterBodies.length > 0) && (
+                        <div className={styles.loadingSpinnerContainer}>
+                            <svg className={styles.spinner} viewBox="0 0 50 50">
+                                <circle className={styles.spinnerPath} cx="25" cy="25" r="20" fill="none" strokeWidth="5"></circle>
+                            </svg>
+                            <p className={styles.loadingText}>Carregando conteúdo detalhado...</p>
+                        </div>
+                    )}
+                    {!shouldHydrateCodeResults && !data.markdown && !isTipiResults(renderableCodeResults || null) && (
+                        <p>Sem resultados para exibir.</p>
+                    )}
+                    
+                    {/* Texto renderizado via fragmentos HTML sanitizados */}
+                    <div
+                        className={styles.contentText}
+                        ref={(el) => {
+                            (contentRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+                        }}
+                    />
+                </div>
+
+                {/* Painel de Comentários (Google Docs style) — só exibido quando ativado */}
+                {canUseRestrictedUi && commentsEnabled && (
+                    <CommentPanel
+                        pending={pendingComment}
+                        comments={localComments}
+                        onSubmit={handleCommentSubmit}
+                        onDismiss={handleDismissComment}
+                        onEdit={editComment}
+                        onDelete={removeComment}
+                        currentUserId={userId}
+                    />
+                )}
+            </div>
+
+            {searchHighlighterQuery && (
+                <SearchHighlighter
+                    query={searchHighlighterQuery}
+                    contentContainerRef={contentRef}
+                    isContentReady={isContentReady}
+                    isFullyRendered={isFullyRendered}
+                    onHighlightScrollComplete={handleHighlightScrollComplete}
+                />
             )}
-          {!shouldHydrateCodeResults &&
-            !data.markdown &&
-            !isTipiResults(renderableCodeResults || null) && (
-              <p>Sem resultados para exibir.</p>
+
+            {/* Toggle de Comentários */}
+            {canUseRestrictedUi && (
+                <button
+                    className={commentToggleClasses}
+                    onClick={toggleComments}
+                    aria-label={commentToggleLabel}
+                    title={commentToggleLabel}
+                >
+                    💬
+                </button>
             )}
 
-          {/* Texto renderizado via fragmentos HTML sanitizados */}
-          <div
-            className={styles.contentText}
-            ref={(el) => {
-              ;(
-                contentRef as React.MutableRefObject<HTMLDivElement | null>
-              ).current = el
-            }}
-          />
+            {/* Botão bolha flutuante (aparece ao selecionar texto, se comentários ativos) */}
+            {canUseRestrictedUi && commentsEnabled && selection && (
+                <HighlightPopover
+                    selection={selection}
+                    onRequestComment={handleOpenComment}
+                    onPopoverMouseDown={onPopoverMouseDown}
+                />
+            )}
+
+            {/* Drawer de Comentários — responsivo < 1280px */}
+            {canUseRestrictedUi && commentsEnabled && (
+                <CommentDrawer
+                    open={drawerOpen}
+                    onClose={toggleDrawer}
+                    pending={pendingComment}
+                    comments={localComments}
+                    onSubmit={handleCommentSubmit}
+                    onDismiss={handleDismissComment}
+                    onEdit={editComment}
+                    onDelete={removeComment}
+                    currentUserId={userId}
+                />
+            )}
+
+            {/* Mobile Sidebar Overlay */}
+            {shouldRenderSidebar && (
+                <button
+                    type="button"
+                    className={`${styles.mobileOverlay || ''} ${mobileMenuOpen ? (styles.mobileOverlayOpen || '') : ''}`}
+                    onClick={onCloseMobileMenu}
+                    aria-label="Fechar menu lateral"
+                />
+            )}
+
+            {/* Sidebar Container - Coluna 2 */}
+            {shouldRenderSidebar && (
+                <div className={styles.sidebarContainer}>
+                    <Sidebar
+                        results={renderableCodeResults}
+                        onNavigate={handleNavigate}
+                        onClose={onCloseMobileMenu}
+                        searchQuery={latestTextQuery || data.query || data.ncm}
+                        activeAnchorId={activeAnchorId}
+                    />
+                </div>
+            )}
         </div>
-
-        {/* Painel de Comentários (Google Docs style) — só exibido quando ativado */}
-        {canUseRestrictedUi && commentsEnabled && (
-          <CommentPanel
-            pending={pendingComment}
-            comments={localComments}
-            onSubmit={handleCommentSubmit}
-            onDismiss={handleDismissComment}
-            onEdit={editComment}
-            onDelete={removeComment}
-            currentUserId={userId}
-          />
-        )}
-      </div>
-
-      {searchHighlighterQuery && (
-        <SearchHighlighter
-          query={searchHighlighterQuery}
-          contentContainerRef={contentRef}
-          isContentReady={isContentReady}
-          isFullyRendered={isFullyRendered}
-          onHighlightScrollComplete={handleHighlightScrollComplete}
-        />
-      )}
-
-      {/* Toggle de Comentários */}
-      {canUseRestrictedUi && (
-        <button
-          className={commentToggleClasses}
-          onClick={toggleComments}
-          aria-label={commentToggleLabel}
-          title={commentToggleLabel}
-        >
-          💬
-        </button>
-      )}
-
-      {/* Botão bolha flutuante (aparece ao selecionar texto, se comentários ativos) */}
-      {canUseRestrictedUi && commentsEnabled && selection && (
-        <HighlightPopover
-          selection={selection}
-          onRequestComment={handleOpenComment}
-          onPopoverMouseDown={onPopoverMouseDown}
-        />
-      )}
-
-      {/* Drawer de Comentários — responsivo < 1280px */}
-      {canUseRestrictedUi && commentsEnabled && (
-        <CommentDrawer
-          open={drawerOpen}
-          onClose={toggleDrawer}
-          pending={pendingComment}
-          comments={localComments}
-          onSubmit={handleCommentSubmit}
-          onDismiss={handleDismissComment}
-          onEdit={editComment}
-          onDelete={removeComment}
-          currentUserId={userId}
-        />
-      )}
-
-      {/* Mobile Sidebar Overlay */}
-      {shouldRenderSidebar && (
-        <div
-          className={`${styles.mobileOverlay || ''} ${mobileMenuOpen ? styles.mobileOverlayOpen || '' : ''}`}
-          onClick={onCloseMobileMenu}
-        />
-      )}
-
-      {/* Sidebar Container - Coluna 2 */}
-      {shouldRenderSidebar && (
-        <div className={styles.sidebarContainer}>
-          <Sidebar
-            results={renderableCodeResults}
-            onNavigate={handleNavigate}
-            isOpen={mobileMenuOpen}
-            onClose={onCloseMobileMenu}
-            searchQuery={latestTextQuery || data.query || data.ncm}
-            activeAnchorId={activeAnchorId}
-          />
-        </div>
-      )}
-    </div>
-  )
-})
+    );
+});

--- a/client/src/components/ResultDisplay.tsx
+++ b/client/src/components/ResultDisplay.tsx
@@ -1858,7 +1858,6 @@ export const ResultDisplay = React.memo(function ResultDisplay({
                     <Sidebar
                         results={renderableCodeResults}
                         onNavigate={handleNavigate}
-                        isOpen={mobileMenuOpen}
                         onClose={onCloseMobileMenu}
                         searchQuery={latestTextQuery || data.query || data.ncm}
                         activeAnchorId={activeAnchorId}

--- a/client/src/components/ResultDisplay.tsx
+++ b/client/src/components/ResultDisplay.tsx
@@ -1858,6 +1858,7 @@ export const ResultDisplay = React.memo(function ResultDisplay({
                     <Sidebar
                         results={renderableCodeResults}
                         onNavigate={handleNavigate}
+                        isOpen={mobileMenuOpen}
                         onClose={onCloseMobileMenu}
                         searchQuery={latestTextQuery || data.query || data.ncm}
                         activeAnchorId={activeAnchorId}

--- a/client/src/components/ResultDisplay.tsx
+++ b/client/src/components/ResultDisplay.tsx
@@ -1,118 +1,153 @@
-import { TextSearchResults } from './TextSearchResults';
-import React, { startTransition, useEffect, useRef, useState, useCallback, useMemo } from 'react';
-import { marked } from 'marked';
-import { useRobustScroll } from '../hooks/useRobustScroll';
-import { generateAnchorId } from '../utils/id_utils';
-import { SearchResultItem } from './TextSearchResults';
-import styles from './ResultDisplay.module.css';
-import { debug } from '../utils/debug';
-import { NeshRenderer } from '../utils/NeshRenderer';
-import { useSettings } from '../context/SettingsContext';
-import { Sidebar } from './Sidebar';
-import { SearchHighlighter } from './SearchHighlighter';
-import { useTextSelection } from '../hooks/useTextSelection';
-import { HighlightPopover } from './HighlightPopover';
-import { CommentPanel } from './CommentPanel';
-import { CommentDrawer } from './CommentDrawer';
-import type { PendingCommentEntry } from './CommentPanel';
-import { useAuth } from '../context/AuthContext';
-import { useComments } from '../hooks/useComments';
-import toast from 'react-hot-toast';
+import { TextSearchResults } from './TextSearchResults'
+import React, {
+  startTransition,
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+  useMemo,
+} from 'react'
+import { marked } from 'marked'
+import { useRobustScroll } from '../hooks/useRobustScroll'
+import { generateAnchorId } from '../utils/id_utils'
+import { SearchResultItem } from './TextSearchResults'
+import styles from './ResultDisplay.module.css'
+import { debug } from '../utils/debug'
+import { NeshRenderer } from '../utils/NeshRenderer'
+import { useSettings } from '../context/SettingsContext'
+import { Sidebar } from './Sidebar'
+import { SearchHighlighter } from './SearchHighlighter'
+import { useTextSelection } from '../hooks/useTextSelection'
+import { HighlightPopover } from './HighlightPopover'
+import { CommentPanel } from './CommentPanel'
+import { CommentDrawer } from './CommentDrawer'
+import type { PendingCommentEntry } from './CommentPanel'
+import { useAuth } from '../context/AuthContext'
+import { useComments } from '../hooks/useComments'
+import toast from 'react-hot-toast'
 import {
-    appendTrustedHtmlToElement,
-    replaceElementWithTrustedHtml,
-    sanitizeRichHtml,
-} from '../utils/contentSecurity';
-import { getNeshChapterBody } from '../services/api';
-import type { ChapterBodyResponse } from '../types/api.types';
+  appendTrustedHtmlToElement,
+  replaceElementWithTrustedHtml,
+  sanitizeRichHtml,
+} from '../utils/contentSecurity'
+import { getNeshChapterBody } from '../services/api'
+import type { ChapterBodyResponse } from '../types/api.types'
 
-const LEGACY_MARKDOWN_PATTERN = /(^|\n)\s{0,3}(?:#{1,6}\s|>\s|[-*+]\s|\d+\.\s|---+\s*$)|\*\*[^*\n]+?\*\*/m;
+const LEGACY_MARKDOWN_PATTERN =
+  /(^|\n)\s{0,3}(?:#{1,6}\s|>\s|[-*+]\s|\d+\.\s|---+\s*$)|\*\*[^*\n]+?\*\*/m
 
-const isLikelyLegacyMarkdown = (value: string) => LEGACY_MARKDOWN_PATTERN.test(value);
+const isLikelyLegacyMarkdown = (value: string) =>
+  LEGACY_MARKDOWN_PATTERN.test(value)
 
-const SHARED_MARKUP_CACHE_MAX = 12;
-const sharedRawMarkupCache = new Map<string, string>();
-const sharedSanitizedMarkupCache = new Map<string, string>();
+const SHARED_MARKUP_CACHE_MAX = 12
+const sharedRawMarkupCache = new Map<string, string>()
+const sharedSanitizedMarkupCache = new Map<string, string>()
 
 function cacheGet(map: Map<string, string>, key: string): string | null {
-    const value = map.get(key);
-    if (value === undefined) return null;
-    map.delete(key);
-    map.set(key, value);
-    return value;
+  const value = map.get(key)
+  if (value === undefined) return null
+  map.delete(key)
+  map.set(key, value)
+  return value
 }
 
 function cacheSet(map: Map<string, string>, key: string, value: string) {
-    if (map.has(key)) {
-        map.delete(key);
-    } else if (map.size >= SHARED_MARKUP_CACHE_MAX) {
-        const oldestKey = map.keys().next().value as string | undefined;
-        if (oldestKey !== undefined) {
-            map.delete(oldestKey);
-        }
+  if (map.has(key)) {
+    map.delete(key)
+  } else if (map.size >= SHARED_MARKUP_CACHE_MAX) {
+    const oldestKey = map.keys().next().value as string | undefined
+    if (oldestKey !== undefined) {
+      map.delete(oldestKey)
     }
-    map.set(key, value);
+  }
+  map.set(key, value)
 }
 
-
 const getAliquotClass = (aliquota: string) => {
-    const normalized = (aliquota || '').toString().trim().toUpperCase();
-    if (!normalized || normalized === '0' || normalized === '0%') {
-        return { className: 'aliquot-zero', tooltip: 'Isento de IPI', display: normalized || '0%' };
+  const normalized = (aliquota || '').toString().trim().toUpperCase()
+  if (!normalized || normalized === '0' || normalized === '0%') {
+    return {
+      className: 'aliquot-zero',
+      tooltip: 'Isento de IPI',
+      display: normalized || '0%',
     }
-    if (normalized === 'NT') {
-        return { className: 'aliquot-nt', tooltip: 'Não Tributável', display: 'NT' };
-    }
+  }
+  if (normalized === 'NT') {
+    return { className: 'aliquot-nt', tooltip: 'Não Tributável', display: 'NT' }
+  }
 
-    const numeric = Number(normalized.replace('%', '').replace(',', '.'));
-    if (!Number.isNaN(numeric)) {
-        if (numeric <= 5) {
-            return { className: 'aliquot-low', tooltip: 'Alíquota Reduzida (1-5%)', display: `${numeric}%` };
-        }
-        if (numeric <= 10) {
-            return { className: 'aliquot-med', tooltip: 'Alíquota Média (6-10%)', display: `${numeric}%` };
-        }
-        return { className: 'aliquot-high', tooltip: 'Alíquota Elevada (>10%)', display: `${numeric}%` };
+  const numeric = Number(normalized.replace('%', '').replace(',', '.'))
+  if (!Number.isNaN(numeric)) {
+    if (numeric <= 5) {
+      return {
+        className: 'aliquot-low',
+        tooltip: 'Alíquota Reduzida (1-5%)',
+        display: `${numeric}%`,
+      }
     }
+    if (numeric <= 10) {
+      return {
+        className: 'aliquot-med',
+        tooltip: 'Alíquota Média (6-10%)',
+        display: `${numeric}%`,
+      }
+    }
+    return {
+      className: 'aliquot-high',
+      tooltip: 'Alíquota Elevada (>10%)',
+      display: `${numeric}%`,
+    }
+  }
 
-    return { className: 'aliquot-zero', tooltip: 'Isento de IPI', display: normalized };
-};
+  return {
+    className: 'aliquot-zero',
+    tooltip: 'Isento de IPI',
+    display: normalized,
+  }
+}
 
 const isTipiResults = (resultados: Record<string, any> | null | undefined) => {
-    if (!resultados || typeof resultados !== 'object') return false;
-    const chapters = Object.values(resultados);
-    return chapters.some((chapter) =>
-        Array.isArray(chapter?.posicoes) && chapter.posicoes.some((pos: any) => 'aliquota' in pos || 'nivel' in pos)
-    );
-};
+  if (!resultados || typeof resultados !== 'object') return false
+  const chapters = Object.values(resultados)
+  return chapters.some(
+    (chapter) =>
+      Array.isArray(chapter?.posicoes) &&
+      chapter.posicoes.some((pos: any) => 'aliquota' in pos || 'nivel' in pos)
+  )
+}
 
 const renderTipiFallback = (resultados: Record<string, any>) => {
-    const chapters = Object.values(resultados)
-        .sort((a: any, b: any) => parseInt(a?.capitulo || '0', 10) - parseInt(b?.capitulo || '0', 10));
+  const chapters = Object.values(resultados).sort(
+    (a: any, b: any) =>
+      parseInt(a?.capitulo || '0', 10) - parseInt(b?.capitulo || '0', 10)
+  )
 
-    return chapters.map((chapter: any) => {
-        const capitulo = chapter?.capitulo || '';
-        const titulo = chapter?.titulo || `Capítulo ${capitulo}`;
-        const posicoes = Array.isArray(chapter?.posicoes) ? chapter.posicoes : [];
+  return chapters
+    .map((chapter: any) => {
+      const capitulo = chapter?.capitulo || ''
+      const titulo = chapter?.titulo || `Capítulo ${capitulo}`
+      const posicoes = Array.isArray(chapter?.posicoes) ? chapter.posicoes : []
 
-        const positionsHtml = posicoes.map((pos: any) => {
-            const codigo = pos?.codigo || pos?.ncm || '';
-            const ncm = pos?.ncm || codigo;
-            const descricao = pos?.descricao || '';
-            const nivel = typeof pos?.nivel === 'number' ? pos.nivel : 1;
-            const indentClass = `tipi-nivel-${Math.min(nivel, 5)}`;
-            const { className, tooltip, display } = getAliquotClass(pos?.aliquota);
-            const elementId = generateAnchorId(codigo);
+      const positionsHtml = posicoes
+        .map((pos: any) => {
+          const codigo = pos?.codigo || pos?.ncm || ''
+          const ncm = pos?.ncm || codigo
+          const descricao = pos?.descricao || ''
+          const nivel = typeof pos?.nivel === 'number' ? pos.nivel : 1
+          const indentClass = `tipi-nivel-${Math.min(nivel, 5)}`
+          const { className, tooltip, display } = getAliquotClass(pos?.aliquota)
+          const elementId = generateAnchorId(codigo)
 
-            return `
+          return `
 <article class="tipi-position ${indentClass}" id="${elementId}" data-ncm="${ncm}" aria-label="NCM ${codigo}">
     <span class="tipi-ncm smart-link" data-ncm="${ncm}" role="link" tabindex="0">${codigo}</span>
     <span class="tipi-desc">${descricao}</span>
     <span class="tipi-aliquota ${className}" data-tooltip="${tooltip}" aria-label="${tooltip}">${display}</span>
-</article>`;
-        }).join('');
+</article>`
+        })
+        .join('')
 
-        return `
+      return `
 <div class="tipi-chapter" id="cap-${capitulo}">
     <h2 class="tipi-chapter-header">
         <span class="tipi-cap-badge">${capitulo}</span>
@@ -121,1744 +156,2056 @@ const renderTipiFallback = (resultados: Record<string, any>) => {
     <div class="tipi-positions">
         ${positionsHtml}
     </div>
-</div>`;
-    }).join('\n');
-};
+</div>`
+    })
+    .join('\n')
+}
 
-type ChapterSectionType = 'titulo' | 'notas' | 'consideracoes' | 'definicoes';
+type ChapterSectionType = 'titulo' | 'notas' | 'consideracoes' | 'definicoes'
 
-const SECTION_TARGET_PATTERN = /^chapter-([^-]+)-(titulo|notas|consideracoes|definicoes)$/i;
+const SECTION_TARGET_PATTERN =
+  /^chapter-([^-]+)-(titulo|notas|consideracoes|definicoes)$/i
 
 const SECTION_SELECTOR_FALLBACKS: Record<ChapterSectionType, string[]> = {
-    titulo: ['.section-titulo'],
-    notas: ['.section-notas', '.regras-gerais'],
-    consideracoes: ['.section-consideracoes'],
-    definicoes: ['.section-definicoes']
-};
+  titulo: ['.section-titulo'],
+  notas: ['.section-notas', '.regras-gerais'],
+  consideracoes: ['.section-consideracoes'],
+  definicoes: ['.section-definicoes'],
+}
 
 const SECTION_TEXT_FALLBACKS: Record<ChapterSectionType, RegExp> = {
-    titulo: /t[ií]tulo do cap[ií]tulo/i,
-    notas: /notas do cap[ií]tulo|regras gerais do cap[ií]tulo/i,
-    consideracoes: /considera[cç][oõ]es gerais/i,
-    definicoes: /defini[cç][oõ]es t[eé]cnicas/i
-};
+  titulo: /t[ií]tulo do cap[ií]tulo/i,
+  notas: /notas do cap[ií]tulo|regras gerais do cap[ií]tulo/i,
+  consideracoes: /considera[cç][oõ]es gerais/i,
+  definicoes: /defini[cç][oõ]es t[eé]cnicas/i,
+}
 
-function getSectionTargetMeta(targetId: string): { capitulo: string; sectionType: ChapterSectionType } | null {
-    const match = targetId.match(SECTION_TARGET_PATTERN);
-    if (!match) return null;
-    return { capitulo: match[1], sectionType: match[2].toLowerCase() as ChapterSectionType };
+function getSectionTargetMeta(
+  targetId: string
+): { capitulo: string; sectionType: ChapterSectionType } | null {
+  const match = targetId.match(SECTION_TARGET_PATTERN)
+  if (!match) return null
+  return {
+    capitulo: match[1],
+    sectionType: match[2].toLowerCase() as ChapterSectionType,
+  }
 }
 
 function getChapterAnchors(container: HTMLElement): HTMLElement[] {
-    return Array.from(container.querySelectorAll('[id]'))
-        .filter((node) => /^(?:cap|chapter)-\d{1,2}$/.test((node as HTMLElement).id)) as HTMLElement[];
+  return Array.from(container.querySelectorAll('[id]')).filter((node) =>
+    /^(?:cap|chapter)-\d{1,2}$/.test((node as HTMLElement).id)
+  ) as HTMLElement[]
 }
 
-function getChapterBounds(container: HTMLElement, capitulo: string): { start: HTMLElement | null; next: HTMLElement | null } {
-    const startByCap = container.querySelector(`#${CSS.escape(`cap-${capitulo}`)}`) as HTMLElement | null;
-    const startByChapter = container.querySelector(`#${CSS.escape(`chapter-${capitulo}`)}`) as HTMLElement | null;
-    const start = startByCap || startByChapter;
-    if (!start) return { start: null, next: null };
+function getChapterBounds(
+  container: HTMLElement,
+  capitulo: string
+): { start: HTMLElement | null; next: HTMLElement | null } {
+  const startByCap = container.querySelector(
+    `#${CSS.escape(`cap-${capitulo}`)}`
+  ) as HTMLElement | null
+  const startByChapter = container.querySelector(
+    `#${CSS.escape(`chapter-${capitulo}`)}`
+  ) as HTMLElement | null
+  const start = startByCap || startByChapter
+  if (!start) return { start: null, next: null }
 
-    const anchors = getChapterAnchors(container);
-    const idx = anchors.findIndex((el) => el === start);
-    if (idx < 0) return { start, next: null };
+  const anchors = getChapterAnchors(container)
+  const idx = anchors.findIndex((el) => el === start)
+  if (idx < 0) return { start, next: null }
 
-    return { start, next: anchors[idx + 1] || null };
+  return { start, next: anchors[idx + 1] || null }
 }
 
-function isElementWithinBounds(element: HTMLElement, start: HTMLElement, next: HTMLElement | null): boolean {
-    const isAfterStart = start === element
-        || Boolean(start.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_FOLLOWING);
-    if (!isAfterStart) return false;
-    if (!next) return true;
-    return Boolean(element.compareDocumentPosition(next) & Node.DOCUMENT_POSITION_FOLLOWING);
+function isElementWithinBounds(
+  element: HTMLElement,
+  start: HTMLElement,
+  next: HTMLElement | null
+): boolean {
+  const isAfterStart =
+    start === element ||
+    Boolean(
+      start.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_FOLLOWING
+    )
+  if (!isAfterStart) return false
+  if (!next) return true
+  return Boolean(
+    element.compareDocumentPosition(next) & Node.DOCUMENT_POSITION_FOLLOWING
+  )
 }
 
-function resolveSectionElement(container: HTMLElement, targetId: string): HTMLElement | null {
-    const sectionMeta = getSectionTargetMeta(targetId);
-    if (!sectionMeta) return null;
+function resolveSectionElement(
+  container: HTMLElement,
+  targetId: string
+): HTMLElement | null {
+  const sectionMeta = getSectionTargetMeta(targetId)
+  if (!sectionMeta) return null
 
-    const { capitulo, sectionType } = sectionMeta;
-    const { start, next } = getChapterBounds(container, capitulo);
-    const isInChapter = (candidate: HTMLElement) =>
-        !start || isElementWithinBounds(candidate, start, next);
+  const { capitulo, sectionType } = sectionMeta
+  const { start, next } = getChapterBounds(container, capitulo)
+  const isInChapter = (candidate: HTMLElement) =>
+    !start || isElementWithinBounds(candidate, start, next)
 
-    for (const selector of SECTION_SELECTOR_FALLBACKS[sectionType]) {
-        const candidate = Array.from(container.querySelectorAll(selector))
-            .find((node) => node instanceof HTMLElement && isInChapter(node as HTMLElement)) as HTMLElement | undefined;
+  for (const selector of SECTION_SELECTOR_FALLBACKS[sectionType]) {
+    const candidate = Array.from(container.querySelectorAll(selector)).find(
+      (node) => node instanceof HTMLElement && isInChapter(node as HTMLElement)
+    ) as HTMLElement | undefined
 
-        if (candidate) {
-            if (!candidate.id) candidate.id = targetId;
-            return candidate;
-        }
+    if (candidate) {
+      if (!candidate.id) candidate.id = targetId
+      return candidate
     }
+  }
 
-    const headingRegex = SECTION_TEXT_FALLBACKS[sectionType];
-    const heading = Array.from(container.querySelectorAll('h2, h3, h4, p, strong'))
-        .find((node) =>
-            node instanceof HTMLElement
-            && isInChapter(node as HTMLElement)
-            && headingRegex.test((node.textContent || '').trim())
-        ) as HTMLElement | undefined;
+  const headingRegex = SECTION_TEXT_FALLBACKS[sectionType]
+  const heading = Array.from(
+    container.querySelectorAll('h2, h3, h4, p, strong')
+  ).find(
+    (node) =>
+      node instanceof HTMLElement &&
+      isInChapter(node as HTMLElement) &&
+      headingRegex.test((node.textContent || '').trim())
+  ) as HTMLElement | undefined
 
-    if (!heading) return null;
+  if (!heading) return null
 
-    const sectionRoot = heading.closest('div, section, article, blockquote') as HTMLElement | null;
-    const resolved = sectionRoot || heading;
-    if (!resolved.id) resolved.id = targetId;
-    return resolved;
+  const sectionRoot = heading.closest(
+    'div, section, article, blockquote'
+  ) as HTMLElement | null
+  const resolved = sectionRoot || heading
+  if (!resolved.id) resolved.id = targetId
+  return resolved
 }
 
-const TERM_MARK_ATTR = 'data-text-query-highlight';
-const TERM_MARK_SELECTOR = `mark[${TERM_MARK_ATTR}="true"]`;
-const TERM_HIGHLIGHT_MAX_MATCHES = 250;
-const TERM_HIGHLIGHT_MIN_LENGTH = 2;
-const MANUAL_NAVIGATION_HIGHLIGHT_LOCK_MS = 900;
-const SKIP_HIGHLIGHT_TAGS = new Set(['SCRIPT', 'STYLE', 'MARK', 'NOSCRIPT', 'TEXTAREA']);
+const TERM_MARK_ATTR = 'data-text-query-highlight'
+const TERM_MARK_SELECTOR = `mark[${TERM_MARK_ATTR}="true"]`
+const TERM_HIGHLIGHT_MAX_MATCHES = 250
+const TERM_HIGHLIGHT_MIN_LENGTH = 2
+const MANUAL_NAVIGATION_HIGHLIGHT_LOCK_MS = 900
+const SKIP_HIGHLIGHT_TAGS = new Set([
+  'SCRIPT',
+  'STYLE',
+  'MARK',
+  'NOSCRIPT',
+  'TEXTAREA',
+])
 
 function escapeRegex(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 function unwrapQueryHighlights(container: HTMLElement) {
-    const marks = Array.from(container.querySelectorAll<HTMLElement>(TERM_MARK_SELECTOR));
-    marks.forEach(mark => {
-        const parent = mark.parentNode;
-        if (!parent) return;
-        parent.replaceChild(document.createTextNode(mark.textContent || ''), mark);
-        if (parent instanceof HTMLElement) {
-            parent.normalize();
-        }
-    });
+  const marks = Array.from(
+    container.querySelectorAll<HTMLElement>(TERM_MARK_SELECTOR)
+  )
+  marks.forEach((mark) => {
+    const parent = mark.parentNode
+    if (!parent) return
+    parent.replaceChild(document.createTextNode(mark.textContent || ''), mark)
+    if (parent instanceof HTMLElement) {
+      parent.normalize()
+    }
+  })
 }
 
-function collectHighlightableTextNodes(container: HTMLElement, matcher: RegExp): Text[] {
-    const textNodes: Text[] = [];
-    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
-        acceptNode: (node) => {
-            const value = node.nodeValue || '';
-            if (!value.trim()) return NodeFilter.FILTER_REJECT;
+function collectHighlightableTextNodes(
+  container: HTMLElement,
+  matcher: RegExp
+): Text[] {
+  const textNodes: Text[] = []
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
+    acceptNode: (node) => {
+      const value = node.nodeValue || ''
+      if (!value.trim()) return NodeFilter.FILTER_REJECT
 
-            const parentElement = (node as Text).parentElement;
-            if (!parentElement) return NodeFilter.FILTER_REJECT;
-            if (SKIP_HIGHLIGHT_TAGS.has(parentElement.tagName)) return NodeFilter.FILTER_REJECT;
-            if (parentElement.closest(TERM_MARK_SELECTOR)) return NodeFilter.FILTER_REJECT;
-            if (!matcher.test(value)) return NodeFilter.FILTER_REJECT;
+      const parentElement = (node as Text).parentElement
+      if (!parentElement) return NodeFilter.FILTER_REJECT
+      if (SKIP_HIGHLIGHT_TAGS.has(parentElement.tagName))
+        return NodeFilter.FILTER_REJECT
+      if (parentElement.closest(TERM_MARK_SELECTOR))
+        return NodeFilter.FILTER_REJECT
+      if (!matcher.test(value)) return NodeFilter.FILTER_REJECT
 
-            return NodeFilter.FILTER_ACCEPT;
-        },
-    });
+      return NodeFilter.FILTER_ACCEPT
+    },
+  })
 
-    let currentNode = walker.nextNode();
-    while (currentNode) {
-        textNodes.push(currentNode as Text);
-        currentNode = walker.nextNode();
-    }
+  let currentNode = walker.nextNode()
+  while (currentNode) {
+    textNodes.push(currentNode as Text)
+    currentNode = walker.nextNode()
+  }
 
-    return textNodes;
+  return textNodes
 }
 
 function buildHighlightedFragment(
-    parts: string[],
-    normalizedLowerTerm: string,
-    highlightedCount: number,
+  parts: string[],
+  normalizedLowerTerm: string,
+  highlightedCount: number
 ): { fragment: DocumentFragment; replaced: boolean; highlightedCount: number } {
-    const fragment = document.createDocumentFragment();
-    let replaced = false;
-    let nextCount = highlightedCount;
+  const fragment = document.createDocumentFragment()
+  let replaced = false
+  let nextCount = highlightedCount
 
-    for (const part of parts) {
-        if (!part) continue;
+  for (const part of parts) {
+    if (!part) continue
 
-        const canHighlight = nextCount < TERM_HIGHLIGHT_MAX_MATCHES
-            && part.toLowerCase() === normalizedLowerTerm;
-        if (!canHighlight) {
-            fragment.appendChild(document.createTextNode(part));
-            continue;
-        }
-
-        const mark = document.createElement('mark');
-        mark.setAttribute(TERM_MARK_ATTR, 'true');
-        mark.className = 'search-highlight search-highlight-partial';
-        mark.textContent = part;
-        fragment.appendChild(mark);
-        nextCount += 1;
-        replaced = true;
+    const canHighlight =
+      nextCount < TERM_HIGHLIGHT_MAX_MATCHES &&
+      part.toLowerCase() === normalizedLowerTerm
+    if (!canHighlight) {
+      fragment.appendChild(document.createTextNode(part))
+      continue
     }
 
-    return { fragment, replaced, highlightedCount: nextCount };
+    const mark = document.createElement('mark')
+    mark.setAttribute(TERM_MARK_ATTR, 'true')
+    mark.className = 'search-highlight search-highlight-partial'
+    mark.textContent = part
+    fragment.appendChild(mark)
+    nextCount += 1
+    replaced = true
+  }
+
+  return { fragment, replaced, highlightedCount: nextCount }
 }
 
-function highlightTermInContainer(container: HTMLElement, term: string): number {
-    const normalizedTerm = term.trim();
-    if (normalizedTerm.length < TERM_HIGHLIGHT_MIN_LENGTH) return 0;
+function highlightTermInContainer(
+  container: HTMLElement,
+  term: string
+): number {
+  const normalizedTerm = term.trim()
+  if (normalizedTerm.length < TERM_HIGHLIGHT_MIN_LENGTH) return 0
 
-    const matcher = new RegExp(escapeRegex(normalizedTerm), 'i');
-    const splitRegex = new RegExp(`(${escapeRegex(normalizedTerm)})`, 'gi');
-    const textNodes = collectHighlightableTextNodes(container, matcher);
+  const matcher = new RegExp(escapeRegex(normalizedTerm), 'i')
+  const splitRegex = new RegExp(`(${escapeRegex(normalizedTerm)})`, 'gi')
+  const textNodes = collectHighlightableTextNodes(container, matcher)
 
-    let highlightedCount = 0;
-    const normalizedLowerTerm = normalizedTerm.toLowerCase();
+  let highlightedCount = 0
+  const normalizedLowerTerm = normalizedTerm.toLowerCase()
 
-    for (const node of textNodes) {
-        if (highlightedCount >= TERM_HIGHLIGHT_MAX_MATCHES) break;
+  for (const node of textNodes) {
+    if (highlightedCount >= TERM_HIGHLIGHT_MAX_MATCHES) break
 
-        const text = node.nodeValue || '';
-        const parts = text.split(splitRegex);
-        if (parts.length < 3) continue;
+    const text = node.nodeValue || ''
+    const parts = text.split(splitRegex)
+    if (parts.length < 3) continue
 
-        const { fragment, replaced, highlightedCount: nextCount } = buildHighlightedFragment(
-            parts,
-            normalizedLowerTerm,
-            highlightedCount,
-        );
-        highlightedCount = nextCount;
+    const {
+      fragment,
+      replaced,
+      highlightedCount: nextCount,
+    } = buildHighlightedFragment(parts, normalizedLowerTerm, highlightedCount)
+    highlightedCount = nextCount
 
-        if (!replaced || !node.parentNode) continue;
-        node.parentNode.replaceChild(fragment, node);
-    }
+    if (!replaced || !node.parentNode) continue
+    node.parentNode.replaceChild(fragment, node)
+  }
 
-    return highlightedCount;
+  return highlightedCount
 }
 
 interface ResultData {
-    type?: 'text' | 'code';
-    markdown?: string;
-    ncm?: string;
-    query?: string;
-    results?: SearchResultItem[] | Record<string, any>;
-    resultados?: any; // Complex object passed to Sidebar
+  type?: 'text' | 'code'
+  markdown?: string
+  ncm?: string
+  query?: string
+  results?: SearchResultItem[] | Record<string, any>
+  resultados?: any // Complex object passed to Sidebar
 }
 
 interface ResultDisplayProps {
-    data: ResultData | null;
-    mobileMenuOpen: boolean;
-    onCloseMobileMenu: () => void;
-    onToggleMobileMenu?: () => void;
-    isActive: boolean;
-    tabId: string;
-    initialScrollTop?: number;
-    onPersistScroll?: (tabId: string, scrollTop: number) => void;
-    latestTextQuery?: string;
-    /** Flag indicando nova busca - ativa auto-scroll */
-    isNewSearch: boolean;
-    /** Callback para consumir flag após auto-scroll, recebendo opcionalmente o scroll final */
-    onConsumeNewSearch: (tabId: string, finalScrollTop?: number) => void;
-    /** Callback to notify parent when content is ready (for coordinated loading) */
-    onContentReady?: (tabId: string) => void;
-    onHydratedResults?: (tabId: string, results: Record<string, any>) => void;
+  data: ResultData | null
+  mobileMenuOpen: boolean
+  onCloseMobileMenu: () => void
+  onToggleMobileMenu?: () => void
+  isActive: boolean
+  tabId: string
+  initialScrollTop?: number
+  onPersistScroll?: (tabId: string, scrollTop: number) => void
+  latestTextQuery?: string
+  /** Flag indicando nova busca - ativa auto-scroll */
+  isNewSearch: boolean
+  /** Callback para consumir flag após auto-scroll, recebendo opcionalmente o scroll final */
+  onConsumeNewSearch: (tabId: string, finalScrollTop?: number) => void
+  /** Callback to notify parent when content is ready (for coordinated loading) */
+  onContentReady?: (tabId: string) => void
+  onHydratedResults?: (tabId: string, results: Record<string, any>) => void
 }
 
 type MarkupRenderRefs = {
-    contentRef: React.RefObject<HTMLDivElement | null>;
-    renderedMarkupKeyRef: React.MutableRefObject<string | null>;
-    lastMarkupRef: React.MutableRefObject<string | null>;
-    lastHtmlRef: React.MutableRefObject<string | null>;
-};
+  contentRef: React.RefObject<HTMLDivElement | null>
+  renderedMarkupKeyRef: React.MutableRefObject<string | null>
+  lastMarkupRef: React.MutableRefObject<string | null>
+  lastHtmlRef: React.MutableRefObject<string | null>
+}
 
 type MarkupRenderOptions = {
-    rawMarkdown: string;
-    markupToRender: string;
-    isActive: boolean;
-    isContentReady: boolean;
-    refs: MarkupRenderRefs;
-    setIsContentReady: React.Dispatch<React.SetStateAction<boolean>>;
-    setIsFullyRendered: React.Dispatch<React.SetStateAction<boolean>>;
-};
+  rawMarkdown: string
+  markupToRender: string
+  isActive: boolean
+  isContentReady: boolean
+  refs: MarkupRenderRefs
+  setIsContentReady: React.Dispatch<React.SetStateAction<boolean>>
+  setIsFullyRendered: React.Dispatch<React.SetStateAction<boolean>>
+}
 
-const SECTION_TYPES: ChapterSectionType[] = ['titulo', 'notas', 'consideracoes', 'definicoes'];
-const CHUNK_SIZE_THRESHOLD = 50_000;
+const SECTION_TYPES: ChapterSectionType[] = [
+  'titulo',
+  'notas',
+  'consideracoes',
+  'definicoes',
+]
+const CHUNK_SIZE_THRESHOLD = 50_000
 
 function scheduleIdleTask(callback: () => void): number {
-    if (typeof requestIdleCallback === 'function') {
-        return requestIdleCallback(callback, { timeout: 100 });
-    }
-    return setTimeout(callback, 16) as unknown as number;
+  if (typeof requestIdleCallback === 'function') {
+    return requestIdleCallback(callback, { timeout: 100 })
+  }
+  return setTimeout(callback, 16) as unknown as number
 }
 
 function cancelIdleTask(taskId: number) {
-    if (typeof cancelIdleCallback === 'function') {
-        cancelIdleCallback(taskId);
-        return;
-    }
-    clearTimeout(taskId);
+  if (typeof cancelIdleCallback === 'function') {
+    cancelIdleCallback(taskId)
+    return
+  }
+  clearTimeout(taskId)
 }
 
 function appendMarkupChunk(container: HTMLElement, htmlChunk: string) {
-    appendTrustedHtmlToElement(container, htmlChunk);
+  appendTrustedHtmlToElement(container, htmlChunk)
 }
 
 function normalizeDigits(value: string): string {
-    return value.replace(/\D/g, '');
+  return value.replace(/\D/g, '')
 }
 
 function buildAnchorCandidatesFromDigits(digits: string): string[] {
-    if (digits.length < 4) return [];
+  if (digits.length < 4) return []
 
-    const head4 = digits.slice(0, 4);
-    const candidates = [`pos-${head4.slice(0, 2)}-${head4.slice(2)}`, `pos-${head4}`];
-    if (digits.length >= 6) {
-        candidates.push(`pos-${digits.slice(0, 4)}-${digits.slice(4, 6)}`);
-    }
-    if (digits.length >= 8) {
-        candidates.push(`pos-${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`);
-    }
-    return candidates;
+  const head4 = digits.slice(0, 4)
+  const candidates = [
+    `pos-${head4.slice(0, 2)}-${head4.slice(2)}`,
+    `pos-${head4}`,
+  ]
+  if (digits.length >= 6) {
+    candidates.push(`pos-${digits.slice(0, 4)}-${digits.slice(4, 6)}`)
+  }
+  if (digits.length >= 8) {
+    candidates.push(
+      `pos-${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`
+    )
+  }
+  return candidates
 }
 
 function resolveNcmToScroll(data: ResultData | null): string | null {
-    if (!data) return null;
-    return data.ncm || data.query || null;
+  if (!data) return null
+  return data.ncm || data.query || null
 }
 
 function resolveMarkupToRender(
-    rawMarkdown: string,
-    codeResults: Record<string, any> | null,
+  rawMarkdown: string,
+  codeResults: Record<string, any> | null
 ): string {
-    if (rawMarkdown) return rawMarkdown;
-    if (!codeResults) return '';
-    if (isTipiResults(codeResults)) {
-        return renderTipiFallback(codeResults);
-    }
+  if (rawMarkdown) return rawMarkdown
+  if (!codeResults) return ''
+  if (isTipiResults(codeResults)) {
+    return renderTipiFallback(codeResults)
+  }
 
-    console.warn('[ResultDisplay] Fallback NeshRenderer used - backend should send markdown');
-    return NeshRenderer.renderFullResponse(codeResults);
+  console.warn(
+    '[ResultDisplay] Fallback NeshRenderer used - backend should send markdown'
+  )
+  return NeshRenderer.renderFullResponse(codeResults)
 }
 
 function chapterHasRenderableContent(chapter: any): boolean {
-    const content = chapter?.conteudo;
-    return typeof content === 'string' && content.trim().length > 0;
+  const content = chapter?.conteudo
+  return typeof content === 'string' && content.trim().length > 0
 }
 
 function getSectionContent(sectionValue: unknown): string {
-    if (typeof sectionValue === 'string') {
-        return sectionValue.trim();
-    }
-    if (typeof sectionValue === 'number') {
-        return String(sectionValue).trim();
-    }
-    return '';
+  if (typeof sectionValue === 'string') {
+    return sectionValue.trim()
+  }
+  if (typeof sectionValue === 'number') {
+    return String(sectionValue).trim()
+  }
+  return ''
 }
 
 function getAnchorCodeFromNcmValue(value: string): string {
-    if (value.includes('.') || value.length !== 4) {
-        return value;
-    }
-    return `${value.slice(0, 2)}.${value.slice(2, 4)}`;
+  if (value.includes('.') || value.length !== 4) {
+    return value
+  }
+  return `${value.slice(0, 2)}.${value.slice(2, 4)}`
 }
 
 function resolveChapterResultKey(
-    results: Record<string, any>,
-    chapterNumber: string,
+  results: Record<string, any>,
+  chapterNumber: string
 ): string {
-    return Object.keys(results).find((key) => {
-        const existingChapter = results[key];
-        return existingChapter?.capitulo === chapterNumber;
-    }) ?? chapterNumber;
+  return (
+    Object.keys(results).find((key) => {
+      const existingChapter = results[key]
+      return existingChapter?.capitulo === chapterNumber
+    }) ?? chapterNumber
+  )
 }
 
 function mergeHydratedChapterBodies(
-    baseResults: Record<string, any>,
-    chapterBodies: ChapterBodyResponse[],
+  baseResults: Record<string, any>,
+  chapterBodies: ChapterBodyResponse[]
 ): Record<string, any> {
-    const nextResults = { ...baseResults };
+  const nextResults = { ...baseResults }
 
-    for (const chapterBody of chapterBodies) {
-        const chapterKey = resolveChapterResultKey(nextResults, chapterBody.capitulo);
-        const existingChapter = nextResults[chapterKey];
-        if (!existingChapter || typeof existingChapter !== 'object') {
-            continue;
-        }
-
-        nextResults[chapterKey] = {
-            ...existingChapter,
-            conteudo: chapterBody.conteudo,
-            notas_parseadas: chapterBody.notas_parseadas ?? existingChapter.notas_parseadas ?? {},
-            notas_gerais: chapterBody.notas_gerais ?? existingChapter.notas_gerais ?? null,
-            secoes: chapterBody.secoes ?? existingChapter.secoes,
-        };
+  for (const chapterBody of chapterBodies) {
+    const chapterKey = resolveChapterResultKey(
+      nextResults,
+      chapterBody.capitulo
+    )
+    const existingChapter = nextResults[chapterKey]
+    if (!existingChapter || typeof existingChapter !== 'object') {
+      continue
     }
 
-    return nextResults;
+    nextResults[chapterKey] = {
+      ...existingChapter,
+      conteudo: chapterBody.conteudo,
+      notas_parseadas:
+        chapterBody.notas_parseadas ?? existingChapter.notas_parseadas ?? {},
+      notas_gerais:
+        chapterBody.notas_gerais ?? existingChapter.notas_gerais ?? null,
+      secoes: chapterBody.secoes ?? existingChapter.secoes,
+    }
+  }
+
+  return nextResults
 }
 
 type ChapterHydrationResult = {
-    chapterBodies: ChapterBodyResponse[];
-    failedChapters: string[];
-};
+  chapterBodies: ChapterBodyResponse[]
+  failedChapters: string[]
+}
 
 function createFailedChapterBodiesUpdater(failedChapters: string[]) {
-    return (current: string[]) => Array.from(new Set([...current, ...failedChapters]));
+  return (current: string[]) =>
+    Array.from(new Set([...current, ...failedChapters]))
 }
 
-function createRecoveredChapterBodiesUpdater(chapterBodies: ChapterBodyResponse[]) {
-    const recoveredChapters = new Set(chapterBodies.map((body) => body.capitulo));
-    return (current: string[]) => current.filter((chapter) => !recoveredChapters.has(chapter));
+function createRecoveredChapterBodiesUpdater(
+  chapterBodies: ChapterBodyResponse[]
+) {
+  const recoveredChapters = new Set(chapterBodies.map((body) => body.capitulo))
+  return (current: string[]) =>
+    current.filter((chapter) => !recoveredChapters.has(chapter))
 }
 
-async function fetchChapterBodies(chapters: string[]): Promise<ChapterHydrationResult> {
-    const settledBodies = await Promise.allSettled(
-        chapters.map((chapter) => getNeshChapterBody(chapter)),
-    );
-    const fulfilledBodies: ChapterBodyResponse[] = [];
-    const failedChapters: string[] = [];
+async function fetchChapterBodies(
+  chapters: string[]
+): Promise<ChapterHydrationResult> {
+  const settledBodies = await Promise.allSettled(
+    chapters.map((chapter) => getNeshChapterBody(chapter))
+  )
+  const fulfilledBodies: ChapterBodyResponse[] = []
+  const failedChapters: string[] = []
 
-    settledBodies.forEach((result, index) => {
-        if (result.status === 'fulfilled') {
-            fulfilledBodies.push(result.value);
-            return;
-        }
+  settledBodies.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      fulfilledBodies.push(result.value)
+      return
+    }
 
-        failedChapters.push(chapters[index]);
-        console.error('[ResultDisplay] Failed to fetch chapter body', {
-            chapter: chapters[index],
-            error: result.reason,
-        });
-    });
+    failedChapters.push(chapters[index])
+    console.error('[ResultDisplay] Failed to fetch chapter body', {
+      chapter: chapters[index],
+      error: result.reason,
+    })
+  })
 
-    return {
-        chapterBodies: fulfilledBodies,
-        failedChapters,
-    };
+  return {
+    chapterBodies: fulfilledBodies,
+    failedChapters,
+  }
 }
 
 function getCachedRawMarkup(
-    cacheKey: string,
-    shouldParseMarkdown: boolean,
-    markupToRender: string,
-    lastMarkupRef: React.MutableRefObject<string | null>,
-    lastHtmlRef: React.MutableRefObject<string | null>,
+  cacheKey: string,
+  shouldParseMarkdown: boolean,
+  markupToRender: string,
+  lastMarkupRef: React.MutableRefObject<string | null>,
+  lastHtmlRef: React.MutableRefObject<string | null>
 ): string {
-    const cachedRawMarkup = cacheGet(sharedRawMarkupCache, cacheKey);
-    if (cachedRawMarkup) return cachedRawMarkup;
+  const cachedRawMarkup = cacheGet(sharedRawMarkupCache, cacheKey)
+  if (cachedRawMarkup) return cachedRawMarkup
 
-    const reusableMarkup = lastMarkupRef.current === cacheKey ? lastHtmlRef.current : null;
-    if (reusableMarkup) {
-        cacheSet(sharedRawMarkupCache, cacheKey, reusableMarkup);
-        return reusableMarkup;
-    }
+  const reusableMarkup =
+    lastMarkupRef.current === cacheKey ? lastHtmlRef.current : null
+  if (reusableMarkup) {
+    cacheSet(sharedRawMarkupCache, cacheKey, reusableMarkup)
+    return reusableMarkup
+  }
 
-    let nextRawMarkup = markupToRender;
-    if (shouldParseMarkdown) {
-        // @ts-ignore - marked types might mismatch slightly depending on version
-        nextRawMarkup = marked.parse(markupToRender) as string;
-    }
+  let nextRawMarkup = markupToRender
+  if (shouldParseMarkdown) {
+    // @ts-ignore - marked types might mismatch slightly depending on version
+    nextRawMarkup = marked.parse(markupToRender) as string
+  }
 
-    cacheSet(sharedRawMarkupCache, cacheKey, nextRawMarkup);
-    return nextRawMarkup;
+  cacheSet(sharedRawMarkupCache, cacheKey, nextRawMarkup)
+  return nextRawMarkup
 }
 
 function getFinalMarkup(rawMarkup: string, cacheKey: string): string {
-    const cachedSanitizedMarkup = cacheGet(sharedSanitizedMarkupCache, cacheKey);
-    if (cachedSanitizedMarkup) return cachedSanitizedMarkup;
+  const cachedSanitizedMarkup = cacheGet(sharedSanitizedMarkupCache, cacheKey)
+  if (cachedSanitizedMarkup) return cachedSanitizedMarkup
 
-    const sanitizedMarkup = sanitizeRichHtml(rawMarkup);
-    cacheSet(sharedSanitizedMarkupCache, cacheKey, sanitizedMarkup);
-    return sanitizedMarkup;
+  const sanitizedMarkup = sanitizeRichHtml(rawMarkup)
+  cacheSet(sharedSanitizedMarkupCache, cacheKey, sanitizedMarkup)
+  return sanitizedMarkup
 }
 
 function renderSmallMarkup(
-    contentRef: React.RefObject<HTMLDivElement | null>,
-    finalMarkup: string,
-    cacheKey: string,
-    renderedMarkupKeyRef: React.MutableRefObject<string | null>,
-    setIsContentReady: React.Dispatch<React.SetStateAction<boolean>>,
-    setIsFullyRendered: React.Dispatch<React.SetStateAction<boolean>>,
+  contentRef: React.RefObject<HTMLDivElement | null>,
+  finalMarkup: string,
+  cacheKey: string,
+  renderedMarkupKeyRef: React.MutableRefObject<string | null>,
+  setIsContentReady: React.Dispatch<React.SetStateAction<boolean>>,
+  setIsFullyRendered: React.Dispatch<React.SetStateAction<boolean>>
 ): () => void {
-    const frameId = requestAnimationFrame(() => {
-        if (!contentRef.current) return;
-        replaceElementWithTrustedHtml(contentRef.current, finalMarkup);
-        renderedMarkupKeyRef.current = cacheKey;
-        setIsContentReady(true);
-        setIsFullyRendered(true);
-    });
+  const frameId = requestAnimationFrame(() => {
+    if (!contentRef.current) return
+    replaceElementWithTrustedHtml(contentRef.current, finalMarkup)
+    renderedMarkupKeyRef.current = cacheKey
+    setIsContentReady(true)
+    setIsFullyRendered(true)
+  })
 
-    return () => cancelAnimationFrame(frameId);
+  return () => cancelAnimationFrame(frameId)
 }
 
 function renderChunkedMarkup(
-    contentRef: React.RefObject<HTMLDivElement | null>,
-    finalMarkup: string,
-    cacheKey: string,
-    renderedMarkupKeyRef: React.MutableRefObject<string | null>,
-    setIsContentReady: React.Dispatch<React.SetStateAction<boolean>>,
-    setIsFullyRendered: React.Dispatch<React.SetStateAction<boolean>>,
+  contentRef: React.RefObject<HTMLDivElement | null>,
+  finalMarkup: string,
+  cacheKey: string,
+  renderedMarkupKeyRef: React.MutableRefObject<string | null>,
+  setIsContentReady: React.Dispatch<React.SetStateAction<boolean>>,
+  setIsFullyRendered: React.Dispatch<React.SetStateAction<boolean>>
 ): () => void {
-    const chunks = finalMarkup.split(/(?=<hr\s*\/?>)/i);
-    const pendingIdleIds: number[] = [];
-    let cancelled = false;
+  const chunks = finalMarkup.split(/(?=<hr\s*\/?>)/i)
+  const pendingIdleIds: number[] = []
+  let cancelled = false
 
-    const frameId = requestAnimationFrame(() => {
-        if (cancelled || !contentRef.current) return;
+  const frameId = requestAnimationFrame(() => {
+    if (cancelled || !contentRef.current) return
 
-        contentRef.current.textContent = '';
-        if (chunks.length > 0) {
-            appendMarkupChunk(contentRef.current, chunks[0]);
-        }
+    contentRef.current.textContent = ''
+    if (chunks.length > 0) {
+      appendMarkupChunk(contentRef.current, chunks[0])
+    }
 
-        // Marca o conteúdo como pronto após o primeiro chunk para liberar auto-scroll cedo.
-        renderedMarkupKeyRef.current = cacheKey;
-        setIsContentReady(true);
+    // Marca o conteúdo como pronto após o primeiro chunk para liberar auto-scroll cedo.
+    renderedMarkupKeyRef.current = cacheKey
+    setIsContentReady(true)
 
-        const enqueueChunk = (index: number) => {
-            if (index >= chunks.length) {
-                setIsFullyRendered(true);
-                return;
-            }
+    const enqueueChunk = (index: number) => {
+      if (index >= chunks.length) {
+        setIsFullyRendered(true)
+        return
+      }
 
-            const idleId = scheduleIdleTask(() => {
-                if (cancelled || !contentRef.current) return;
-                appendMarkupChunk(contentRef.current, chunks[index]);
-                enqueueChunk(index + 1);
-            });
-            pendingIdleIds.push(idleId);
-        };
+      const idleId = scheduleIdleTask(() => {
+        if (cancelled || !contentRef.current) return
+        appendMarkupChunk(contentRef.current, chunks[index])
+        enqueueChunk(index + 1)
+      })
+      pendingIdleIds.push(idleId)
+    }
 
-        enqueueChunk(1);
-    });
+    enqueueChunk(1)
+  })
 
-    return () => {
-        cancelled = true;
-        cancelAnimationFrame(frameId);
-        pendingIdleIds.forEach(cancelIdleTask);
-    };
+  return () => {
+    cancelled = true
+    cancelAnimationFrame(frameId)
+    pendingIdleIds.forEach(cancelIdleTask)
+  }
 }
 
-function renderMarkupContent(options: MarkupRenderOptions): (() => void) | undefined {
-    const { rawMarkdown, markupToRender, isActive, isContentReady, refs, setIsContentReady, setIsFullyRendered } = options;
-    const container = refs.contentRef.current;
-    if (!container) return undefined;
+function renderMarkupContent(
+  options: MarkupRenderOptions
+): (() => void) | undefined {
+  const {
+    rawMarkdown,
+    markupToRender,
+    isActive,
+    isContentReady,
+    refs,
+    setIsContentReady,
+    setIsFullyRendered,
+  } = options
+  const container = refs.contentRef.current
+  if (!container) return undefined
 
-    const shouldParseMarkdown = !!rawMarkdown && isLikelyLegacyMarkdown(markupToRender);
-    const cacheKey = `${shouldParseMarkdown ? 'md' : 'html'}:${markupToRender}`;
+  const shouldParseMarkdown =
+    !!rawMarkdown && isLikelyLegacyMarkdown(markupToRender)
+  const cacheKey = `${shouldParseMarkdown ? 'md' : 'html'}:${markupToRender}`
 
-    // Aba inativa: preservar o DOM existente para restauração de scroll.
-    // TabPanel já esconde com display:none; não precisa limpar.
-    if (!isActive) {
-        return undefined;
-    }
+  // Aba inativa: preservar o DOM existente para restauração de scroll.
+  // TabPanel já esconde com display:none; não precisa limpar.
+  if (!isActive) {
+    return undefined
+  }
 
-    const isAlreadyRendered = refs.renderedMarkupKeyRef.current === cacheKey && container.childNodes.length > 0;
-    if (isAlreadyRendered) {
-        if (!isContentReady) setIsContentReady(true);
-        setIsFullyRendered(true);
-        return undefined;
-    }
+  const isAlreadyRendered =
+    refs.renderedMarkupKeyRef.current === cacheKey &&
+    container.childNodes.length > 0
+  if (isAlreadyRendered) {
+    if (!isContentReady) setIsContentReady(true)
+    setIsFullyRendered(true)
+    return undefined
+  }
 
-    setIsContentReady(false);
-    setIsFullyRendered(false);
-    const rawMarkup = getCachedRawMarkup(
-        cacheKey,
-        shouldParseMarkdown,
-        markupToRender,
-        refs.lastMarkupRef,
-        refs.lastHtmlRef,
-    );
-    refs.lastMarkupRef.current = cacheKey;
-    refs.lastHtmlRef.current = rawMarkup;
+  setIsContentReady(false)
+  setIsFullyRendered(false)
+  const rawMarkup = getCachedRawMarkup(
+    cacheKey,
+    shouldParseMarkdown,
+    markupToRender,
+    refs.lastMarkupRef,
+    refs.lastHtmlRef
+  )
+  refs.lastMarkupRef.current = cacheKey
+  refs.lastHtmlRef.current = rawMarkup
 
-    const finalMarkup = getFinalMarkup(rawMarkup, cacheKey);
-    if (finalMarkup.length <= CHUNK_SIZE_THRESHOLD) {
-        return renderSmallMarkup(refs.contentRef, finalMarkup, cacheKey, refs.renderedMarkupKeyRef, setIsContentReady, setIsFullyRendered);
-    }
+  const finalMarkup = getFinalMarkup(rawMarkup, cacheKey)
+  if (finalMarkup.length <= CHUNK_SIZE_THRESHOLD) {
+    return renderSmallMarkup(
+      refs.contentRef,
+      finalMarkup,
+      cacheKey,
+      refs.renderedMarkupKeyRef,
+      setIsContentReady,
+      setIsFullyRendered
+    )
+  }
 
-    return renderChunkedMarkup(refs.contentRef, finalMarkup, cacheKey, refs.renderedMarkupKeyRef, setIsContentReady, setIsFullyRendered);
+  return renderChunkedMarkup(
+    refs.contentRef,
+    finalMarkup,
+    cacheKey,
+    refs.renderedMarkupKeyRef,
+    setIsContentReady,
+    setIsFullyRendered
+  )
 }
 
 function getWrapperClasses(
-    stylesMap: typeof styles,
-    sidebarCollapsed: boolean,
-    mobileMenuOpen: boolean,
-    sidebarPosition: 'left' | 'right',
+  stylesMap: typeof styles,
+  sidebarCollapsed: boolean,
+  mobileMenuOpen: boolean,
+  sidebarPosition: 'left' | 'right'
 ): string {
-    return [
-        stylesMap.wrapper,
-        sidebarCollapsed ? stylesMap.sidebarCollapsed : '',
-        mobileMenuOpen ? stylesMap.sidebarOpen : '',
-        sidebarPosition === 'left' ? stylesMap.sidebarLeft : '',
-    ].filter(Boolean).join(' ');
+  return [
+    stylesMap.wrapper,
+    sidebarCollapsed ? stylesMap.sidebarCollapsed : '',
+    mobileMenuOpen ? stylesMap.sidebarOpen : '',
+    sidebarPosition === 'left' ? stylesMap.sidebarLeft : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
 }
 
-function getSidebarToggleIcon(sidebarPosition: 'left' | 'right', sidebarCollapsed: boolean): string {
-    if (sidebarPosition === 'left') {
-        return sidebarCollapsed ? '▶' : '◀';
-    }
-    return sidebarCollapsed ? '◀' : '▶';
+function getSidebarToggleIcon(
+  sidebarPosition: 'left' | 'right',
+  sidebarCollapsed: boolean
+): string {
+  if (sidebarPosition === 'left') {
+    return sidebarCollapsed ? '▶' : '◀'
+  }
+  return sidebarCollapsed ? '◀' : '▶'
 }
 
 function getSidebarToggleLabel(sidebarCollapsed: boolean): string {
-    return sidebarCollapsed ? 'Expandir navegação' : 'Recolher navegação';
+  return sidebarCollapsed ? 'Expandir navegação' : 'Recolher navegação'
 }
 
-function getContentVisibilityClass(stylesMap: typeof styles, isContentReady: boolean): string {
-    return isContentReady ? stylesMap.contentVisible : stylesMap.contentHidden;
+function getContentVisibilityClass(
+  stylesMap: typeof styles,
+  isContentReady: boolean
+): string {
+  return isContentReady ? stylesMap.contentVisible : stylesMap.contentHidden
 }
 
-function getCommentToggleClassName(stylesMap: typeof styles, commentsEnabled: boolean): string {
-    if (!commentsEnabled) return stylesMap.commentToggle;
-    return `${stylesMap.commentToggle} ${stylesMap.commentToggleActive}`;
+function getCommentToggleClassName(
+  stylesMap: typeof styles,
+  commentsEnabled: boolean
+): string {
+  if (!commentsEnabled) return stylesMap.commentToggle
+  return `${stylesMap.commentToggle} ${stylesMap.commentToggleActive}`
 }
 
 function getCommentToggleLabel(commentsEnabled: boolean): string {
-    return commentsEnabled ? 'Desativar comentários' : 'Ativar comentários';
+  return commentsEnabled ? 'Desativar comentários' : 'Ativar comentários'
 }
 
 function findAnchorIdInChapter(
-    chapter: any,
-    normalizedQuery: string,
-    existingPrefix: string | null,
+  chapter: any,
+  normalizedQuery: string,
+  existingPrefix: string | null
 ): { exactMatch: string | null; prefixMatch: string | null } {
-    const positions = Array.isArray(chapter?.posicoes) ? chapter.posicoes : [];
-    let prefixMatch = existingPrefix;
+  const positions = Array.isArray(chapter?.posicoes) ? chapter.posicoes : []
+  let prefixMatch = existingPrefix
 
-    for (const pos of positions) {
-        const codigo = (pos?.codigo || pos?.ncm || '').toString();
-        if (!codigo) continue;
+  for (const pos of positions) {
+    const codigo = (pos?.codigo || pos?.ncm || '').toString()
+    if (!codigo) continue
 
-        const normalizedCodigo = normalizeDigits(codigo);
-        if (normalizedCodigo === normalizedQuery) {
-            return {
-                exactMatch: pos?.anchor_id || generateAnchorId(codigo),
-                prefixMatch,
-            };
-        }
-
-        if (!prefixMatch && normalizedCodigo.startsWith(normalizedQuery)) {
-            prefixMatch = pos?.anchor_id || generateAnchorId(codigo);
-        }
+    const normalizedCodigo = normalizeDigits(codigo)
+    if (normalizedCodigo === normalizedQuery) {
+      return {
+        exactMatch: pos?.anchor_id || generateAnchorId(codigo),
+        prefixMatch,
+      }
     }
 
-    return { exactMatch: null, prefixMatch };
+    if (!prefixMatch && normalizedCodigo.startsWith(normalizedQuery)) {
+      prefixMatch = pos?.anchor_id || generateAnchorId(codigo)
+    }
+  }
+
+  return { exactMatch: null, prefixMatch }
 }
 
-function getStructuredSectionIds(capitulo: string, secoes: Record<string, unknown>): string[] {
-    const ids: string[] = [];
-    for (const sectionType of SECTION_TYPES) {
-        const sectionValue = secoes[sectionType];
-        const sectionContent = getSectionContent(sectionValue);
-        if (!sectionContent) continue;
-        ids.push(`chapter-${capitulo}-${sectionType}`);
-    }
-    return ids;
+function getStructuredSectionIds(
+  capitulo: string,
+  secoes: Record<string, unknown>
+): string[] {
+  const ids: string[] = []
+  for (const sectionType of SECTION_TYPES) {
+    const sectionValue = secoes[sectionType]
+    const sectionContent = getSectionContent(sectionValue)
+    if (!sectionContent) continue
+    ids.push(`chapter-${capitulo}-${sectionType}`)
+  }
+  return ids
 }
 
 function resolveAutoScrollCandidates(
-    ncmToScroll: string,
-    codeResults: Record<string, any> | null,
-    findAnchorIdForQuery: (resultados: any, query: string) => string | null,
-    getPosicaoAlvoFromResultados: (resultados: any) => string | null,
+  ncmToScroll: string,
+  codeResults: Record<string, any> | null,
+  findAnchorIdForQuery: (resultados: any, query: string) => string | null,
+  getPosicaoAlvoFromResultados: (resultados: any) => string | null
 ): string[] {
-    const posicaoAlvo = codeResults ? getPosicaoAlvoFromResultados(codeResults) : null;
-    const anchorFromResultados = codeResults ? findAnchorIdForQuery(codeResults, ncmToScroll) : null;
-    const exactId = anchorFromResultados
-        || (posicaoAlvo ? generateAnchorId(posicaoAlvo) : null)
-        || generateAnchorId(ncmToScroll);
+  const posicaoAlvo = codeResults
+    ? getPosicaoAlvoFromResultados(codeResults)
+    : null
+  const anchorFromResultados = codeResults
+    ? findAnchorIdForQuery(codeResults, ncmToScroll)
+    : null
+  const exactId =
+    anchorFromResultados ||
+    (posicaoAlvo ? generateAnchorId(posicaoAlvo) : null) ||
+    generateAnchorId(ncmToScroll)
 
-    const candidates = [exactId];
-    candidates.push(...buildAnchorCandidatesFromDigits(normalizeDigits(ncmToScroll)));
-    return Array.from(new Set(candidates));
+  const candidates = [exactId]
+  candidates.push(
+    ...buildAnchorCandidatesFromDigits(normalizeDigits(ncmToScroll))
+  )
+  return Array.from(new Set(candidates))
 }
 
-function findExistingTargetElement(container: HTMLElement, targets: string[]): HTMLElement | null {
-    for (const id of targets) {
-        const element = container.querySelector(`#${CSS.escape(id)}`) as HTMLElement | null;
-        if (element) return element;
-    }
-    return null;
+function findExistingTargetElement(
+  container: HTMLElement,
+  targets: string[]
+): HTMLElement | null {
+  for (const id of targets) {
+    const element = container.querySelector(
+      `#${CSS.escape(id)}`
+    ) as HTMLElement | null
+    if (element) return element
+  }
+  return null
 }
 
 function buildDataNcmTargetValues(candidateNcm: string): string[] {
-    const normalized = normalizeDigits(candidateNcm);
-    if (!normalized) return [];
+  const normalized = normalizeDigits(candidateNcm)
+  if (!normalized) return []
 
-    const values = new Set<string>([normalized]);
-    if (normalized.length >= 6) {
-        values.add(`${normalized.slice(0, 4)}.${normalized.slice(4, 6)}`);
-    }
-    if (normalized.length >= 8) {
-        values.add(`${normalized.slice(0, 4)}.${normalized.slice(4, 6)}.${normalized.slice(6, 8)}`);
-    }
-    if (normalized.length >= 4) {
-        const positionDigits = normalized.slice(0, 4);
-        values.add(positionDigits);
-        values.add(`${positionDigits.slice(0, 2)}.${positionDigits.slice(2, 4)}`);
-    }
+  const values = new Set<string>([normalized])
+  if (normalized.length >= 6) {
+    values.add(`${normalized.slice(0, 4)}.${normalized.slice(4, 6)}`)
+  }
+  if (normalized.length >= 8) {
+    values.add(
+      `${normalized.slice(0, 4)}.${normalized.slice(4, 6)}.${normalized.slice(6, 8)}`
+    )
+  }
+  if (normalized.length >= 4) {
+    const positionDigits = normalized.slice(0, 4)
+    values.add(positionDigits)
+    values.add(`${positionDigits.slice(0, 2)}.${positionDigits.slice(2, 4)}`)
+  }
 
-    return Array.from(values);
+  return Array.from(values)
 }
 
 function ensureTargetAnchorFromDataNcm(
-    container: HTMLElement,
-    candidateNcm: string | null | undefined,
+  container: HTMLElement,
+  candidateNcm: string | null | undefined
 ): HTMLElement | null {
-    for (const value of buildDataNcmTargetValues(candidateNcm || '')) {
-        const element = container.querySelector(`[data-ncm="${value}"]`) as HTMLElement | null;
-        if (!element) continue;
+  for (const value of buildDataNcmTargetValues(candidateNcm || '')) {
+    const element = container.querySelector(
+      `[data-ncm="${value}"]`
+    ) as HTMLElement | null
+    if (!element) continue
 
-        const anchorCode = getAnchorCodeFromNcmValue(value);
-        if (!element.id) {
-            element.id = generateAnchorId(anchorCode);
-        }
-        return element;
+    const anchorCode = getAnchorCodeFromNcmValue(value)
+    if (!element.id) {
+      element.id = generateAnchorId(anchorCode)
     }
+    return element
+  }
 
-    return null;
+  return null
 }
 
-function getNextVisibleAnchorId(entries: IntersectionObserverEntry[]): string | null {
-    const visible = entries
-        .filter(entry => entry.isIntersecting)
-        .sort((left, right) => left.boundingClientRect.top - right.boundingClientRect.top);
-    return visible[0]?.target?.id || null;
+function getNextVisibleAnchorId(
+  entries: IntersectionObserverEntry[]
+): string | null {
+  const visible = entries
+    .filter((entry) => entry.isIntersecting)
+    .sort(
+      (left, right) =>
+        left.boundingClientRect.top - right.boundingClientRect.top
+    )
+  return visible[0]?.target?.id || null
 }
 
 function scheduleActiveAnchorUpdate(
-    nextAnchorId: string,
-    activeAnchorIdRef: React.MutableRefObject<string | null>,
-    anchorRafRef: React.MutableRefObject<number | null>,
-    setActiveAnchorId: React.Dispatch<React.SetStateAction<string | null>>,
+  nextAnchorId: string,
+  activeAnchorIdRef: React.MutableRefObject<string | null>,
+  anchorRafRef: React.MutableRefObject<number | null>,
+  setActiveAnchorId: React.Dispatch<React.SetStateAction<string | null>>
 ) {
-    if (nextAnchorId === activeAnchorIdRef.current) return;
+  if (nextAnchorId === activeAnchorIdRef.current) return
 
-    if (anchorRafRef.current !== null) {
-        cancelAnimationFrame(anchorRafRef.current);
-    }
+  if (anchorRafRef.current !== null) {
+    cancelAnimationFrame(anchorRafRef.current)
+  }
 
-    anchorRafRef.current = requestAnimationFrame(() => {
-        anchorRafRef.current = null;
-        setActiveAnchorId(prev => (prev === nextAnchorId ? prev : nextAnchorId));
-    });
+  anchorRafRef.current = requestAnimationFrame(() => {
+    anchorRafRef.current = null
+    setActiveAnchorId((prev) => (prev === nextAnchorId ? prev : nextAnchorId))
+  })
 }
 
 export const ResultDisplay = React.memo(function ResultDisplay({
-    data,
-    mobileMenuOpen,
-    onCloseMobileMenu,
-    onToggleMobileMenu,
-    isActive,
-    tabId,
-    initialScrollTop,
-    onPersistScroll,
-    latestTextQuery,
-    isNewSearch,
-    onConsumeNewSearch,
-    onContentReady,
-    onHydratedResults
+  data,
+  mobileMenuOpen,
+  onCloseMobileMenu,
+  onToggleMobileMenu,
+  isActive,
+  tabId,
+  initialScrollTop,
+  onPersistScroll,
+  latestTextQuery,
+  isNewSearch,
+  onConsumeNewSearch,
+  onContentReady,
+  onHydratedResults,
 }: ResultDisplayProps) {
-    const { sidebarPosition } = useSettings();
-    const {
-        userName,
-        userImageUrl,
-        isSignedIn,
-        isLoading: isAuthLoading,
-        userId,
-        canUseRestrictedUi,
-    } = useAuth();
-    const containerRef = useRef<HTMLDivElement>(null);
-    const latestScrollTopRef = useRef(initialScrollTop ?? 0);
-    const hasScrollSnapshotRef = useRef(typeof initialScrollTop === 'number');
-    const lastPersistedScrollRef = useRef<number | null>(null);
-    const [isContentReady, setIsContentReady] = useState(false);
-    const [isFullyRendered, setIsFullyRendered] = useState(false);
-    const [isTargetReady, setIsTargetReady] = useState(false);
-    const [activeTerm, setActiveTerm] = useState('');
-    const [activeAnchorId, setActiveAnchorId] = useState<string | null>(null);
-    const containerId = `results-content-${tabId}`;
-    const lastMarkupRef = useRef<string | null>(null);
-    const lastHtmlRef = useRef<string | null>(null);
-    const renderedMarkupKeyRef = useRef<string | null>(null);
-    const activeAnchorIdRef = useRef<string | null>(null);
-    const anchorRafRef = useRef<number | null>(null);
-    const manualNavigationLockRef = useRef<{ anchorId: string; expiresAt: number } | null>(null);
-    const onContentReadyRef = useRef(onContentReady);
-
-    // Sidebar collapsed state for lateral layout
-    const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-    const toggleSidebar = useCallback(() => { if (window.innerWidth <= 1024) { if (onToggleMobileMenu) onToggleMobileMenu(); else if (onCloseMobileMenu && mobileMenuOpen) onCloseMobileMenu(); } else { setSidebarCollapsed(prev => !prev); } }, [onToggleMobileMenu, onCloseMobileMenu, mobileMenuOpen]);
-
-    // ── Sistema de Comentários (Google Docs Style) ─────────────────────────
-    const [commentsEnabled, setCommentsEnabled] = useState(false);
-    const toggleComments = useCallback(() => {
-        if (isAuthLoading) {
-            toast.error('Aguarde a autenticação carregar e tente novamente.');
-            return;
-        }
-        if (!isSignedIn) {
-            toast.error('Faça login para usar comentários.');
-            return;
-        }
-        if (!canUseRestrictedUi) {
-            toast.error('Seu usuário não tem acesso a comentários.');
-            return;
-        }
-        if (import.meta.env.DEV && typeof window !== 'undefined') {
-            const host = window.location.hostname;
-            const isLanHost = host !== 'localhost' && host !== '127.0.0.1';
-            if (isLanHost) {
-                toast.error('Comentários não estão disponíveis neste ambiente agora.');
-                return;
-            }
-        }
-        setCommentsEnabled(prev => !prev);
-    }, [canUseRestrictedUi, isSignedIn, isAuthLoading]);
-
-    const contentRef = useRef<HTMLDivElement>(null);
-    const { selection, clearSelection, onPopoverMouseDown } = useTextSelection(contentRef);
-
-    const [pendingComment, setPendingComment] = useState<PendingCommentEntry | null>(null);
-    const {
-        comments: localComments,
-        addComment,
-        editComment,
-        removeComment,
-        commentedAnchors,
-        loadCommentedAnchors,
-        loadComments,
-        resetFetchedAnchors,
-    } = useComments();
-    const commentedAnchorsLoadedRef = useRef(false);
-
-    // Drawer state for responsive screens < 1280px
-    const [drawerOpen, setDrawerOpen] = useState(false);
-    const toggleDrawer = useCallback(() => setDrawerOpen(prev => !prev), []);
-    const [hydratedCodeResults, setHydratedCodeResults] = useState<Record<string, any> | null>(null);
-    const [isHydratingCodeResults, setIsHydratingCodeResults] = useState(false);
-    const [failedChapterBodies, setFailedChapterBodies] = useState<string[]>([]);
-
-    /** Abre o formulário no painel direito ancorado ao trecho selecionado. */
-    const handleOpenComment = useCallback(() => {
-        if (!selection?.anchorKey) {
-            if (selection) toast.error('Selecione texto dentro de um elemento NCM para comentar.');
-            return;
-        }
-        if (!selection) return;
-        const container = containerRef.current;
-        if (!container) return;
-        const containerRect = container.getBoundingClientRect();
-        // anchorTop = posição Y relativa ao topo do scroll container
-        const anchorTop = selection.rect.top - containerRect.top + container.scrollTop;
-        setPendingComment({
-            anchorTop,
-            anchorKey: selection.anchorKey,
-            selectedText: selection.text,
-        });
-        clearSelection();
-        // Em telas estreitas, abre o drawer automaticamente
-        if (window.matchMedia('(max-width: 1280px)').matches) {
-            setDrawerOpen(true);
-        }
-    }, [selection, containerRef, clearSelection]);
-
-    /** Confirma o comentário via API (otimista). */
-    const handleCommentSubmit = useCallback(async (body: string, isPrivate: boolean): Promise<boolean> => {
-        if (!pendingComment) return false;
-        const success = await addComment(
-            pendingComment,
-            body,
-            isPrivate,
-            userName || 'Usuário',
-            userImageUrl || null,
-        );
-        if (success) {
-            setPendingComment(null);
-        }
-        return success;
-    }, [pendingComment, userName, userImageUrl, addComment]);
-
-    const handleDismissComment = useCallback(() => {
-        setPendingComment(null);
-    }, []);
-
-    useEffect(() => {
-        if (canUseRestrictedUi) return;
-        setCommentsEnabled(false);
-        setPendingComment(null);
-        setDrawerOpen(false);
-    }, [canUseRestrictedUi]);
-
-    // ── Carregar anchors com comentários quando ativado ────────────────────
-    useEffect(() => {
-        if (!canUseRestrictedUi || !commentsEnabled) {
-            commentedAnchorsLoadedRef.current = false;
-            return;
-        }
-
-        if (!isSignedIn || isAuthLoading) return;
-        if (commentedAnchorsLoadedRef.current) return;
-
-        commentedAnchorsLoadedRef.current = true;
-        void loadCommentedAnchors();
-    }, [canUseRestrictedUi, commentsEnabled, loadCommentedAnchors, isSignedIn, isAuthLoading]);
-
-    // ── Aplicar/remover classe .has-comment nos elementos do DOM ──────────
-    useEffect(() => {
-        const container = contentRef.current;
-        if (!container) return;
-
-        // Sempre limpa marcações anteriores
-        container.querySelectorAll('.has-comment').forEach(el => {
-            el.classList.remove('has-comment');
-        });
-
-        // Só aplica quando comments estão ativos e há anchors
-        if (!canUseRestrictedUi || !commentsEnabled || commentedAnchors.length === 0) return;
-
-        commentedAnchors.forEach(anchorKey => {
-            const el = container.querySelector(`[id="${CSS.escape(anchorKey)}"]`);
-            if (el) {
-                el.classList.add('has-comment');
-            }
-        });
-    }, [canUseRestrictedUi, commentsEnabled, commentedAnchors, isContentReady]);
-
-    // ── Carregar comentários ao clicar em elemento com .has-comment ───────
-    useEffect(() => {
-        const container = contentRef.current;
-        if (!container || !canUseRestrictedUi || !commentsEnabled) return;
-
-        const handleHasCommentClick = (e: Event) => {
-            const target = (e.target as HTMLElement).closest('.has-comment');
-            if (!target) return;
-            const anchorKey = target.id;
-            if (!anchorKey) return;
-
-            // Busca os comentários deste anchor
-            void loadComments(anchorKey, target.getBoundingClientRect().top);
-
-            // Em telas estreitas, abre o drawer
-            if (window.matchMedia('(max-width: 1280px)').matches) {
-                setDrawerOpen(true);
-            }
-        };
-
-        container.addEventListener('click', handleHasCommentClick);
-        return () => container.removeEventListener('click', handleHasCommentClick);
-    }, [canUseRestrictedUi, commentsEnabled, loadComments]);
-
-    // ── Reset ao mudar de conteúdo ────────────────────────────────────────
-    useEffect(() => {
-        resetFetchedAnchors();
-    }, [data?.markdown, data?.ncm, data?.query, resetFetchedAnchors]);
-
-    // ───────────────────────────────────────────────────────────────────────
-    const codeResults = useMemo(() => {
-        if (!data || data.type === 'text') return null;
-        if (data.resultados && typeof data.resultados === 'object') {
-            return data.resultados as Record<string, any>;
-        }
-        if (data.results && !Array.isArray(data.results) && typeof data.results === 'object') {
-            return data.results as Record<string, any>;
-        }
-        return null;
-    }, [data?.type, data?.resultados, data?.results]);
-
-    useEffect(() => {
-        startTransition(() => {
-            setHydratedCodeResults(null);
-            setIsHydratingCodeResults(false);
-            setFailedChapterBodies([]);
-        });
-    }, [data?.markdown, data?.ncm, data?.query, tabId]);
-
-    const shouldHydrateCodeResults = useMemo(() => {
-        return !!codeResults
-            && data?.type === 'code'
-            && !data?.markdown
-            && !isTipiResults(codeResults);
-    }, [codeResults, data?.markdown, data?.type]);
-
-    const renderableCodeResults = useMemo(() => {
-        return hydratedCodeResults ?? codeResults;
-    }, [codeResults, hydratedCodeResults]);
-
-    const missingChapterBodies = useMemo(() => {
-        if (!shouldHydrateCodeResults || !renderableCodeResults) return [] as string[];
-
-        return Object.entries(renderableCodeResults)
-            .filter(([, chapter]) => !chapterHasRenderableContent(chapter))
-            .map(([chapterKey, chapter]) => {
-                const capitulo = (chapter as { capitulo?: unknown })?.capitulo;
-                return typeof capitulo === 'string' && capitulo.trim()
-                    ? capitulo.trim()
-                    : chapterKey;
-            })
-            .filter((chapter) => !failedChapterBodies.includes(chapter));
-    }, [failedChapterBodies, renderableCodeResults, shouldHydrateCodeResults]);
-
-    useEffect(() => {
-        if (!isActive || !shouldHydrateCodeResults || !renderableCodeResults || missingChapterBodies.length === 0) {
-            return;
-        }
-
-        let cancelled = false;
-        setIsHydratingCodeResults(true);
-
-        const applyHydrationResult = ({
-            chapterBodies,
-            failedChapters,
-        }: ChapterHydrationResult) => {
-            if (cancelled) return;
-
-            if (failedChapters.length > 0) {
-                startTransition(() => {
-                    setFailedChapterBodies(createFailedChapterBodiesUpdater(failedChapters));
-                });
-            }
-
-            if (chapterBodies.length === 0) return;
-
-            const mergedResults = mergeHydratedChapterBodies(
-                renderableCodeResults,
-                chapterBodies,
-            );
-
-            startTransition(() => {
-                setHydratedCodeResults(mergedResults);
-                setFailedChapterBodies(
-                    createRecoveredChapterBodiesUpdater(chapterBodies),
-                );
-                onHydratedResults?.(tabId, mergedResults);
-            });
-        };
-
-        void fetchChapterBodies(missingChapterBodies)
-            .then(applyHydrationResult)
-            .catch((error) => {
-                console.error('[ResultDisplay] Failed to hydrate chapter bodies', error);
-            })
-            .finally(() => {
-                if (!cancelled) {
-                    setIsHydratingCodeResults(false);
-                }
-            });
-
-        return () => {
-            cancelled = true;
-        };
-    }, [
-        isActive,
-        missingChapterBodies,
-        onHydratedResults,
-        renderableCodeResults,
-        shouldHydrateCodeResults,
-        tabId,
-    ]);
-
-    const findAnchorIdForQuery = useCallback((resultados: any, query: string) => {
-        if (!resultados || typeof resultados !== 'object') return null;
-
-        const normalizedQuery = normalizeDigits(query);
-        if (!normalizedQuery) return null;
-
-        const chapters = Object.values(resultados) as any[];
-        let exactMatch: string | null = null;
-        let prefixMatch: string | null = null;
-
-        for (const chapter of chapters) {
-            const match = findAnchorIdInChapter(chapter, normalizedQuery, prefixMatch);
-            if (match.exactMatch) {
-                exactMatch = match.exactMatch;
-                break;
-            }
-            prefixMatch = match.prefixMatch;
-        }
-
-        return exactMatch || prefixMatch;
-    }, []);
-
-    const getPosicaoAlvoFromResultados = useCallback((resultados: any) => {
-        if (!resultados || typeof resultados !== 'object') return null as string | null;
-        const chapters = Object.values(resultados) as any[];
-        if (chapters.length !== 1) return null;
-        const posicaoAlvo = (chapters[0]?.posicao_alvo || chapters[0]?.posicaoAlvo || '').toString().trim();
-        return posicaoAlvo || null;
-    }, []);
-
-    const getSectionAnchorIdsFromResultados = useCallback((resultados: any) => {
-        if (!resultados || typeof resultados !== 'object') return [] as string[];
-
-        const ids: string[] = [];
-        const chapters = Object.values(resultados) as any[];
-        for (const chapter of chapters) {
-            const capitulo = (chapter?.capitulo || '').toString().trim();
-            if (!capitulo) continue;
-
-            const secoes = chapter?.secoes;
-            if (secoes && typeof secoes === 'object') {
-                const structuredSectionIds = getStructuredSectionIds(capitulo, secoes as Record<string, unknown>);
-                ids.push(...structuredSectionIds);
-                if (structuredSectionIds.length > 0) continue;
-            }
-
-            if ((chapter?.notas_gerais || '').toString().trim()) {
-                ids.push(`chapter-${capitulo}-notas`);
-            }
-        }
-
-        return ids;
-    }, []);
-
-    const getAnchorIdsFromResultados = useCallback((resultados: any) => {
-        if (!resultados || typeof resultados !== 'object') return [] as string[];
-
-        const ids = getSectionAnchorIdsFromResultados(resultados);
-        const chapters = Object.values(resultados) as any[];
-        for (const chapter of chapters) {
-            const positions = Array.isArray(chapter?.posicoes) ? chapter.posicoes : [];
-            for (const pos of positions) {
-                const codigo = (pos?.codigo || pos?.ncm || '').toString();
-                if (!codigo) continue;
-                ids.push(pos?.anchor_id || generateAnchorId(codigo));
-            }
-        }
-        return Array.from(new Set(ids));
-    }, [getSectionAnchorIdsFromResultados]);
-
-    const ensureSectionAnchors = useCallback((resultados: any, container: HTMLElement) => {
-        const sectionIds = getSectionAnchorIdsFromResultados(resultados);
-        for (const sectionId of sectionIds) {
-            const existing = container.querySelector(`#${CSS.escape(sectionId)}`) as HTMLElement | null;
-            if (existing) continue;
-            resolveSectionElement(container, sectionId);
-        }
-    }, [getSectionAnchorIdsFromResultados]);
-
-    const searchHighlighterQuery = useMemo(() => {
-        const candidate = (latestTextQuery || '').trim();
-        return candidate || null;
-    }, [latestTextQuery]);
-    const searchHighlighterOwnsScroll = data?.type === 'text' && !!searchHighlighterQuery;
-    const consumeNewSearchKey = useMemo(
-        () => `${tabId}|${isNewSearch ? '1' : '0'}|${data?.query ?? ''}|${data?.ncm ?? ''}|${latestTextQuery ?? ''}`,
-        [data?.ncm, data?.query, isNewSearch, latestTextQuery, tabId],
-    );
-
-    // Sidebar Navigation Handler
-    const handleNavigate = useCallback((targetId: string) => {
-        const container = containerRef.current;
-        if (!container) return;
-
-        // Try direct ID first (backend should provide correct anchor_id)
-        let element = container.querySelector(`#${CSS.escape(targetId)}`) as HTMLElement | null;
-
-        // Fallback: generate anchor ID from codigo (e.g., "84.13" -> "pos-84-13")
-        if (!element) {
-            const generatedId = generateAnchorId(targetId);
-            element = container.querySelector(`#${CSS.escape(generatedId)}`) as HTMLElement | null;
-        }
-
-        // Section fallback: backend HTML may provide section classes without stable IDs.
-        if (!element) {
-            element = resolveSectionElement(container, targetId);
-        }
-
-        if (element) {
-            element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            element.classList.add('flash-highlight');
-            setTimeout(() => element.classList.remove('flash-highlight'), 2000);
-            const nextAnchor = element.id || targetId;
-            manualNavigationLockRef.current = {
-                anchorId: nextAnchor,
-                expiresAt: Date.now() + MANUAL_NAVIGATION_HIGHLIGHT_LOCK_MS,
-            };
-            setActiveAnchorId(prev => (prev === nextAnchor ? prev : nextAnchor));
-        } else {
-            debug.warn('[Navigate] target not found:', targetId);
-        }
-    }, []); // Empty dependency array as it only uses refs or DOM APIs
-
-    const targetCandidates = useMemo(() => {
-        if (!data) return null;
-
-        const ncmToScroll = resolveNcmToScroll(data);
-        if (!ncmToScroll) return null;
-
-        return resolveAutoScrollCandidates(
-            ncmToScroll,
-            renderableCodeResults,
-            findAnchorIdForQuery,
-            getPosicaoAlvoFromResultados,
-        );
-    }, [data, findAnchorIdForQuery, getPosicaoAlvoFromResultados, renderableCodeResults]);
-
-    const resolveAutoScrollTargetReadiness = useCallback((container: HTMLElement) => {
-        if (renderableCodeResults) {
-            ensureSectionAnchors(renderableCodeResults, container);
-        }
-
-        if (!targetCandidates || targetCandidates.length === 0) {
-            return false;
-        }
-
-        if (findExistingTargetElement(container, targetCandidates)) {
-            return true;
-        }
-
-        const posicaoAlvo = renderableCodeResults ? getPosicaoAlvoFromResultados(renderableCodeResults) : null;
-        const candidateNcm = posicaoAlvo || (data?.ncm || data?.query || '');
-        if (!candidateNcm) {
-            return false;
-        }
-
-        const fallback = ensureTargetAnchorFromDataNcm(container, candidateNcm);
-        if (!fallback) {
-            return false;
-        }
-
-        return !!findExistingTargetElement(container, targetCandidates);
-    }, [
-        renderableCodeResults,
-        data?.ncm,
-        data?.query,
-        ensureSectionAnchors,
-        getPosicaoAlvoFromResultados,
-        targetCandidates,
-    ]);
-
-    // Stabilize onConsumeNewSearch callback to prevent AutoScroll effect loop
-    const onConsumeNewSearchRef = useRef(onConsumeNewSearch);
-    useEffect(() => {
-        onConsumeNewSearchRef.current = onConsumeNewSearch;
-    }, [onConsumeNewSearch]);
-
-    const onPersistScrollRef = useRef(onPersistScroll);
-    const hasConsumedNewSearchRef = useRef(false);
-    const isActiveRef = useRef(isActive);
-    const isNewSearchRef = useRef(isNewSearch);
-    useEffect(() => {
-        onPersistScrollRef.current = onPersistScroll;
-    }, [onPersistScroll]);
-    useEffect(() => {
-        hasConsumedNewSearchRef.current = false;
-    }, [consumeNewSearchKey]);
-    useEffect(() => {
-        isActiveRef.current = isActive;
-    }, [isActive]);
-    useEffect(() => {
-        isNewSearchRef.current = isNewSearch;
-    }, [isNewSearch]);
-    useEffect(() => {
-        onContentReadyRef.current = onContentReady;
-    }, [onContentReady]);
-    useEffect(() => {
-        activeAnchorIdRef.current = activeAnchorId;
-    }, [activeAnchorId]);
-    useEffect(() => {
-        return () => {
-            if (anchorRafRef.current !== null) {
-                cancelAnimationFrame(anchorRafRef.current);
-            }
-        };
-    }, []);
-    useEffect(() => {
-        if (isContentReady) {
-            onContentReadyRef.current?.(tabId);
-        }
-    }, [isContentReady, tabId]);
-
-    // Keep active term in sync with the latest text query for this tab.
-    useEffect(() => {
-        const normalizedLatestTextQuery = (latestTextQuery || '').trim();
-        setActiveTerm(prev => (prev === normalizedLatestTextQuery ? prev : normalizedLatestTextQuery));
-    }, [latestTextQuery, data?.query, tabId]);
-
-    const consumeNewSearchScroll = useCallback((scrollTop?: number, force = false) => {
-        if (hasConsumedNewSearchRef.current) return;
-        if (!force && (!isActiveRef.current || !isNewSearchRef.current)) return;
-        hasConsumedNewSearchRef.current = true;
-        onConsumeNewSearchRef.current(tabId, scrollTop);
-    }, [tabId]);
-
-    const handleAutoScrollComplete = useCallback((success?: boolean) => {
-        if (!success) return;
-        // Wrap in RAF to ensure DOM has updated/painted the scroll action
-        // before we capture the final position and update app state.
-        requestAnimationFrame(() => {
-            if (!isActiveRef.current || !isNewSearchRef.current) return;
-            const currentScroll = containerRef.current?.scrollTop || 0;
-            consumeNewSearchScroll(currentScroll);
-        });
-    }, [consumeNewSearchScroll]);
-
-    const handleHighlightScrollComplete = useCallback((scrollTop: number) => {
-        if (!isActiveRef.current || !isNewSearchRef.current) return;
-        consumeNewSearchScroll(scrollTop);
-    }, [consumeNewSearchScroll]);
-
-    // `isContentReady` means the tab can render, but auto-scroll only starts
-    // once at least one candidate anchor is actually present in the DOM.
-    // Only auto-scroll when:
-    // 1. Tab is active
-    // 2. This is a NEW search (not returning to existing tab)
-    // 3. Let SearchHighlighter take precedence for text-result tabs, but keep anchor scroll as fallback elsewhere
-    const shouldAutoScroll = !!targetCandidates?.length
-        && isActive
-        && isNewSearch
-        && isContentReady
-        && !searchHighlighterOwnsScroll
-        && isTargetReady;
-    useRobustScroll({
-        targetId: targetCandidates,
-        shouldScroll: shouldAutoScroll,
-        containerRef,
-        onComplete: handleAutoScrollComplete,
-        expectedTags: ['H1', 'H2', 'H3', 'H4', 'ARTICLE', 'SECTION', 'DIV']
-    });
-
-    // Track scroll position for persistence
-    useEffect(() => {
-        const element = containerRef.current;
-        if (!element) return;
-
-        const handleScroll = () => {
-            const currentScroll = element.scrollTop;
-            latestScrollTopRef.current = currentScroll;
-            hasScrollSnapshotRef.current = true;
-
-            if (!isActive) return;
-
-            const persist = onPersistScrollRef.current;
-            if (!persist) return;
-            if (lastPersistedScrollRef.current === currentScroll) return;
-
-            lastPersistedScrollRef.current = currentScroll;
-            persist(tabId, currentScroll);
-        };
-
-        element.addEventListener('scroll', handleScroll, { passive: true });
-        return () => element.removeEventListener('scroll', handleScroll);
-    }, [data?.type, data?.markdown, renderableCodeResults, isActive, tabId]);
-
-    useEffect(() => {
-        if (isActive) return;
-
-        const persist = onPersistScrollRef.current;
-        if (!persist) return;
-        if (!hasScrollSnapshotRef.current) return;
-
-        const currentScroll = latestScrollTopRef.current;
-        if (isNewSearchRef.current && !hasConsumedNewSearchRef.current) {
-            consumeNewSearchScroll(currentScroll, true);
-            return;
-        }
-        if (lastPersistedScrollRef.current === currentScroll) return;
-
-        lastPersistedScrollRef.current = currentScroll;
-        persist(tabId, currentScroll);
-    }, [consumeNewSearchScroll, isActive, tabId]);
-
-    // Restore scroll when tab becomes active (only if NOT a new search)
-    const hasRestoredInitialScrollRef = useRef(false);
-    useEffect(() => {
-        // Skip restore if this is a new search - auto-scroll will handle positioning
-        if (!isActive || isNewSearch) return;
-        // Wait until content is rendered before restoring scroll
-        if (!isContentReady) return;
-        const element = containerRef.current;
-        if (!element) return;
-
-        if (typeof initialScrollTop !== 'number') return;
-        const targetScrollTop = initialScrollTop;
-
-        if (hasRestoredInitialScrollRef.current) return;
-        if (Math.abs(element.scrollTop - targetScrollTop) < 1) return;
-
-        let cancelled = false;
-        let attempts = 0;
-        let frameId = 0;
-        const maxAttempts = 20;
-
-        const tryRestore = () => {
-            if (cancelled) return;
-
-            const currentContainer = containerRef.current;
-            if (!currentContainer) return;
-
-            if (Math.abs(currentContainer.scrollTop - targetScrollTop) < 1) {
-                latestScrollTopRef.current = targetScrollTop;
-                hasScrollSnapshotRef.current = true;
-                lastPersistedScrollRef.current = targetScrollTop;
-                hasRestoredInitialScrollRef.current = true;
-                return;
-            }
-
-            const hasScrollableContent = currentContainer.scrollHeight > currentContainer.clientHeight;
-            if (!hasScrollableContent && attempts < maxAttempts) {
-                attempts += 1;
-                frameId = requestAnimationFrame(tryRestore);
-                return;
-            }
-
-            currentContainer.scrollTop = targetScrollTop;
-            latestScrollTopRef.current = targetScrollTop;
-            hasScrollSnapshotRef.current = true;
-            lastPersistedScrollRef.current = targetScrollTop;
-
-            if (Math.abs(currentContainer.scrollTop - targetScrollTop) < 1) {
-                hasRestoredInitialScrollRef.current = true;
-                return;
-            }
-
-            if (attempts < maxAttempts) {
-                attempts += 1;
-                frameId = requestAnimationFrame(tryRestore);
-                return;
-            }
-
-            hasRestoredInitialScrollRef.current = true;
-        };
-
-        frameId = requestAnimationFrame(tryRestore);
-
-        return () => {
-            cancelled = true;
-            cancelAnimationFrame(frameId);
-        };
-    }, [isActive, initialScrollTop, isNewSearch, isContentReady]);
-
-    // Reset restored flag when inactive so it can restore again when returning
-    useEffect(() => {
-        if (!isActive) {
-            hasRestoredInitialScrollRef.current = false;
-        }
-    }, [isActive]);
-
-
-
-    // Render backend content (prefer HTML; parse markdown only as legacy fallback)
-    useEffect(() => {
-        if (data?.type === 'text') {
-            renderedMarkupKeyRef.current = null;
-            setIsContentReady(true);
-            setIsFullyRendered(true);
-            return;
-        }
-        if (!contentRef.current) return;
-
-        const rawMarkdown = typeof data?.markdown === 'string' ? data.markdown.trim() : '';
-        const markupToRender = resolveMarkupToRender(rawMarkdown, renderableCodeResults);
-
-        if (!markupToRender) {
-            if (shouldHydrateCodeResults && missingChapterBodies.length > 0) {
-                renderedMarkupKeyRef.current = null;
-                setIsContentReady(true);
-                setIsFullyRendered(false);
-                return;
-            }
-            contentRef.current.textContent = '';
-            renderedMarkupKeyRef.current = null;
-            setIsContentReady(true);
-            setIsFullyRendered(true);
-            return;
-        }
-
-        try {
-            return renderMarkupContent({
-                rawMarkdown,
-                markupToRender,
-                isActive,
-                isContentReady,
-                refs: {
-                    contentRef,
-                    renderedMarkupKeyRef,
-                    lastMarkupRef,
-                    lastHtmlRef,
-                },
-                setIsContentReady,
-                setIsFullyRendered,
-            });
-        } catch (e) {
-            console.error("Content render error:", e);
-            if (contentRef.current) contentRef.current.textContent = 'Error rendering content.';
-            renderedMarkupKeyRef.current = null;
-            setIsContentReady(true);
-            setIsFullyRendered(true);
-        }
-    }, [
-        data?.markdown,
-        data?.type,
-        isActive,
-        missingChapterBodies.length,
-        renderableCodeResults,
-        shouldHydrateCodeResults,
-    ]);
-
-    useEffect(() => {
-        if (!isContentReady || !containerRef.current || !targetCandidates?.length) {
-            setIsTargetReady(false);
-            return;
-        }
-
-        let cancelled = false;
-        let observer: MutationObserver | null = null;
-        const container = containerRef.current;
-
-        const syncReadiness = () => {
-            const ready = resolveAutoScrollTargetReadiness(container);
-            if (!cancelled) {
-                setIsTargetReady(ready);
-            }
-            return ready;
-        };
-
-        if (syncReadiness()) {
-            return () => {
-                cancelled = true;
-            };
-        }
-
-        if (!isFullyRendered) {
-            observer = new MutationObserver(() => {
-                if (syncReadiness()) {
-                    observer?.disconnect();
-                    observer = null;
-                }
-            });
-            observer.observe(container, {
-                childList: true,
-                subtree: true,
-            });
-        }
-
-        return () => {
-            cancelled = true;
-            observer?.disconnect();
-        };
-    }, [
-        isContentReady,
-        isFullyRendered,
-        resolveAutoScrollTargetReadiness,
-        targetCandidates,
-    ]);
-
-    // Ensure structured section anchors exist for sidebar navigation/highlight syncing.
-    useEffect(() => {
-        if (!isContentReady || !renderableCodeResults || !containerRef.current) return;
-        ensureSectionAnchors(renderableCodeResults, containerRef.current);
-    }, [ensureSectionAnchors, isContentReady, renderableCodeResults]);
-
-    // Query-term highlighting for code results.
-    // Always clean previous wrappers first to avoid nested/duplicated marks after query changes.
-    useEffect(() => {
-        const contentContainer = contentRef.current;
-        if (!contentContainer || data?.type === 'text') return;
-
-        unwrapQueryHighlights(contentContainer);
-
-        if (!isActive || !isContentReady || !activeTerm || searchHighlighterQuery) {
-            return () => {
-                const current = contentRef.current;
-                if (current) unwrapQueryHighlights(current);
-            };
-        }
-
-        highlightTermInContainer(contentContainer, activeTerm);
-
-        return () => {
-            const current = contentRef.current;
-            if (current) unwrapQueryHighlights(current);
-        };
-    }, [activeTerm, isActive, isContentReady, searchHighlighterQuery, tabId, data?.type, data?.markdown]);
-
-    // Sync Sidebar to current visible anchor
-    useEffect(() => {
-        if (!isActive || !isContentReady || !renderableCodeResults || !containerRef.current) return;
-
-        const ids = getAnchorIdsFromResultados(renderableCodeResults);
-        if (ids.length === 0) return;
-
-        const elements = ids
-            .map(id => containerRef.current?.querySelector(`#${CSS.escape(id)}`) as HTMLElement | null)
-            .filter(Boolean) as HTMLElement[];
-
-        if (elements.length === 0) return;
-
-        const observer = new IntersectionObserver(
-            (entries) => {
-                const nextAnchorId = getNextVisibleAnchorId(entries);
-                if (!nextAnchorId) return;
-
-                const manualNavigationLock = manualNavigationLockRef.current;
-                if (manualNavigationLock) {
-                    const now = Date.now();
-                    if (now < manualNavigationLock.expiresAt) {
-                        if (nextAnchorId !== manualNavigationLock.anchorId) {
-                            return;
-                        }
-                        manualNavigationLockRef.current = null;
-                    } else {
-                        manualNavigationLockRef.current = null;
-                    }
-                }
-
-                scheduleActiveAnchorUpdate(nextAnchorId, activeAnchorIdRef, anchorRafRef, setActiveAnchorId);
-            },
-            {
-                root: containerRef.current,
-                rootMargin: '0px 0px -60% 0px',
-                threshold: 0.1
-            }
-        );
-
-        elements.forEach(el => observer.observe(el));
-
-        return () => observer.disconnect();
-    }, [getAnchorIdsFromResultados, isActive, isContentReady, renderableCodeResults]);
-
-
-    if (!data) {
-        return <p className={styles.emptyMessage}>Sem resultados para exibir.</p>;
+  const { sidebarPosition } = useSettings()
+  const {
+    userName,
+    userImageUrl,
+    isSignedIn,
+    isLoading: isAuthLoading,
+    userId,
+    canUseRestrictedUi,
+  } = useAuth()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const latestScrollTopRef = useRef(initialScrollTop ?? 0)
+  const hasScrollSnapshotRef = useRef(typeof initialScrollTop === 'number')
+  const lastPersistedScrollRef = useRef<number | null>(null)
+  const [isContentReady, setIsContentReady] = useState(false)
+  const [isFullyRendered, setIsFullyRendered] = useState(false)
+  const [isTargetReady, setIsTargetReady] = useState(false)
+  const [activeTerm, setActiveTerm] = useState('')
+  const [activeAnchorId, setActiveAnchorId] = useState<string | null>(null)
+  const containerId = `results-content-${tabId}`
+  const lastMarkupRef = useRef<string | null>(null)
+  const lastHtmlRef = useRef<string | null>(null)
+  const renderedMarkupKeyRef = useRef<string | null>(null)
+  const activeAnchorIdRef = useRef<string | null>(null)
+  const anchorRafRef = useRef<number | null>(null)
+  const manualNavigationLockRef = useRef<{
+    anchorId: string
+    expiresAt: number
+  } | null>(null)
+  const onContentReadyRef = useRef(onContentReady)
+
+  // Sidebar collapsed state for lateral layout
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const toggleSidebar = useCallback(() => {
+    if (window.innerWidth <= 1024) {
+      if (onToggleMobileMenu) {
+        onToggleMobileMenu()
+      } else if (onCloseMobileMenu && mobileMenuOpen) {
+        onCloseMobileMenu()
+      }
     }
 
-    // Text Search Rendering
-    if (data.type === 'text') {
-        return (
-            <div className={`${styles.content} ${styles.textSearchContent}`} ref={containerRef} id={containerId}>
-                <TextSearchResults
-                    results={(data.results as SearchResultItem[]) || null}
-                    query={latestTextQuery || data.query || ""}
-                    onResultClick={(ncm: string) => globalThis.nesh.openTextResultInNewTab(ncm, latestTextQuery || data.query || '')}
-                    scrollParentRef={containerRef}
-                />
-            </div>
-        );
+    setSidebarCollapsed((prev) => !prev)
+  }, [onToggleMobileMenu, onCloseMobileMenu, mobileMenuOpen])
+
+  // ── Sistema de Comentários (Google Docs Style) ─────────────────────────
+  const [commentsEnabled, setCommentsEnabled] = useState(false)
+  const toggleComments = useCallback(() => {
+    if (isAuthLoading) {
+      toast.error('Aguarde a autenticação carregar e tente novamente.')
+      return
+    }
+    if (!isSignedIn) {
+      toast.error('Faça login para usar comentários.')
+      return
+    }
+    if (!canUseRestrictedUi) {
+      toast.error('Seu usuário não tem acesso a comentários.')
+      return
+    }
+    if (import.meta.env.DEV && typeof window !== 'undefined') {
+      const host = window.location.hostname
+      const isLanHost = host !== 'localhost' && host !== '127.0.0.1'
+      if (isLanHost) {
+        toast.error('Comentários não estão disponíveis neste ambiente agora.')
+        return
+      }
+    }
+    setCommentsEnabled((prev) => !prev)
+  }, [canUseRestrictedUi, isSignedIn, isAuthLoading])
+
+  const contentRef = useRef<HTMLDivElement>(null)
+  const { selection, clearSelection, onPopoverMouseDown } =
+    useTextSelection(contentRef)
+
+  const [pendingComment, setPendingComment] =
+    useState<PendingCommentEntry | null>(null)
+  const {
+    comments: localComments,
+    addComment,
+    editComment,
+    removeComment,
+    commentedAnchors,
+    loadCommentedAnchors,
+    loadComments,
+    resetFetchedAnchors,
+  } = useComments()
+  const commentedAnchorsLoadedRef = useRef(false)
+
+  // Drawer state for responsive screens < 1280px
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const toggleDrawer = useCallback(() => setDrawerOpen((prev) => !prev), [])
+  const [hydratedCodeResults, setHydratedCodeResults] = useState<Record<
+    string,
+    any
+  > | null>(null)
+  const [isHydratingCodeResults, setIsHydratingCodeResults] = useState(false)
+  const [failedChapterBodies, setFailedChapterBodies] = useState<string[]>([])
+
+  /** Abre o formulário no painel direito ancorado ao trecho selecionado. */
+  const handleOpenComment = useCallback(() => {
+    if (!selection?.anchorKey) {
+      if (selection)
+        toast.error('Selecione texto dentro de um elemento NCM para comentar.')
+      return
+    }
+    if (!selection) return
+    const container = containerRef.current
+    if (!container) return
+    const containerRect = container.getBoundingClientRect()
+    // anchorTop = posição Y relativa ao topo do scroll container
+    const anchorTop =
+      selection.rect.top - containerRect.top + container.scrollTop
+    setPendingComment({
+      anchorTop,
+      anchorKey: selection.anchorKey,
+      selectedText: selection.text,
+    })
+    clearSelection()
+    // Em telas estreitas, abre o drawer automaticamente
+    if (window.matchMedia('(max-width: 1280px)').matches) {
+      setDrawerOpen(true)
+    }
+  }, [selection, containerRef, clearSelection])
+
+  /** Confirma o comentário via API (otimista). */
+  const handleCommentSubmit = useCallback(
+    async (body: string, isPrivate: boolean): Promise<boolean> => {
+      if (!pendingComment) return false
+      const success = await addComment(
+        pendingComment,
+        body,
+        isPrivate,
+        userName || 'Usuário',
+        userImageUrl || null
+      )
+      if (success) {
+        setPendingComment(null)
+      }
+      return success
+    },
+    [pendingComment, userName, userImageUrl, addComment]
+  )
+
+  const handleDismissComment = useCallback(() => {
+    setPendingComment(null)
+  }, [])
+
+  useEffect(() => {
+    if (canUseRestrictedUi) return
+    setCommentsEnabled(false)
+    setPendingComment(null)
+    setDrawerOpen(false)
+  }, [canUseRestrictedUi])
+
+  // ── Carregar anchors com comentários quando ativado ────────────────────
+  useEffect(() => {
+    if (!canUseRestrictedUi || !commentsEnabled) {
+      commentedAnchorsLoadedRef.current = false
+      return
     }
 
-    // Default: Code View (Markdown + Sidebar)
-    // Layout: Grid with content and sidebar (position from settings)
-    const wrapperClasses = getWrapperClasses(styles, sidebarCollapsed, mobileMenuOpen, sidebarPosition);
-    const sidebarToggleLabel = getSidebarToggleLabel(sidebarCollapsed);
-    const sidebarToggleIcon = getSidebarToggleIcon(sidebarPosition, sidebarCollapsed);
-    const contentVisibilityClass = getContentVisibilityClass(styles, isContentReady);
-    const commentToggleLabel = getCommentToggleLabel(commentsEnabled);
-    const commentToggleClasses = getCommentToggleClassName(styles, commentsEnabled);
-    const shouldRenderSidebar = isActive && !!renderableCodeResults;
+    if (!isSignedIn || isAuthLoading) return
+    if (commentedAnchorsLoadedRef.current) return
 
+    commentedAnchorsLoadedRef.current = true
+    void loadCommentedAnchors()
+  }, [
+    canUseRestrictedUi,
+    commentsEnabled,
+    loadCommentedAnchors,
+    isSignedIn,
+    isAuthLoading,
+  ])
+
+  // ── Aplicar/remover classe .has-comment nos elementos do DOM ──────────
+  useEffect(() => {
+    const container = contentRef.current
+    if (!container) return
+
+    // Sempre limpa marcações anteriores
+    container.querySelectorAll('.has-comment').forEach((el) => {
+      el.classList.remove('has-comment')
+    })
+
+    // Só aplica quando comments estão ativos e há anchors
+    if (
+      !canUseRestrictedUi ||
+      !commentsEnabled ||
+      commentedAnchors.length === 0
+    )
+      return
+
+    commentedAnchors.forEach((anchorKey) => {
+      const el = container.querySelector(`[id="${CSS.escape(anchorKey)}"]`)
+      if (el) {
+        el.classList.add('has-comment')
+      }
+    })
+  }, [canUseRestrictedUi, commentsEnabled, commentedAnchors, isContentReady])
+
+  // ── Carregar comentários ao clicar em elemento com .has-comment ───────
+  useEffect(() => {
+    const container = contentRef.current
+    if (!container || !canUseRestrictedUi || !commentsEnabled) return
+
+    const handleHasCommentClick = (e: Event) => {
+      const target = (e.target as HTMLElement).closest('.has-comment')
+      if (!target) return
+      const anchorKey = target.id
+      if (!anchorKey) return
+
+      // Busca os comentários deste anchor
+      void loadComments(anchorKey, target.getBoundingClientRect().top)
+
+      // Em telas estreitas, abre o drawer
+      if (window.matchMedia('(max-width: 1280px)').matches) {
+        setDrawerOpen(true)
+      }
+    }
+
+    container.addEventListener('click', handleHasCommentClick)
+    return () => container.removeEventListener('click', handleHasCommentClick)
+  }, [canUseRestrictedUi, commentsEnabled, loadComments])
+
+  // ── Reset ao mudar de conteúdo ────────────────────────────────────────
+  useEffect(() => {
+    resetFetchedAnchors()
+  }, [data?.markdown, data?.ncm, data?.query, resetFetchedAnchors])
+
+  // ───────────────────────────────────────────────────────────────────────
+  const codeResults = useMemo(() => {
+    if (!data || data.type === 'text') return null
+    if (data.resultados && typeof data.resultados === 'object') {
+      return data.resultados as Record<string, any>
+    }
+    if (
+      data.results &&
+      !Array.isArray(data.results) &&
+      typeof data.results === 'object'
+    ) {
+      return data.results as Record<string, any>
+    }
+    return null
+  }, [data?.type, data?.resultados, data?.results])
+
+  useEffect(() => {
+    startTransition(() => {
+      setHydratedCodeResults(null)
+      setIsHydratingCodeResults(false)
+      setFailedChapterBodies([])
+    })
+  }, [data?.markdown, data?.ncm, data?.query, tabId])
+
+  const shouldHydrateCodeResults = useMemo(() => {
     return (
-        <div className={wrapperClasses}>
-            {/* Toggle Button */}
-            <button
-                className={styles.sidebarToggle}
-                onClick={toggleSidebar}
-                aria-label={sidebarToggleLabel}
-            >
-                {sidebarToggleIcon}
-            </button>
+      !!codeResults &&
+      data?.type === 'code' &&
+      !data?.markdown &&
+      !isTipiResults(codeResults)
+    )
+  }, [codeResults, data?.markdown, data?.type])
 
-            {/* Content scroll container - Coluna 1 */}
-            <div
-                className={`${styles.content} ${contentVisibilityClass} markdown-body`}
-                ref={(el) => {
-                    // containerRef = scroll container (para scroll tracking e texto selection)
-                    (containerRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
-                }}
-                id={containerId}
-            >
-                {/* O container interno organiza o conteúdo da esquerda verticalmente (mensagens + texto) */}
-                <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
-                    {shouldHydrateCodeResults && (isHydratingCodeResults || missingChapterBodies.length > 0) && (
-                        <div className={styles.loadingSpinnerContainer}>
-                            <svg className={styles.spinner} viewBox="0 0 50 50">
-                                <circle className={styles.spinnerPath} cx="25" cy="25" r="20" fill="none" strokeWidth="5"></circle>
-                            </svg>
-                            <p className={styles.loadingText}>Carregando conteúdo detalhado...</p>
-                        </div>
-                    )}
-                    {!shouldHydrateCodeResults && !data.markdown && !isTipiResults(renderableCodeResults || null) && (
-                        <p>Sem resultados para exibir.</p>
-                    )}
-                    
-                    {/* Texto renderizado via fragmentos HTML sanitizados */}
-                    <div
-                        className={styles.contentText}
-                        ref={(el) => {
-                            (contentRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
-                        }}
-                    />
-                </div>
+  const renderableCodeResults = useMemo(() => {
+    return hydratedCodeResults ?? codeResults
+  }, [codeResults, hydratedCodeResults])
 
-                {/* Painel de Comentários (Google Docs style) — só exibido quando ativado */}
-                {canUseRestrictedUi && commentsEnabled && (
-                    <CommentPanel
-                        pending={pendingComment}
-                        comments={localComments}
-                        onSubmit={handleCommentSubmit}
-                        onDismiss={handleDismissComment}
-                        onEdit={editComment}
-                        onDelete={removeComment}
-                        currentUserId={userId}
-                    />
-                )}
-            </div>
+  const missingChapterBodies = useMemo(() => {
+    if (!shouldHydrateCodeResults || !renderableCodeResults)
+      return [] as string[]
 
-            {searchHighlighterQuery && (
-                <SearchHighlighter
-                    query={searchHighlighterQuery}
-                    contentContainerRef={contentRef}
-                    isContentReady={isContentReady}
-                    isFullyRendered={isFullyRendered}
-                    onHighlightScrollComplete={handleHighlightScrollComplete}
-                />
+    return Object.entries(renderableCodeResults)
+      .filter(([, chapter]) => !chapterHasRenderableContent(chapter))
+      .map(([chapterKey, chapter]) => {
+        const capitulo = (chapter as { capitulo?: unknown })?.capitulo
+        return typeof capitulo === 'string' && capitulo.trim()
+          ? capitulo.trim()
+          : chapterKey
+      })
+      .filter((chapter) => !failedChapterBodies.includes(chapter))
+  }, [failedChapterBodies, renderableCodeResults, shouldHydrateCodeResults])
+
+  useEffect(() => {
+    if (
+      !isActive ||
+      !shouldHydrateCodeResults ||
+      !renderableCodeResults ||
+      missingChapterBodies.length === 0
+    ) {
+      return
+    }
+
+    let cancelled = false
+    setIsHydratingCodeResults(true)
+
+    const applyHydrationResult = ({
+      chapterBodies,
+      failedChapters,
+    }: ChapterHydrationResult) => {
+      if (cancelled) return
+
+      if (failedChapters.length > 0) {
+        startTransition(() => {
+          setFailedChapterBodies(
+            createFailedChapterBodiesUpdater(failedChapters)
+          )
+        })
+      }
+
+      if (chapterBodies.length === 0) return
+
+      const mergedResults = mergeHydratedChapterBodies(
+        renderableCodeResults,
+        chapterBodies
+      )
+
+      startTransition(() => {
+        setHydratedCodeResults(mergedResults)
+        setFailedChapterBodies(
+          createRecoveredChapterBodiesUpdater(chapterBodies)
+        )
+        onHydratedResults?.(tabId, mergedResults)
+      })
+    }
+
+    void fetchChapterBodies(missingChapterBodies)
+      .then(applyHydrationResult)
+      .catch((error) => {
+        console.error('[ResultDisplay] Failed to hydrate chapter bodies', error)
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsHydratingCodeResults(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    isActive,
+    missingChapterBodies,
+    onHydratedResults,
+    renderableCodeResults,
+    shouldHydrateCodeResults,
+    tabId,
+  ])
+
+  const findAnchorIdForQuery = useCallback((resultados: any, query: string) => {
+    if (!resultados || typeof resultados !== 'object') return null
+
+    const normalizedQuery = normalizeDigits(query)
+    if (!normalizedQuery) return null
+
+    const chapters = Object.values(resultados) as any[]
+    let exactMatch: string | null = null
+    let prefixMatch: string | null = null
+
+    for (const chapter of chapters) {
+      const match = findAnchorIdInChapter(chapter, normalizedQuery, prefixMatch)
+      if (match.exactMatch) {
+        exactMatch = match.exactMatch
+        break
+      }
+      prefixMatch = match.prefixMatch
+    }
+
+    return exactMatch || prefixMatch
+  }, [])
+
+  const getPosicaoAlvoFromResultados = useCallback((resultados: any) => {
+    if (!resultados || typeof resultados !== 'object')
+      return null as string | null
+    const chapters = Object.values(resultados) as any[]
+    if (chapters.length !== 1) return null
+    const posicaoAlvo = (
+      chapters[0]?.posicao_alvo ||
+      chapters[0]?.posicaoAlvo ||
+      ''
+    )
+      .toString()
+      .trim()
+    return posicaoAlvo || null
+  }, [])
+
+  const getSectionAnchorIdsFromResultados = useCallback((resultados: any) => {
+    if (!resultados || typeof resultados !== 'object') return [] as string[]
+
+    const ids: string[] = []
+    const chapters = Object.values(resultados) as any[]
+    for (const chapter of chapters) {
+      const capitulo = (chapter?.capitulo || '').toString().trim()
+      if (!capitulo) continue
+
+      const secoes = chapter?.secoes
+      if (secoes && typeof secoes === 'object') {
+        const structuredSectionIds = getStructuredSectionIds(
+          capitulo,
+          secoes as Record<string, unknown>
+        )
+        ids.push(...structuredSectionIds)
+        if (structuredSectionIds.length > 0) continue
+      }
+
+      if ((chapter?.notas_gerais || '').toString().trim()) {
+        ids.push(`chapter-${capitulo}-notas`)
+      }
+    }
+
+    return ids
+  }, [])
+
+  const getAnchorIdsFromResultados = useCallback(
+    (resultados: any) => {
+      if (!resultados || typeof resultados !== 'object') return [] as string[]
+
+      const ids = getSectionAnchorIdsFromResultados(resultados)
+      const chapters = Object.values(resultados) as any[]
+      for (const chapter of chapters) {
+        const positions = Array.isArray(chapter?.posicoes)
+          ? chapter.posicoes
+          : []
+        for (const pos of positions) {
+          const codigo = (pos?.codigo || pos?.ncm || '').toString()
+          if (!codigo) continue
+          ids.push(pos?.anchor_id || generateAnchorId(codigo))
+        }
+      }
+      return Array.from(new Set(ids))
+    },
+    [getSectionAnchorIdsFromResultados]
+  )
+
+  const ensureSectionAnchors = useCallback(
+    (resultados: any, container: HTMLElement) => {
+      const sectionIds = getSectionAnchorIdsFromResultados(resultados)
+      for (const sectionId of sectionIds) {
+        const existing = container.querySelector(
+          `#${CSS.escape(sectionId)}`
+        ) as HTMLElement | null
+        if (existing) continue
+        resolveSectionElement(container, sectionId)
+      }
+    },
+    [getSectionAnchorIdsFromResultados]
+  )
+
+  const searchHighlighterQuery = useMemo(() => {
+    const candidate = (latestTextQuery || '').trim()
+    return candidate || null
+  }, [latestTextQuery])
+  const searchHighlighterOwnsScroll =
+    data?.type === 'text' && !!searchHighlighterQuery
+  const consumeNewSearchKey = useMemo(
+    () =>
+      `${tabId}|${isNewSearch ? '1' : '0'}|${data?.query ?? ''}|${data?.ncm ?? ''}|${latestTextQuery ?? ''}`,
+    [data?.ncm, data?.query, isNewSearch, latestTextQuery, tabId]
+  )
+
+  // Sidebar Navigation Handler
+  const handleNavigate = useCallback((targetId: string) => {
+    const container = containerRef.current
+    if (!container) return
+
+    // Try direct ID first (backend should provide correct anchor_id)
+    let element = container.querySelector(
+      `#${CSS.escape(targetId)}`
+    ) as HTMLElement | null
+
+    // Fallback: generate anchor ID from codigo (e.g., "84.13" -> "pos-84-13")
+    if (!element) {
+      const generatedId = generateAnchorId(targetId)
+      element = container.querySelector(
+        `#${CSS.escape(generatedId)}`
+      ) as HTMLElement | null
+    }
+
+    // Section fallback: backend HTML may provide section classes without stable IDs.
+    if (!element) {
+      element = resolveSectionElement(container, targetId)
+    }
+
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      element.classList.add('flash-highlight')
+      setTimeout(() => element.classList.remove('flash-highlight'), 2000)
+      const nextAnchor = element.id || targetId
+      manualNavigationLockRef.current = {
+        anchorId: nextAnchor,
+        expiresAt: Date.now() + MANUAL_NAVIGATION_HIGHLIGHT_LOCK_MS,
+      }
+      setActiveAnchorId((prev) => (prev === nextAnchor ? prev : nextAnchor))
+    } else {
+      debug.warn('[Navigate] target not found:', targetId)
+    }
+  }, []) // Empty dependency array as it only uses refs or DOM APIs
+
+  const targetCandidates = useMemo(() => {
+    if (!data) return null
+
+    const ncmToScroll = resolveNcmToScroll(data)
+    if (!ncmToScroll) return null
+
+    return resolveAutoScrollCandidates(
+      ncmToScroll,
+      renderableCodeResults,
+      findAnchorIdForQuery,
+      getPosicaoAlvoFromResultados
+    )
+  }, [
+    data,
+    findAnchorIdForQuery,
+    getPosicaoAlvoFromResultados,
+    renderableCodeResults,
+  ])
+
+  const resolveAutoScrollTargetReadiness = useCallback(
+    (container: HTMLElement) => {
+      if (renderableCodeResults) {
+        ensureSectionAnchors(renderableCodeResults, container)
+      }
+
+      if (!targetCandidates || targetCandidates.length === 0) {
+        return false
+      }
+
+      if (findExistingTargetElement(container, targetCandidates)) {
+        return true
+      }
+
+      const posicaoAlvo = renderableCodeResults
+        ? getPosicaoAlvoFromResultados(renderableCodeResults)
+        : null
+      const candidateNcm = posicaoAlvo || data?.ncm || data?.query || ''
+      if (!candidateNcm) {
+        return false
+      }
+
+      const fallback = ensureTargetAnchorFromDataNcm(container, candidateNcm)
+      if (!fallback) {
+        return false
+      }
+
+      return !!findExistingTargetElement(container, targetCandidates)
+    },
+    [
+      renderableCodeResults,
+      data?.ncm,
+      data?.query,
+      ensureSectionAnchors,
+      getPosicaoAlvoFromResultados,
+      targetCandidates,
+    ]
+  )
+
+  // Stabilize onConsumeNewSearch callback to prevent AutoScroll effect loop
+  const onConsumeNewSearchRef = useRef(onConsumeNewSearch)
+  useEffect(() => {
+    onConsumeNewSearchRef.current = onConsumeNewSearch
+  }, [onConsumeNewSearch])
+
+  const onPersistScrollRef = useRef(onPersistScroll)
+  const hasConsumedNewSearchRef = useRef(false)
+  const isActiveRef = useRef(isActive)
+  const isNewSearchRef = useRef(isNewSearch)
+  useEffect(() => {
+    onPersistScrollRef.current = onPersistScroll
+  }, [onPersistScroll])
+  useEffect(() => {
+    hasConsumedNewSearchRef.current = false
+  }, [consumeNewSearchKey])
+  useEffect(() => {
+    isActiveRef.current = isActive
+  }, [isActive])
+  useEffect(() => {
+    isNewSearchRef.current = isNewSearch
+  }, [isNewSearch])
+  useEffect(() => {
+    onContentReadyRef.current = onContentReady
+  }, [onContentReady])
+  useEffect(() => {
+    activeAnchorIdRef.current = activeAnchorId
+  }, [activeAnchorId])
+  useEffect(() => {
+    return () => {
+      if (anchorRafRef.current !== null) {
+        cancelAnimationFrame(anchorRafRef.current)
+      }
+    }
+  }, [])
+  useEffect(() => {
+    if (isContentReady) {
+      onContentReadyRef.current?.(tabId)
+    }
+  }, [isContentReady, tabId])
+
+  // Keep active term in sync with the latest text query for this tab.
+  useEffect(() => {
+    const normalizedLatestTextQuery = (latestTextQuery || '').trim()
+    setActiveTerm((prev) =>
+      prev === normalizedLatestTextQuery ? prev : normalizedLatestTextQuery
+    )
+  }, [latestTextQuery, data?.query, tabId])
+
+  const consumeNewSearchScroll = useCallback(
+    (scrollTop?: number, force = false) => {
+      if (hasConsumedNewSearchRef.current) return
+      if (!force && (!isActiveRef.current || !isNewSearchRef.current)) return
+      hasConsumedNewSearchRef.current = true
+      onConsumeNewSearchRef.current(tabId, scrollTop)
+    },
+    [tabId]
+  )
+
+  const handleAutoScrollComplete = useCallback(
+    (success?: boolean) => {
+      if (!success) return
+      // Wrap in RAF to ensure DOM has updated/painted the scroll action
+      // before we capture the final position and update app state.
+      requestAnimationFrame(() => {
+        if (!isActiveRef.current || !isNewSearchRef.current) return
+        const currentScroll = containerRef.current?.scrollTop || 0
+        consumeNewSearchScroll(currentScroll)
+      })
+    },
+    [consumeNewSearchScroll]
+  )
+
+  const handleHighlightScrollComplete = useCallback(
+    (scrollTop: number) => {
+      if (!isActiveRef.current || !isNewSearchRef.current) return
+      consumeNewSearchScroll(scrollTop)
+    },
+    [consumeNewSearchScroll]
+  )
+
+  // `isContentReady` means the tab can render, but auto-scroll only starts
+  // once at least one candidate anchor is actually present in the DOM.
+  // Only auto-scroll when:
+  // 1. Tab is active
+  // 2. This is a NEW search (not returning to existing tab)
+  // 3. Let SearchHighlighter take precedence for text-result tabs, but keep anchor scroll as fallback elsewhere
+  const shouldAutoScroll =
+    !!targetCandidates?.length &&
+    isActive &&
+    isNewSearch &&
+    isContentReady &&
+    !searchHighlighterOwnsScroll &&
+    isTargetReady
+  useRobustScroll({
+    targetId: targetCandidates,
+    shouldScroll: shouldAutoScroll,
+    containerRef,
+    onComplete: handleAutoScrollComplete,
+    expectedTags: ['H1', 'H2', 'H3', 'H4', 'ARTICLE', 'SECTION', 'DIV'],
+  })
+
+  // Track scroll position for persistence
+  useEffect(() => {
+    const element = containerRef.current
+    if (!element) return
+
+    const handleScroll = () => {
+      const currentScroll = element.scrollTop
+      latestScrollTopRef.current = currentScroll
+      hasScrollSnapshotRef.current = true
+
+      if (!isActive) return
+
+      const persist = onPersistScrollRef.current
+      if (!persist) return
+      if (lastPersistedScrollRef.current === currentScroll) return
+
+      lastPersistedScrollRef.current = currentScroll
+      persist(tabId, currentScroll)
+    }
+
+    element.addEventListener('scroll', handleScroll, { passive: true })
+    return () => element.removeEventListener('scroll', handleScroll)
+  }, [data?.type, data?.markdown, renderableCodeResults, isActive, tabId])
+
+  useEffect(() => {
+    if (isActive) return
+
+    const persist = onPersistScrollRef.current
+    if (!persist) return
+    if (!hasScrollSnapshotRef.current) return
+
+    const currentScroll = latestScrollTopRef.current
+    if (isNewSearchRef.current && !hasConsumedNewSearchRef.current) {
+      consumeNewSearchScroll(currentScroll, true)
+      return
+    }
+    if (lastPersistedScrollRef.current === currentScroll) return
+
+    lastPersistedScrollRef.current = currentScroll
+    persist(tabId, currentScroll)
+  }, [consumeNewSearchScroll, isActive, tabId])
+
+  // Restore scroll when tab becomes active (only if NOT a new search)
+  const hasRestoredInitialScrollRef = useRef(false)
+  useEffect(() => {
+    // Skip restore if this is a new search - auto-scroll will handle positioning
+    if (!isActive || isNewSearch) return
+    // Wait until content is rendered before restoring scroll
+    if (!isContentReady) return
+    const element = containerRef.current
+    if (!element) return
+
+    if (typeof initialScrollTop !== 'number') return
+    const targetScrollTop = initialScrollTop
+
+    if (hasRestoredInitialScrollRef.current) return
+    if (Math.abs(element.scrollTop - targetScrollTop) < 1) return
+
+    let cancelled = false
+    let attempts = 0
+    let frameId = 0
+    const maxAttempts = 20
+
+    const tryRestore = () => {
+      if (cancelled) return
+
+      const currentContainer = containerRef.current
+      if (!currentContainer) return
+
+      if (Math.abs(currentContainer.scrollTop - targetScrollTop) < 1) {
+        latestScrollTopRef.current = targetScrollTop
+        hasScrollSnapshotRef.current = true
+        lastPersistedScrollRef.current = targetScrollTop
+        hasRestoredInitialScrollRef.current = true
+        return
+      }
+
+      const hasScrollableContent =
+        currentContainer.scrollHeight > currentContainer.clientHeight
+      if (!hasScrollableContent && attempts < maxAttempts) {
+        attempts += 1
+        frameId = requestAnimationFrame(tryRestore)
+        return
+      }
+
+      currentContainer.scrollTop = targetScrollTop
+      latestScrollTopRef.current = targetScrollTop
+      hasScrollSnapshotRef.current = true
+      lastPersistedScrollRef.current = targetScrollTop
+
+      if (Math.abs(currentContainer.scrollTop - targetScrollTop) < 1) {
+        hasRestoredInitialScrollRef.current = true
+        return
+      }
+
+      if (attempts < maxAttempts) {
+        attempts += 1
+        frameId = requestAnimationFrame(tryRestore)
+        return
+      }
+
+      hasRestoredInitialScrollRef.current = true
+    }
+
+    frameId = requestAnimationFrame(tryRestore)
+
+    return () => {
+      cancelled = true
+      cancelAnimationFrame(frameId)
+    }
+  }, [isActive, initialScrollTop, isNewSearch, isContentReady])
+
+  // Reset restored flag when inactive so it can restore again when returning
+  useEffect(() => {
+    if (!isActive) {
+      hasRestoredInitialScrollRef.current = false
+    }
+  }, [isActive])
+
+  // Render backend content (prefer HTML; parse markdown only as legacy fallback)
+  useEffect(() => {
+    if (data?.type === 'text') {
+      renderedMarkupKeyRef.current = null
+      setIsContentReady(true)
+      setIsFullyRendered(true)
+      return
+    }
+    if (!contentRef.current) return
+
+    const rawMarkdown =
+      typeof data?.markdown === 'string' ? data.markdown.trim() : ''
+    const markupToRender = resolveMarkupToRender(
+      rawMarkdown,
+      renderableCodeResults
+    )
+
+    if (!markupToRender) {
+      if (shouldHydrateCodeResults && missingChapterBodies.length > 0) {
+        renderedMarkupKeyRef.current = null
+        setIsContentReady(true)
+        setIsFullyRendered(false)
+        return
+      }
+      contentRef.current.textContent = ''
+      renderedMarkupKeyRef.current = null
+      setIsContentReady(true)
+      setIsFullyRendered(true)
+      return
+    }
+
+    try {
+      return renderMarkupContent({
+        rawMarkdown,
+        markupToRender,
+        isActive,
+        isContentReady,
+        refs: {
+          contentRef,
+          renderedMarkupKeyRef,
+          lastMarkupRef,
+          lastHtmlRef,
+        },
+        setIsContentReady,
+        setIsFullyRendered,
+      })
+    } catch (e) {
+      console.error('Content render error:', e)
+      if (contentRef.current)
+        contentRef.current.textContent = 'Error rendering content.'
+      renderedMarkupKeyRef.current = null
+      setIsContentReady(true)
+      setIsFullyRendered(true)
+    }
+  }, [
+    data?.markdown,
+    data?.type,
+    isActive,
+    missingChapterBodies.length,
+    renderableCodeResults,
+    shouldHydrateCodeResults,
+  ])
+
+  useEffect(() => {
+    if (!isContentReady || !containerRef.current || !targetCandidates?.length) {
+      setIsTargetReady(false)
+      return
+    }
+
+    let cancelled = false
+    let observer: MutationObserver | null = null
+    const container = containerRef.current
+
+    const syncReadiness = () => {
+      const ready = resolveAutoScrollTargetReadiness(container)
+      if (!cancelled) {
+        setIsTargetReady(ready)
+      }
+      return ready
+    }
+
+    if (syncReadiness()) {
+      return () => {
+        cancelled = true
+      }
+    }
+
+    if (!isFullyRendered) {
+      observer = new MutationObserver(() => {
+        if (syncReadiness()) {
+          observer?.disconnect()
+          observer = null
+        }
+      })
+      observer.observe(container, {
+        childList: true,
+        subtree: true,
+      })
+    }
+
+    return () => {
+      cancelled = true
+      observer?.disconnect()
+    }
+  }, [
+    isContentReady,
+    isFullyRendered,
+    resolveAutoScrollTargetReadiness,
+    targetCandidates,
+  ])
+
+  // Ensure structured section anchors exist for sidebar navigation/highlight syncing.
+  useEffect(() => {
+    if (!isContentReady || !renderableCodeResults || !containerRef.current)
+      return
+    ensureSectionAnchors(renderableCodeResults, containerRef.current)
+  }, [ensureSectionAnchors, isContentReady, renderableCodeResults])
+
+  // Query-term highlighting for code results.
+  // Always clean previous wrappers first to avoid nested/duplicated marks after query changes.
+  useEffect(() => {
+    const contentContainer = contentRef.current
+    if (!contentContainer || data?.type === 'text') return
+
+    unwrapQueryHighlights(contentContainer)
+
+    if (!isActive || !isContentReady || !activeTerm || searchHighlighterQuery) {
+      return () => {
+        const current = contentRef.current
+        if (current) unwrapQueryHighlights(current)
+      }
+    }
+
+    highlightTermInContainer(contentContainer, activeTerm)
+
+    return () => {
+      const current = contentRef.current
+      if (current) unwrapQueryHighlights(current)
+    }
+  }, [
+    activeTerm,
+    isActive,
+    isContentReady,
+    searchHighlighterQuery,
+    tabId,
+    data?.type,
+    data?.markdown,
+  ])
+
+  // Sync Sidebar to current visible anchor
+  useEffect(() => {
+    if (
+      !isActive ||
+      !isContentReady ||
+      !renderableCodeResults ||
+      !containerRef.current
+    )
+      return
+
+    const ids = getAnchorIdsFromResultados(renderableCodeResults)
+    if (ids.length === 0) return
+
+    const elements = ids
+      .map(
+        (id) =>
+          containerRef.current?.querySelector(
+            `#${CSS.escape(id)}`
+          ) as HTMLElement | null
+      )
+      .filter(Boolean) as HTMLElement[]
+
+    if (elements.length === 0) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const nextAnchorId = getNextVisibleAnchorId(entries)
+        if (!nextAnchorId) return
+
+        const manualNavigationLock = manualNavigationLockRef.current
+        if (manualNavigationLock) {
+          const now = Date.now()
+          if (now < manualNavigationLock.expiresAt) {
+            if (nextAnchorId !== manualNavigationLock.anchorId) {
+              return
+            }
+            manualNavigationLockRef.current = null
+          } else {
+            manualNavigationLockRef.current = null
+          }
+        }
+
+        scheduleActiveAnchorUpdate(
+          nextAnchorId,
+          activeAnchorIdRef,
+          anchorRafRef,
+          setActiveAnchorId
+        )
+      },
+      {
+        root: containerRef.current,
+        rootMargin: '0px 0px -60% 0px',
+        threshold: 0.1,
+      }
+    )
+
+    elements.forEach((el) => observer.observe(el))
+
+    return () => observer.disconnect()
+  }, [
+    getAnchorIdsFromResultados,
+    isActive,
+    isContentReady,
+    renderableCodeResults,
+  ])
+
+  if (!data) {
+    return <p className={styles.emptyMessage}>Sem resultados para exibir.</p>
+  }
+
+  // Text Search Rendering
+  if (data.type === 'text') {
+    return (
+      <div
+        className={`${styles.content} ${styles.textSearchContent}`}
+        ref={containerRef}
+        id={containerId}
+      >
+        <TextSearchResults
+          results={(data.results as SearchResultItem[]) || null}
+          query={latestTextQuery || data.query || ''}
+          onResultClick={(ncm: string) =>
+            globalThis.nesh.openTextResultInNewTab(
+              ncm,
+              latestTextQuery || data.query || ''
+            )
+          }
+          scrollParentRef={containerRef}
+        />
+      </div>
+    )
+  }
+
+  // Default: Code View (Markdown + Sidebar)
+  // Layout: Grid with content and sidebar (position from settings)
+  const wrapperClasses = getWrapperClasses(
+    styles,
+    sidebarCollapsed,
+    mobileMenuOpen,
+    sidebarPosition
+  )
+  const sidebarToggleLabel = getSidebarToggleLabel(sidebarCollapsed)
+  const sidebarToggleIcon = getSidebarToggleIcon(
+    sidebarPosition,
+    sidebarCollapsed
+  )
+  const contentVisibilityClass = getContentVisibilityClass(
+    styles,
+    isContentReady
+  )
+  const commentToggleLabel = getCommentToggleLabel(commentsEnabled)
+  const commentToggleClasses = getCommentToggleClassName(
+    styles,
+    commentsEnabled
+  )
+  const shouldRenderSidebar = isActive && !!renderableCodeResults
+
+  return (
+    <div className={wrapperClasses}>
+      {/* Toggle Button */}
+      <button
+        className={styles.sidebarToggle}
+        onClick={toggleSidebar}
+        aria-label={sidebarToggleLabel}
+      >
+        {sidebarToggleIcon}
+      </button>
+
+      {/* Content scroll container - Coluna 1 */}
+      <div
+        className={`${styles.content} ${contentVisibilityClass} markdown-body`}
+        ref={(el) => {
+          // containerRef = scroll container (para scroll tracking e texto selection)
+          ;(
+            containerRef as React.MutableRefObject<HTMLDivElement | null>
+          ).current = el
+        }}
+        id={containerId}
+      >
+        {/* O container interno organiza o conteúdo da esquerda verticalmente (mensagens + texto) */}
+        <div
+          style={{
+            flex: 1,
+            minWidth: 0,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          {shouldHydrateCodeResults &&
+            (isHydratingCodeResults || missingChapterBodies.length > 0) && (
+              <div className={styles.loadingSpinnerContainer}>
+                <svg className={styles.spinner} viewBox="0 0 50 50">
+                  <circle
+                    className={styles.spinnerPath}
+                    cx="25"
+                    cy="25"
+                    r="20"
+                    fill="none"
+                    strokeWidth="5"
+                  ></circle>
+                </svg>
+                <p className={styles.loadingText}>
+                  Carregando conteúdo detalhado...
+                </p>
+              </div>
+            )}
+          {!shouldHydrateCodeResults &&
+            !data.markdown &&
+            !isTipiResults(renderableCodeResults || null) && (
+              <p>Sem resultados para exibir.</p>
             )}
 
-            {/* Toggle de Comentários */}
-            {canUseRestrictedUi && (
-                <button
-                    className={commentToggleClasses}
-                    onClick={toggleComments}
-                    aria-label={commentToggleLabel}
-                    title={commentToggleLabel}
-                >
-                    💬
-                </button>
-            )}
-
-            {/* Botão bolha flutuante (aparece ao selecionar texto, se comentários ativos) */}
-            {canUseRestrictedUi && commentsEnabled && selection && (
-                <HighlightPopover
-                    selection={selection}
-                    onRequestComment={handleOpenComment}
-                    onPopoverMouseDown={onPopoverMouseDown}
-                />
-            )}
-
-            {/* Drawer de Comentários — responsivo < 1280px */}
-            {canUseRestrictedUi && commentsEnabled && (
-                <CommentDrawer
-                    open={drawerOpen}
-                    onClose={toggleDrawer}
-                    pending={pendingComment}
-                    comments={localComments}
-                    onSubmit={handleCommentSubmit}
-                    onDismiss={handleDismissComment}
-                    onEdit={editComment}
-                    onDelete={removeComment}
-                    currentUserId={userId}
-                />
-            )}
-
-            {/* Mobile Sidebar Overlay */}
-            {shouldRenderSidebar && (
-                <div 
-                    className={`${styles.mobileOverlay || ''} ${mobileMenuOpen ? (styles.mobileOverlayOpen || '') : ''}`}
-                    onClick={onCloseMobileMenu}
-                />
-            )}
-
-            {/* Sidebar Container - Coluna 2 */}
-            {shouldRenderSidebar && (
-                <div className={styles.sidebarContainer}>
-                    <Sidebar
-                        results={renderableCodeResults}
-                        onNavigate={handleNavigate}
-                        isOpen={mobileMenuOpen}
-                        onClose={onCloseMobileMenu}
-                        searchQuery={latestTextQuery || data.query || data.ncm}
-                        activeAnchorId={activeAnchorId}
-                    />
-                </div>
-            )}
+          {/* Texto renderizado via fragmentos HTML sanitizados */}
+          <div
+            className={styles.contentText}
+            ref={(el) => {
+              ;(
+                contentRef as React.MutableRefObject<HTMLDivElement | null>
+              ).current = el
+            }}
+          />
         </div>
-    );
-});
+
+        {/* Painel de Comentários (Google Docs style) — só exibido quando ativado */}
+        {canUseRestrictedUi && commentsEnabled && (
+          <CommentPanel
+            pending={pendingComment}
+            comments={localComments}
+            onSubmit={handleCommentSubmit}
+            onDismiss={handleDismissComment}
+            onEdit={editComment}
+            onDelete={removeComment}
+            currentUserId={userId}
+          />
+        )}
+      </div>
+
+      {searchHighlighterQuery && (
+        <SearchHighlighter
+          query={searchHighlighterQuery}
+          contentContainerRef={contentRef}
+          isContentReady={isContentReady}
+          isFullyRendered={isFullyRendered}
+          onHighlightScrollComplete={handleHighlightScrollComplete}
+        />
+      )}
+
+      {/* Toggle de Comentários */}
+      {canUseRestrictedUi && (
+        <button
+          className={commentToggleClasses}
+          onClick={toggleComments}
+          aria-label={commentToggleLabel}
+          title={commentToggleLabel}
+        >
+          💬
+        </button>
+      )}
+
+      {/* Botão bolha flutuante (aparece ao selecionar texto, se comentários ativos) */}
+      {canUseRestrictedUi && commentsEnabled && selection && (
+        <HighlightPopover
+          selection={selection}
+          onRequestComment={handleOpenComment}
+          onPopoverMouseDown={onPopoverMouseDown}
+        />
+      )}
+
+      {/* Drawer de Comentários — responsivo < 1280px */}
+      {canUseRestrictedUi && commentsEnabled && (
+        <CommentDrawer
+          open={drawerOpen}
+          onClose={toggleDrawer}
+          pending={pendingComment}
+          comments={localComments}
+          onSubmit={handleCommentSubmit}
+          onDismiss={handleDismissComment}
+          onEdit={editComment}
+          onDelete={removeComment}
+          currentUserId={userId}
+        />
+      )}
+
+      {/* Mobile Sidebar Overlay */}
+      {shouldRenderSidebar && (
+        <div
+          className={`${styles.mobileOverlay || ''} ${mobileMenuOpen ? styles.mobileOverlayOpen || '' : ''}`}
+          onClick={onCloseMobileMenu}
+        />
+      )}
+
+      {/* Sidebar Container - Coluna 2 */}
+      {shouldRenderSidebar && (
+        <div className={styles.sidebarContainer}>
+          <Sidebar
+            results={renderableCodeResults}
+            onNavigate={handleNavigate}
+            isOpen={mobileMenuOpen}
+            onClose={onCloseMobileMenu}
+            searchQuery={latestTextQuery || data.query || data.ncm}
+            activeAnchorId={activeAnchorId}
+          />
+        </div>
+      )}
+    </div>
+  )
+})

--- a/client/src/components/ServicesTabContent.tsx
+++ b/client/src/components/ServicesTabContent.tsx
@@ -417,7 +417,7 @@ export function ServicesTabContent({
             : EMPTY_NEBS_STATE
     ), [data.results, detailStatus, doc, nebsDetail, selectedCode]);
 
-    const title = doc === 'nbs' ? 'Resultados NEBS' : 'Resultados NEBS';
+    const title = doc === 'nbs' ? 'Resultados NBS' : 'Resultados NEBS';
     const countLabel = `${data.total} ${doc === 'nbs' ? 'itens' : 'notas'}`;
     const queryLabel = data.query.trim() || 'catalogo raiz';
     const shellClassName = `${styles.shell} ${isWorkspaceReady ? styles.shellVisible : styles.shellHidden}`;
@@ -454,3 +454,4 @@ export function ServicesTabContent({
         </section>
     );
 }
+

--- a/client/src/components/ServicesWorkspace.tsx
+++ b/client/src/components/ServicesWorkspace.tsx
@@ -1,786 +1,915 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import DOMPurify from 'dompurify';
-import { marked } from 'marked';
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import DOMPurify from 'dompurify'
+import { marked } from 'marked'
 import type {
-    NbsDetailResponse,
-    NbsServiceItem,
-    NebsDetailResponse,
-    NebsSearchItem,
-    ServiceDocType,
-} from '../types/api.types';
-import { Loading } from './Loading';
-import styles from './ServicesWorkspace.module.css';
+  NbsDetailResponse,
+  NbsServiceItem,
+  NebsDetailResponse,
+  NebsSearchItem,
+  ServiceDocType,
+} from '../types/api.types'
+import { Loading } from './Loading'
+import styles from './ServicesWorkspace.module.css'
 
-import { useSettings } from '../context/SettingsContext';
+import { useSettings } from '../context/SettingsContext'
 import {
-    getNbsChapterNotesEntry,
-    getNbsChapterNumber,
-    openNbsChapterNotesTab,
-    renderNbsChapterNotesHtml,
-} from '../utils/nbsChapterNotes';
-import { injectServiceLinks } from '../utils/serviceCodes';
+  getNbsChapterNotesEntry,
+  getNbsChapterNumber,
+  openNbsChapterNotesTab,
+  renderNbsChapterNotesHtml,
+} from '../utils/nbsChapterNotes'
+import { injectServiceLinks } from '../utils/serviceCodes'
 
 export interface ServicesWorkspaceNbsState {
-    readonly results: readonly NbsServiceItem[];
-    readonly selectedCode: string | null;
-    readonly detail: NbsDetailResponse | null;
-    readonly isSearching: boolean;
-    readonly isLoadingDetail: boolean;
-    readonly query: string;
+  readonly results: readonly NbsServiceItem[]
+  readonly selectedCode: string | null
+  readonly detail: NbsDetailResponse | null
+  readonly isSearching: boolean
+  readonly isLoadingDetail: boolean
+  readonly query: string
 }
 
 export interface ServicesWorkspaceNebsState {
-    readonly results: readonly NebsSearchItem[];
-    readonly selectedCode: string | null;
-    readonly detail: NebsDetailResponse | null;
-    readonly isSearching: boolean;
-    readonly isLoadingDetail: boolean;
-    readonly hasSearched: boolean;
+  readonly results: readonly NebsSearchItem[]
+  readonly selectedCode: string | null
+  readonly detail: NebsDetailResponse | null
+  readonly isSearching: boolean
+  readonly isLoadingDetail: boolean
+  readonly hasSearched: boolean
 }
 
 interface ServicesWorkspaceProps {
-    readonly doc: ServiceDocType;
-    readonly nbsState: ServicesWorkspaceNbsState;
-    readonly nebsState: ServicesWorkspaceNebsState;
-    readonly onSelectNbs: (code: string) => void;
-    readonly onSelectNebs: (code: string) => void;
-    readonly onSwitchDoc: (doc: ServiceDocType, query?: string) => void;
-    readonly onOpenDocInNewTab?: (doc: ServiceDocType, query?: string) => void;
+  readonly doc: ServiceDocType
+  readonly nbsState: ServicesWorkspaceNbsState
+  readonly nebsState: ServicesWorkspaceNebsState
+  readonly onSelectNbs: (code: string) => void
+  readonly onSelectNebs: (code: string) => void
+  readonly onSwitchDoc: (doc: ServiceDocType, query?: string) => void
+  readonly onOpenDocInNewTab?: (doc: ServiceDocType, query?: string) => void
 }
 
-type NoteContent = {
-    readonly body_markdown?: string | null;
-    readonly body_text?: string | null;
-} | null | undefined;
+type NoteContent =
+  | {
+      readonly body_markdown?: string | null
+      readonly body_text?: string | null
+    }
+  | null
+  | undefined
 
 type OpenCatalogDoc = (
-    targetDoc: ServiceDocType,
-    query?: string,
-    forceNewTab?: boolean,
-) => void;
+  targetDoc: ServiceDocType,
+  query?: string,
+  forceNewTab?: boolean
+) => void
 
 function escapeHtml(value: string): string {
-    return value
-        .replaceAll('&', '&amp;')
-        .replaceAll('<', '&lt;')
-        .replaceAll('>', '&gt;')
-        .replaceAll('"', '&quot;')
-        .replaceAll("'", '&#39;');
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
 }
 
 function renderPlainTextNoteHtml(noteBody: string): string {
-    const normalizedBody = noteBody.replaceAll(/\r\n?/g, '\n');
+  const normalizedBody = noteBody.replaceAll(/\r\n?/g, '\n')
 
-    return normalizedBody
-        .split(/\n{2,}/)
-        .map((paragraph) => `<p>${escapeHtml(paragraph).replaceAll('\n', '<br />')}</p>`)
-        .join('');
+  return normalizedBody
+    .split(/\n{2,}/)
+    .map(
+      (paragraph) =>
+        `<p>${escapeHtml(paragraph).replaceAll('\n', '<br />')}</p>`
+    )
+    .join('')
 }
 
 function renderNoteHtml(note: NoteContent): string {
-    const markdownBody = note?.body_markdown?.trim();
-    if (markdownBody) {
-        const renderedMarkdown = marked.parse(markdownBody, {
-            async: false,
-            breaks: true,
-            gfm: true,
-        });
+  const markdownBody = note?.body_markdown?.trim()
+  if (markdownBody) {
+    const renderedMarkdown = marked.parse(markdownBody, {
+      async: false,
+      breaks: true,
+      gfm: true,
+    })
 
-        const sanitizedMarkdown = DOMPurify.sanitize(renderedMarkdown, {
-            USE_PROFILES: { html: true },
-        });
+    const sanitizedMarkdown = DOMPurify.sanitize(renderedMarkdown, {
+      USE_PROFILES: { html: true },
+    })
 
-        if (sanitizedMarkdown.trim()) {
-            return injectServiceLinks(sanitizedMarkdown);
-        }
+    if (sanitizedMarkdown.trim()) {
+      return injectServiceLinks(sanitizedMarkdown)
     }
+  }
 
-    const plainTextBody = note?.body_text?.trim();
-    if (!plainTextBody) {
-        return '<p>Sem conteudo detalhado.</p>';
-    }
+  const plainTextBody = note?.body_text?.trim()
+  if (!plainTextBody) {
+    return '<p>Sem conteudo detalhado.</p>'
+  }
 
-    return injectServiceLinks(DOMPurify.sanitize(renderPlainTextNoteHtml(plainTextBody), {
-        USE_PROFILES: { html: true },
-    }));
+  return injectServiceLinks(
+    DOMPurify.sanitize(renderPlainTextNoteHtml(plainTextBody), {
+      USE_PROFILES: { html: true },
+    })
+  )
 }
 
 function isCodeLikeNbsQuery(query: string): boolean {
-    const rawQuery = query.trim();
-    if (!rawQuery) return false;
+  const rawQuery = query.trim()
+  if (!rawQuery) return false
 
-    const cleanQuery = rawQuery.replaceAll(/[^0-9.]/g, '');
-    return Boolean(cleanQuery) && [...rawQuery].every(
-        (character) => (character >= '0' && character <= '9') || character === '.',
-    );
+  const cleanQuery = rawQuery.replaceAll(/[^0-9.]/g, '')
+  return (
+    Boolean(cleanQuery) &&
+    [...rawQuery].every(
+      (character) => (character >= '0' && character <= '9') || character === '.'
+    )
+  )
 }
 
 function getExpandedPrefixBranch(
-    results: readonly NbsServiceItem[],
-    query: string,
-    activeCode: string,
+  results: readonly NbsServiceItem[],
+  query: string,
+  activeCode: string
 ): NbsServiceItem[] {
-    const cleanQuery = query.replaceAll(/[^0-9]/g, '');
-    if (!cleanQuery) return [];
+  const cleanQuery = query.replaceAll(/[^0-9]/g, '')
+  if (!cleanQuery) return []
 
-    return results.filter((item) => (
-        item.code !== activeCode
-        && item.code_clean.startsWith(cleanQuery)
-    ));
+  return results.filter(
+    (item) => item.code !== activeCode && item.code_clean.startsWith(cleanQuery)
+  )
 }
 
 interface NbsHierarchySectionProps {
-    readonly activeChapterNumber: string | null;
-    readonly chapterButtonHint: string;
-    readonly chapterButtonLabel: string;
-    readonly currentChapterNotesEntry: ReturnType<typeof getNbsChapterNotesEntry>;
-    readonly nbsState: ServicesWorkspaceNbsState;
-    readonly onOpenChapterNotes: () => void;
-    readonly onSelectNbs: (code: string) => void;
-    readonly visibleChildren: readonly NbsServiceItem[];
+  readonly activeChapterNumber: string | null
+  readonly chapterButtonHint: string
+  readonly chapterButtonLabel: string
+  readonly currentChapterNotesEntry: ReturnType<typeof getNbsChapterNotesEntry>
+  readonly nbsState: ServicesWorkspaceNbsState
+  readonly onOpenChapterNotes: () => void
+  readonly onSelectNbs: (code: string) => void
+  readonly visibleChildren: readonly NbsServiceItem[]
 }
 
 function NbsHierarchySection({
-    activeChapterNumber,
-    chapterButtonHint,
-    chapterButtonLabel,
-    currentChapterNotesEntry,
-    nbsState,
-    onOpenChapterNotes,
-    onSelectNbs,
-    visibleChildren,
+  activeChapterNumber,
+  chapterButtonHint,
+  chapterButtonLabel,
+  currentChapterNotesEntry,
+  nbsState,
+  onOpenChapterNotes,
+  onSelectNbs,
+  visibleChildren,
 }: Readonly<NbsHierarchySectionProps>) {
-    return (
-        <aside className={styles.leftPanel}>
-            <div className={styles.leftPanelHeader}>
-                <div className={styles.leftPanelTitle}>
-                    <button
-                        type="button"
-                        className={styles.chapterNotesButton}
-                        onClick={onOpenChapterNotes}
-                        disabled={!currentChapterNotesEntry}
-                        title={chapterButtonHint}
-                    >
-                        <span className={styles.chapterNotesEyebrow}>Explicações</span>
-                        <span>{chapterButtonLabel}</span>
-                    </button>
-                    Hierarquia NEBS
-                </div>
-                <span className={styles.sectionBadge}>
-                    {activeChapterNumber ? `Capítulo ${activeChapterNumber} ativo` : 'Capítulo ativo'}
-                </span>
-            </div>
+  return (
+    <aside className={styles.leftPanel}>
+      <div className={styles.leftPanelHeader}>
+        <div className={styles.leftPanelTitle}>
+          <button
+            type="button"
+            className={styles.chapterNotesButton}
+            onClick={onOpenChapterNotes}
+            disabled={!currentChapterNotesEntry}
+            title={chapterButtonHint}
+          >
+            <span className={styles.chapterNotesEyebrow}>Explicações</span>
+            <span>{chapterButtonLabel}</span>
+          </button>
+          Hierarquia NEBS
+        </div>
+        <span className={styles.sectionBadge}>
+          {activeChapterNumber
+            ? `Capítulo ${activeChapterNumber} ativo`
+            : 'Capítulo ativo'}
+        </span>
+      </div>
 
-            {nbsState.isSearching ? (
-                <Loading label="Buscando catalogo..." />
-            ) : nbsState.detail ? (
-                <div className={styles.hierarchyList}>
-                    {nbsState.detail.ancestors.map((item, index) => (
-                        <div key={item.code} className={styles.hierarchyNode} style={{ paddingLeft: `${index * 1.5}rem` }}>
-                            <button type="button" className={styles.nodeCard} onClick={() => onSelectNbs(item.code)}>
-                                <div className={styles.nodeIcon}>
-                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="8 17 12 21 16 17"></polyline><line x1="12" y1="12" x2="12" y2="21"></line><path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"></path></svg>
-                                </div>
-                                <div className={styles.nodeContent}>
-                                    <span className={styles.nodeLabel}>Nível {item.level}</span>
-                                    <strong className={`${styles.nodeTitle} ${styles.interactiveCode} service-code-target`} data-service-code={item.code}>{item.code} - {item.description}</strong>
-                                </div>
-                            </button>
-                        </div>
-                    ))}
-                    <div className={styles.hierarchyNode} style={{ paddingLeft: `${nbsState.detail.ancestors.length * 1.5}rem` }}>
-                        <div className={`${styles.nodeCard} ${styles.active}`} data-service-state="active">
-                            <div className={styles.nodeIcon}>
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
-                            </div>
-                            <div className={styles.nodeContent}>
-                                <span className={styles.nodeLabel}>Item Ativo</span>
-                                <strong className={`${styles.nodeTitle} ${styles.interactiveCode} service-code-target`} data-service-code={nbsState.detail.item.code}>{nbsState.detail.item.code} - {nbsState.detail.item.description}</strong>
-                            </div>
-                        </div>
-                        {visibleChildren.length > 0 && (
-                            <div className={styles.peerList} style={{ paddingLeft: '3.5rem' }}>
-                                {visibleChildren.map((child) => (
-                                    <button
-                                        type="button"
-                                        key={child.code}
-                                        className={styles.peerCard}
-                                        onClick={() => onSelectNbs(child.code)}
-                                        style={{
-                                            marginLeft: `${Math.max(0, child.level - nbsState.detail!.item.level - 1) * 1.25}rem`,
-                                        }}
-                                    >
-                                        <div className={styles.peerIcon}></div>
-                                        <span className={`${styles.nodeTitle} ${styles.interactiveCode} service-code-target`} data-service-code={child.code}>{child.code} - {child.description}</span>
-                                    </button>
-                                ))}
-                            </div>
-                        )}
-                    </div>
+      {nbsState.isSearching ? (
+        <Loading label="Buscando catalogo..." />
+      ) : nbsState.detail ? (
+        <div className={styles.hierarchyList}>
+          {nbsState.detail.ancestors.map((item, index) => (
+            <div
+              key={item.code}
+              className={styles.hierarchyNode}
+              style={{ paddingLeft: `${index * 1.5}rem` }}
+            >
+              <button
+                type="button"
+                className={styles.nodeCard}
+                onClick={() => onSelectNbs(item.code)}
+              >
+                <div className={styles.nodeIcon}>
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <polyline points="8 17 12 21 16 17"></polyline>
+                    <line x1="12" y1="12" x2="12" y2="21"></line>
+                    <path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"></path>
+                  </svg>
                 </div>
-            ) : nbsState.results.length > 0 ? (
-                <div className={styles.resultList}>
-                    {nbsState.results.map((item) => (
-                        <button
-                            key={item.code}
-                            type="button"
-                            className={`${styles.resultCard} ${nbsState.selectedCode === item.code ? styles.resultCardActive : ''}`}
-                            onClick={() => onSelectNbs(item.code)}
-                        >
-                            <div className={styles.resultMeta}>
-                                <span className={`${styles.codeBadge} ${styles.interactiveCode} service-code-target`} data-service-code={item.code}>{item.code}</span>
-                                {item.has_nebs && <span className={styles.noteBadge}>NEBS</span>}
-                            </div>
-                            <strong className={`${styles.interactiveCode} service-code-target`} data-service-code={item.code}>{item.description}</strong>
-                            <span className={styles.levelHint}>Nivel {item.level}</span>
-                        </button>
-                    ))}
+                <div className={styles.nodeContent}>
+                  <span className={styles.nodeLabel}>Nível {item.level}</span>
+                  <strong
+                    className={`${styles.nodeTitle} ${styles.interactiveCode} service-code-target`}
+                    data-service-code={item.code}
+                  >
+                    {item.code} - {item.description}
+                  </strong>
                 </div>
-            ) : (
-                <div className={styles.emptyState}>
-                    <strong>Nenhum servico encontrado</strong>
-                    <p>Tente outro codigo ou um termo mais amplo.</p>
-                </div>
+              </button>
+            </div>
+          ))}
+          <div
+            className={styles.hierarchyNode}
+            style={{
+              paddingLeft: `${nbsState.detail.ancestors.length * 1.5}rem`,
+            }}
+          >
+            <div
+              className={`${styles.nodeCard} ${styles.active}`}
+              data-service-state="active"
+            >
+              <div className={styles.nodeIcon}>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <polyline points="16 18 22 12 16 6"></polyline>
+                  <polyline points="8 6 2 12 8 18"></polyline>
+                </svg>
+              </div>
+              <div className={styles.nodeContent}>
+                <span className={styles.nodeLabel}>Item Ativo</span>
+                <strong
+                  className={`${styles.nodeTitle} ${styles.interactiveCode} service-code-target`}
+                  data-service-code={nbsState.detail.item.code}
+                >
+                  {nbsState.detail.item.code} -{' '}
+                  {nbsState.detail.item.description}
+                </strong>
+              </div>
+            </div>
+            {visibleChildren.length > 0 && (
+              <div
+                className={styles.peerList}
+                style={{ paddingLeft: '3.5rem' }}
+              >
+                {visibleChildren.map((child) => (
+                  <button
+                    type="button"
+                    key={child.code}
+                    className={styles.peerCard}
+                    onClick={() => onSelectNbs(child.code)}
+                    style={{
+                      marginLeft: `${Math.max(0, child.level - nbsState.detail!.item.level - 1) * 1.25}rem`,
+                    }}
+                  >
+                    <div className={styles.peerIcon}></div>
+                    <span
+                      className={`${styles.nodeTitle} ${styles.interactiveCode} service-code-target`}
+                      data-service-code={child.code}
+                    >
+                      {child.code} - {child.description}
+                    </span>
+                  </button>
+                ))}
+              </div>
             )}
-        </aside>
-    );
+          </div>
+        </div>
+      ) : nbsState.results.length > 0 ? (
+        <div className={styles.resultList}>
+          {nbsState.results.map((item) => (
+            <button
+              key={item.code}
+              type="button"
+              className={`${styles.resultCard} ${nbsState.selectedCode === item.code ? styles.resultCardActive : ''}`}
+              onClick={() => onSelectNbs(item.code)}
+            >
+              <div className={styles.resultMeta}>
+                <span
+                  className={`${styles.codeBadge} ${styles.interactiveCode} service-code-target`}
+                  data-service-code={item.code}
+                >
+                  {item.code}
+                </span>
+                {item.has_nebs && (
+                  <span className={styles.noteBadge}>NEBS</span>
+                )}
+              </div>
+              <strong
+                className={`${styles.interactiveCode} service-code-target`}
+                data-service-code={item.code}
+              >
+                {item.description}
+              </strong>
+              <span className={styles.levelHint}>Nivel {item.level}</span>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className={styles.emptyState}>
+          <strong>Nenhum servico encontrado</strong>
+          <p>Tente outro codigo ou um termo mais amplo.</p>
+        </div>
+      )}
+    </aside>
+  )
 }
 
 interface NbsDetailSectionProps {
-    readonly nbsNoteBodyHtml: string;
-    readonly nbsNotesContentRef: React.RefObject<HTMLDivElement | null>;
-    readonly nbsState: ServicesWorkspaceNbsState;
-    readonly openCatalogDoc: OpenCatalogDoc;
+  readonly nbsNoteBodyHtml: string
+  readonly nbsNotesContentRef: React.RefObject<HTMLDivElement | null>
+  readonly nbsState: ServicesWorkspaceNbsState
 }
 
 function NbsDetailSection({
-    nbsNoteBodyHtml,
-    nbsNotesContentRef,
-    nbsState,
-    openCatalogDoc,
+  nbsNoteBodyHtml,
+  nbsNotesContentRef,
+  nbsState,
 }: Readonly<NbsDetailSectionProps>) {
-    return (
-        <section className={styles.rightPanel}>
-            {nbsState.isLoadingDetail ? (
-                <Loading label="Montando painel..." />
-            ) : nbsState.detail ? (
-                <>
-                    <h3 className={styles.rightPanelTitle}>Detalhamento Técnico</h3>
+  return (
+    <section className={styles.rightPanel}>
+      {nbsState.isLoadingDetail ? (
+        <Loading label="Montando painel..." />
+      ) : nbsState.detail ? (
+        <>
+          <h3 className={styles.rightPanelTitle}>Detalhamento Técnico</h3>
 
-                    <section className={styles.card}>
-                        <div className={styles.cardLabel}>Descrição</div>
-                        <p>
-                            <strong className={`${styles.interactiveCode} service-code-target`} data-service-code={nbsState.detail.item.code}>{nbsState.detail.item.code}</strong>
-                            {' - '}
-                            {nbsState.detail.item.description}
-                        </p>
-                    </section>
+          <section className={styles.card}>
+            <div className={styles.cardLabel}>Descrição</div>
+            <p>
+              <strong
+                className={`${styles.interactiveCode} service-code-target`}
+                data-service-code={nbsState.detail.item.code}
+              >
+                {nbsState.detail.item.code}
+              </strong>
+              {' - '}
+              {nbsState.detail.item.description}
+            </p>
+          </section>
 
-                    <section className={styles.codeComposition}>
-                        <span className={styles.codeLabel}>COMPOSIÇÃO DO CÓDIGO</span>
-                        <div className={styles.codeBoxes}>
-                            {nbsState.detail.item.code.split('.').map((part, index) => (
-                                <React.Fragment key={index}>
-                                    <div className={styles.codeBox}>{part}</div>
-                                    {index < nbsState.detail!.item.code.split('.').length - 1 && (
-                                        <span className={styles.codeSeparator}>-</span>
-                                    )}
-                                </React.Fragment>
-                            ))}
-                        </div>
-                    </section>
+          <section className={styles.codeComposition}>
+            <span className={styles.codeLabel}>COMPOSIÇÃO DO CÓDIGO</span>
+            <div className={styles.codeBoxes}>
+              {nbsState.detail.item.code.split('.').map((part, index) => (
+                <React.Fragment key={index}>
+                  <div className={styles.codeBox}>{part}</div>
+                  {index < nbsState.detail!.item.code.split('.').length - 1 && (
+                    <span className={styles.codeSeparator}>-</span>
+                  )}
+                </React.Fragment>
+              ))}
+            </div>
+          </section>
 
-                    {nbsState.detail.nebs && (
-                        <section className={styles.notesCard} style={{ marginTop: '1rem' }}>
-                            <div className={styles.notesHeader}>
-                                <span className={styles.notesIcon}>i</span>
-                                <span>NOTAS EXPLICATIVAS</span>
-                            </div>
-                            <div
-                                ref={nbsNotesContentRef}
-                                className={styles.notesContent}
-                                dangerouslySetInnerHTML={{ __html: nbsNoteBodyHtml }}
-                            />
-                        </section>
-                    )}
-
-                    
-                </>
-            ) : (
-                <div className={styles.emptyDetail}>
-                    <strong>Selecione um servico</strong>
-                    <p>O painel mostra descricao, hierarquia e a disponibilidade de nota explicativa publicada.</p>
-                </div>
-            )}
-        </section>
-    );
+          {nbsState.detail.nebs && (
+            <section className={styles.notesCard} style={{ marginTop: '1rem' }}>
+              <div className={styles.notesHeader}>
+                <span className={styles.notesIcon}>i</span>
+                <span>NOTAS EXPLICATIVAS</span>
+              </div>
+              <div
+                ref={nbsNotesContentRef}
+                className={styles.notesContent}
+                dangerouslySetInnerHTML={{ __html: nbsNoteBodyHtml }}
+              />
+            </section>
+          )}
+        </>
+      ) : (
+        <div className={styles.emptyDetail}>
+          <strong>Selecione um servico</strong>
+          <p>
+            O painel mostra descricao, hierarquia e a disponibilidade de nota
+            explicativa publicada.
+          </p>
+        </div>
+      )}
+    </section>
+  )
 }
 
 interface NbsChapterNotesDialogProps {
-    readonly chapterNotesDialogRef: React.RefObject<HTMLDialogElement | null>;
-    readonly chapterNotesHtml: string;
-    readonly closeChapterNotes: () => void;
-    readonly currentChapterNotesEntry: ReturnType<typeof getNbsChapterNotesEntry>;
-    readonly onBackdropClick: (event: React.MouseEvent<HTMLDialogElement>) => void;
-    readonly onDialogKeyDown: (event: React.KeyboardEvent<HTMLDialogElement>) => void;
+  readonly chapterNotesDialogRef: React.RefObject<HTMLDialogElement | null>
+  readonly chapterNotesHtml: string
+  readonly closeChapterNotes: () => void
+  readonly currentChapterNotesEntry: ReturnType<typeof getNbsChapterNotesEntry>
+  readonly onBackdropClick: (event: React.MouseEvent<HTMLDialogElement>) => void
+  readonly onDialogKeyDown: (
+    event: React.KeyboardEvent<HTMLDialogElement>
+  ) => void
 }
 
 function NbsChapterNotesDialog({
-    chapterNotesDialogRef,
-    chapterNotesHtml,
-    closeChapterNotes,
-    currentChapterNotesEntry,
-    onBackdropClick,
-    onDialogKeyDown,
+  chapterNotesDialogRef,
+  chapterNotesHtml,
+  closeChapterNotes,
+  currentChapterNotesEntry,
+  onBackdropClick,
+  onDialogKeyDown,
 }: Readonly<NbsChapterNotesDialogProps>) {
-    return (
-        <dialog
-            ref={chapterNotesDialogRef}
-            className={styles.chapterNotesDialog}
-            aria-labelledby="nbs-chapter-notes-title"
-            onClose={closeChapterNotes}
-            onCancel={closeChapterNotes}
-            onClick={onBackdropClick}
-            onKeyDown={onDialogKeyDown}
-        >
-            {currentChapterNotesEntry && (
-                <section className={styles.chapterNotesSheet}>
-                    <div className={styles.chapterNotesSheetHeader}>
-                        <div className={styles.chapterNotesSheetCopy}>
-                            <span className={styles.chapterNotesSheetEyebrow}>NEBS • Explicações do capítulo</span>
-                            <h3 id="nbs-chapter-notes-title">
-                                Capítulo {currentChapterNotesEntry.chapter} - {currentChapterNotesEntry.title}
-                            </h3>
-                            <p>
-                                Notas oficiais extraídas do Anexo I da Portaria Conjunta RFB/SCS nº 1.429, de 12 de setembro de 2018.
-                            </p>
-                        </div>
-                        <button
-                            type="button"
-                            className={styles.chapterNotesClose}
-                            aria-label="Fechar explicações do capítulo"
-                            onClick={closeChapterNotes}
-                        >
-                            ×
-                        </button>
-                    </div>
+  return (
+    <dialog
+      ref={chapterNotesDialogRef}
+      className={styles.chapterNotesDialog}
+      aria-labelledby="nbs-chapter-notes-title"
+      onClose={closeChapterNotes}
+      onCancel={closeChapterNotes}
+      onClick={onBackdropClick}
+      onKeyDown={onDialogKeyDown}
+    >
+      {currentChapterNotesEntry && (
+        <section className={styles.chapterNotesSheet}>
+          <div className={styles.chapterNotesSheetHeader}>
+            <div className={styles.chapterNotesSheetCopy}>
+              <span className={styles.chapterNotesSheetEyebrow}>
+                NEBS • Explicações do capítulo
+              </span>
+              <h3 id="nbs-chapter-notes-title">
+                Capítulo {currentChapterNotesEntry.chapter} -{' '}
+                {currentChapterNotesEntry.title}
+              </h3>
+              <p>
+                Notas oficiais extraídas do Anexo I da Portaria Conjunta RFB/SCS
+                nº 1.429, de 12 de setembro de 2018.
+              </p>
+            </div>
+            <button
+              type="button"
+              className={styles.chapterNotesClose}
+              aria-label="Fechar explicações do capítulo"
+              onClick={closeChapterNotes}
+            >
+              ×
+            </button>
+          </div>
 
-                    <div className={styles.chapterNotesSheetBody}>
-                        <section className={styles.notesCard}>
-                            <div className={styles.notesHeader}>
-                                <span className={styles.notesIcon}>i</span>
-                                <span>NOTAS DO CAPÍTULO</span>
-                            </div>
-                            <div
-                                className={`${styles.notesContent} ${styles.chapterNotesContent}`}
-                                dangerouslySetInnerHTML={{ __html: chapterNotesHtml }}
-                            />
-                        </section>
-                    </div>
-                </section>
-            )}
-        </dialog>
-    );
+          <div className={styles.chapterNotesSheetBody}>
+            <section className={styles.notesCard}>
+              <div className={styles.notesHeader}>
+                <span className={styles.notesIcon}>i</span>
+                <span>NOTAS DO CAPÍTULO</span>
+              </div>
+              <div
+                className={`${styles.notesContent} ${styles.chapterNotesContent}`}
+                dangerouslySetInnerHTML={{ __html: chapterNotesHtml }}
+              />
+            </section>
+          </div>
+        </section>
+      )}
+    </dialog>
+  )
 }
 
 interface NbsWorkspaceViewProps {
-    readonly activeChapterNumber: string | null;
-    readonly chapterNotesDialogRef: React.RefObject<HTMLDialogElement | null>;
-    readonly chapterNotesHtml: string;
-    readonly currentChapterNotesEntry: ReturnType<typeof getNbsChapterNotesEntry>;
-    readonly nbsChapterNotesNewTab: boolean;
-    readonly nbsNoteBodyHtml: string;
-    readonly nbsNotesContentRef: React.RefObject<HTMLDivElement | null>;
-    readonly nbsPrefixAutoExpand: boolean;
-    readonly nbsState: ServicesWorkspaceNbsState;
-    readonly onSelectNbs: (code: string) => void;
-    readonly openCatalogDoc: OpenCatalogDoc;
-    readonly setIsChapterNotesOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  readonly activeChapterNumber: string | null
+  readonly chapterNotesDialogRef: React.RefObject<HTMLDialogElement | null>
+  readonly chapterNotesHtml: string
+  readonly currentChapterNotesEntry: ReturnType<typeof getNbsChapterNotesEntry>
+  readonly nbsChapterNotesNewTab: boolean
+  readonly nbsNoteBodyHtml: string
+  readonly nbsNotesContentRef: React.RefObject<HTMLDivElement | null>
+  readonly nbsPrefixAutoExpand: boolean
+  readonly nbsState: ServicesWorkspaceNbsState
+  readonly onSelectNbs: (code: string) => void
+  readonly setIsChapterNotesOpen: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 function NbsWorkspaceView({
-    activeChapterNumber,
-    chapterNotesDialogRef,
-    chapterNotesHtml,
-    currentChapterNotesEntry,
-    nbsChapterNotesNewTab,
-    nbsNoteBodyHtml,
-    nbsNotesContentRef,
-    nbsPrefixAutoExpand,
-    nbsState,
-    onSelectNbs,
-    openCatalogDoc,
-    setIsChapterNotesOpen,
+  activeChapterNumber,
+  chapterNotesDialogRef,
+  chapterNotesHtml,
+  currentChapterNotesEntry,
+  nbsChapterNotesNewTab,
+  nbsNoteBodyHtml,
+  nbsNotesContentRef,
+  nbsPrefixAutoExpand,
+  nbsState,
+  onSelectNbs,
+  setIsChapterNotesOpen,
 }: Readonly<NbsWorkspaceViewProps>) {
-    const chapterButtonLabel = activeChapterNumber
-        ? `Capítulo ${activeChapterNumber}`
-        : 'Explicações do capítulo';
-    const chapterButtonHint = currentChapterNotesEntry?.hasOfficialNotes
-        ? 'Abrir explicações oficiais do capítulo'
-        : 'Abrir resumo do capítulo';
+  const chapterButtonLabel = activeChapterNumber
+    ? `Capítulo ${activeChapterNumber}`
+    : 'Explicações do capítulo'
+  const chapterButtonHint = currentChapterNotesEntry?.hasOfficialNotes
+    ? 'Abrir explicações oficiais do capítulo'
+    : 'Abrir resumo do capítulo'
 
-    const closeChapterNotes = () => {
-        setIsChapterNotesOpen(false);
-    };
+  const closeChapterNotes = () => {
+    setIsChapterNotesOpen(false)
+  }
 
-    const handleChapterNotesDialogKeyDown = (
-        event: React.KeyboardEvent<HTMLDialogElement>,
-    ) => {
-        if (event.key === 'Escape') {
-            closeChapterNotes();
-        }
-    };
+  const handleChapterNotesDialogKeyDown = (
+    event: React.KeyboardEvent<HTMLDialogElement>
+  ) => {
+    if (event.key === 'Escape') {
+      closeChapterNotes()
+    }
+  }
 
-    const handleChapterNotesBackdropClick = (
-        event: React.MouseEvent<HTMLDialogElement>,
-    ) => {
-        if (event.target === event.currentTarget) {
-            closeChapterNotes();
-        }
-    };
+  const handleChapterNotesBackdropClick = (
+    event: React.MouseEvent<HTMLDialogElement>
+  ) => {
+    if (event.target === event.currentTarget) {
+      closeChapterNotes()
+    }
+  }
 
-    const handleOpenChapterNotes = () => {
-        if (!currentChapterNotesEntry) return;
-        if (nbsChapterNotesNewTab) {
-            openNbsChapterNotesTab(currentChapterNotesEntry);
-            return;
-        }
+  const handleOpenChapterNotes = () => {
+    if (!currentChapterNotesEntry) return
+    if (nbsChapterNotesNewTab) {
+      openNbsChapterNotesTab(currentChapterNotesEntry)
+      return
+    }
 
-        setIsChapterNotesOpen(true);
-    };
+    setIsChapterNotesOpen(true)
+  }
 
-    const autoExpandedDescendants = (
-        nbsPrefixAutoExpand
-        && isCodeLikeNbsQuery(nbsState.query)
-        && nbsState.detail
-    )
-        ? getExpandedPrefixBranch(
-            nbsState.detail.chapter_items || nbsState.results,
-            nbsState.query,
-            nbsState.detail.item.code,
+  const autoExpandedDescendants =
+    nbsPrefixAutoExpand && isCodeLikeNbsQuery(nbsState.query) && nbsState.detail
+      ? getExpandedPrefixBranch(
+          nbsState.detail.chapter_items || nbsState.results,
+          nbsState.query,
+          nbsState.detail.item.code
         )
-        : [];
-    const visibleChildren = autoExpandedDescendants.length > 0
-        ? autoExpandedDescendants
-        : nbsState.detail?.children || [];
+      : []
+  const visibleChildren =
+    autoExpandedDescendants.length > 0
+      ? autoExpandedDescendants
+      : nbsState.detail?.children || []
 
-    return (
-        <div className={styles.body}>
-            <NbsHierarchySection
-                activeChapterNumber={activeChapterNumber}
-                chapterButtonHint={chapterButtonHint}
-                chapterButtonLabel={chapterButtonLabel}
-                currentChapterNotesEntry={currentChapterNotesEntry}
-                nbsState={nbsState}
-                onOpenChapterNotes={handleOpenChapterNotes}
-                onSelectNbs={onSelectNbs}
-                visibleChildren={visibleChildren}
-            />
-            <NbsDetailSection
-                nbsNoteBodyHtml={nbsNoteBodyHtml}
-                nbsNotesContentRef={nbsNotesContentRef}
-                nbsState={nbsState}
-                openCatalogDoc={openCatalogDoc}
-            />
-            <NbsChapterNotesDialog
-                chapterNotesDialogRef={chapterNotesDialogRef}
-                chapterNotesHtml={chapterNotesHtml}
-                closeChapterNotes={closeChapterNotes}
-                currentChapterNotesEntry={currentChapterNotesEntry}
-                onBackdropClick={handleChapterNotesBackdropClick}
-                onDialogKeyDown={handleChapterNotesDialogKeyDown}
-            />
-        </div>
-    );
+  return (
+    <div className={styles.body}>
+      <NbsHierarchySection
+        activeChapterNumber={activeChapterNumber}
+        chapterButtonHint={chapterButtonHint}
+        chapterButtonLabel={chapterButtonLabel}
+        currentChapterNotesEntry={currentChapterNotesEntry}
+        nbsState={nbsState}
+        onOpenChapterNotes={handleOpenChapterNotes}
+        onSelectNbs={onSelectNbs}
+        visibleChildren={visibleChildren}
+      />
+      <NbsDetailSection
+        nbsNoteBodyHtml={nbsNoteBodyHtml}
+        nbsNotesContentRef={nbsNotesContentRef}
+        nbsState={nbsState}
+      />
+      <NbsChapterNotesDialog
+        chapterNotesDialogRef={chapterNotesDialogRef}
+        chapterNotesHtml={chapterNotesHtml}
+        closeChapterNotes={closeChapterNotes}
+        currentChapterNotesEntry={currentChapterNotesEntry}
+        onBackdropClick={handleChapterNotesBackdropClick}
+        onDialogKeyDown={handleChapterNotesDialogKeyDown}
+      />
+    </div>
+  )
 }
 
 interface NebsResultsSectionProps {
-    readonly nebsState: ServicesWorkspaceNebsState;
-    readonly onSelectNebs: (code: string) => void;
+  readonly nebsState: ServicesWorkspaceNebsState
+  readonly onSelectNebs: (code: string) => void
 }
 
 function NebsResultsSection({
-    nebsState,
-    onSelectNebs,
+  nebsState,
+  onSelectNebs,
 }: Readonly<NebsResultsSectionProps>) {
-    return (
-        <aside className={styles.sidebar}>
-            <div className={styles.sidebarHeader}>
-                <span>Resultados</span>
-                <strong>{nebsState.results.length}</strong>
-            </div>
+  return (
+    <aside className={styles.sidebar}>
+      <div className={styles.sidebarHeader}>
+        <span>Resultados</span>
+        <strong>{nebsState.results.length}</strong>
+      </div>
 
-            {nebsState.isSearching ? (
-                <Loading label="Buscando notas..." />
-            ) : !nebsState.hasSearched ? (
-                <div className={styles.emptyState}>
-                    <strong>Busque uma nota explicativa</strong>
-                    <p>Digite um codigo NEBS ou um termo textual para pesquisar a NEBS.</p>
-                </div>
-            ) : nebsState.results.length > 0 ? (
-                <div className={styles.resultList}>
-                    {nebsState.results.map((item) => (
-                        <button
-                            key={item.code}
-                            type="button"
-                            className={`${styles.resultCard} ${nebsState.selectedCode === item.code ? styles.resultCardActive : ''}`}
-                            onClick={() => onSelectNebs(item.code)}
-                        >
-                            <div className={styles.resultMeta}>
-                                <span className={`${styles.codeBadge} ${styles.interactiveCode} service-code-target`} data-service-code={item.code}>{item.code}</span>
-                                <span className={styles.noteBadge}>NEBS</span>
-                            </div>
-                            <strong className={`${styles.interactiveCode} service-code-target`} data-service-code={item.code}>{item.code} - {item.title}</strong>
-                            <span className={styles.resultExcerpt}>{item.excerpt}</span>
-                            <span className={styles.levelHint}>Paginas {item.page_start} a {item.page_end}</span>
-                        </button>
-                    ))}
-                </div>
-            ) : (
-                <div className={styles.emptyState}>
-                    <strong>Nenhuma nota encontrada</strong>
-                    <p>Tente um termo mais amplo ou um codigo completo.</p>
-                </div>
-            )}
-        </aside>
-    );
+      {nebsState.isSearching ? (
+        <Loading label="Buscando notas..." />
+      ) : !nebsState.hasSearched ? (
+        <div className={styles.emptyState}>
+          <strong>Busque uma nota explicativa</strong>
+          <p>
+            Digite um codigo NEBS ou um termo textual para pesquisar a NEBS.
+          </p>
+        </div>
+      ) : nebsState.results.length > 0 ? (
+        <div className={styles.resultList}>
+          {nebsState.results.map((item) => (
+            <button
+              key={item.code}
+              type="button"
+              className={`${styles.resultCard} ${nebsState.selectedCode === item.code ? styles.resultCardActive : ''}`}
+              onClick={() => onSelectNebs(item.code)}
+            >
+              <div className={styles.resultMeta}>
+                <span
+                  className={`${styles.codeBadge} ${styles.interactiveCode} service-code-target`}
+                  data-service-code={item.code}
+                >
+                  {item.code}
+                </span>
+                <span className={styles.noteBadge}>NEBS</span>
+              </div>
+              <strong
+                className={`${styles.interactiveCode} service-code-target`}
+                data-service-code={item.code}
+              >
+                {item.code} - {item.title}
+              </strong>
+              <span className={styles.resultExcerpt}>{item.excerpt}</span>
+              <span className={styles.levelHint}>
+                Paginas {item.page_start} a {item.page_end}
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className={styles.emptyState}>
+          <strong>Nenhuma nota encontrada</strong>
+          <p>Tente um termo mais amplo ou um codigo completo.</p>
+        </div>
+      )}
+    </aside>
+  )
 }
 
 interface NebsDetailSectionProps {
-    readonly nebsNoteBodyHtml: string;
-    readonly nebsState: ServicesWorkspaceNebsState;
-    readonly openCatalogDoc: OpenCatalogDoc;
+  readonly nebsNoteBodyHtml: string
+  readonly nebsState: ServicesWorkspaceNebsState
+  readonly openCatalogDoc: OpenCatalogDoc
 }
 
 function NebsDetailSection({
-    nebsNoteBodyHtml,
-    nebsState,
-    openCatalogDoc,
+  nebsNoteBodyHtml,
+  nebsState,
+  openCatalogDoc,
 }: Readonly<NebsDetailSectionProps>) {
-    return (
-        <section className={styles.detailPanel}>
-            {nebsState.isLoadingDetail ? (
-                <Loading label="Montando nota..." />
-            ) : nebsState.detail ? (
-                <>
-                    <div className={styles.detailHero}>
-                        <div className={`${styles.detailCode} ${styles.interactiveCode} service-code-target`} data-service-code={nebsState.detail.entry.code}>{nebsState.detail.entry.code}</div>
-                        <h3>{nebsState.detail.entry.title}</h3>
-                        <p className={styles.heroMeta}>
-                            {nebsState.detail.entry.section_title || 'Secao nao informada'} • Paginas {nebsState.detail.entry.page_start} a {nebsState.detail.entry.page_end}
-                        </p>
-                    </div>
+  return (
+    <section className={styles.detailPanel}>
+      {nebsState.isLoadingDetail ? (
+        <Loading label="Montando nota..." />
+      ) : nebsState.detail ? (
+        <>
+          <div className={styles.detailHero}>
+            <div
+              className={`${styles.detailCode} ${styles.interactiveCode} service-code-target`}
+              data-service-code={nebsState.detail.entry.code}
+            >
+              {nebsState.detail.entry.code}
+            </div>
+            <h3>{nebsState.detail.entry.title}</h3>
+            <p className={styles.heroMeta}>
+              {nebsState.detail.entry.section_title || 'Secao nao informada'} •
+              Paginas {nebsState.detail.entry.page_start} a{' '}
+              {nebsState.detail.entry.page_end}
+            </p>
+          </div>
 
-                    <div className={styles.breadcrumbs} aria-label="Hierarquia NEBS">
-                        {nebsState.detail.ancestors.map((ancestor) => (
-                            <button
-                                key={ancestor.code}
-                                type="button"
-                                className={`${styles.crumb} ${styles.interactiveCode} service-code-target`}
-                                data-service-code={ancestor.code}
-                                onClick={() => openCatalogDoc('nbs', ancestor.code)}
-                            >
-                                {ancestor.code}
-                            </button>
-                        ))}
-                        <button
-                            type="button"
-                            className={`${styles.crumbCurrentButton} ${styles.interactiveCode} service-code-target`}
-                            data-service-code={nebsState.detail?.item.code}
-                            onClick={() => openCatalogDoc('nbs', nebsState.detail?.item.code)}
-                        >
-                            {nebsState.detail.item.code}
-                        </button>
-                    </div>
+          <div className={styles.breadcrumbs} aria-label="Hierarquia NEBS">
+            {nebsState.detail.ancestors.map((ancestor) => (
+              <button
+                key={ancestor.code}
+                type="button"
+                className={`${styles.crumb} ${styles.interactiveCode} service-code-target`}
+                data-service-code={ancestor.code}
+                onClick={() => openCatalogDoc('nbs', ancestor.code)}
+              >
+                {ancestor.code}
+              </button>
+            ))}
+            <button
+              type="button"
+              className={`${styles.crumbCurrentButton} ${styles.interactiveCode} service-code-target`}
+              data-service-code={nebsState.detail?.item.code}
+              onClick={() => openCatalogDoc('nbs', nebsState.detail?.item.code)}
+            >
+              {nebsState.detail.item.code}
+            </button>
+          </div>
 
-                    <div className={styles.detailGrid}>
-                        <section className={styles.card}>
-                            <div className={styles.cardLabel}>Servico NEBS vinculado</div>
-                            <p>{nebsState.detail.item.description}</p>
-                        </section>
+          <div className={styles.detailGrid}>
+            <section className={styles.card}>
+              <div className={styles.cardLabel}>Servico NEBS vinculado</div>
+              <p>{nebsState.detail.item.description}</p>
+            </section>
 
-                        <section className={styles.card}>
-                            <div className={styles.cardLabel}>Origem</div>
-                            <p>{nebsState.detail.entry.section_title || 'Secao nao identificada'}</p>
-                        </section>
-                    </div>
+            <section className={styles.card}>
+              <div className={styles.cardLabel}>Origem</div>
+              <p>
+                {nebsState.detail.entry.section_title ||
+                  'Secao nao identificada'}
+              </p>
+            </section>
+          </div>
 
-                    <section className={styles.card}>
-                        <div className={styles.cardLabel}>Conteudo da nota</div>
-                        <div
-                            className={styles.noteBody}
-                            dangerouslySetInnerHTML={{ __html: nebsNoteBodyHtml }}
-                        />
-                    </section>
+          <section className={styles.card}>
+            <div className={styles.cardLabel}>Conteudo da nota</div>
+            <div
+              className={styles.noteBody}
+              dangerouslySetInnerHTML={{ __html: nebsNoteBodyHtml }}
+            />
+          </section>
 
-                    <div className={styles.detailActions}>
-                        <button
-                            type="button"
-                            className={styles.secondaryAction}
-                            onClick={() => openCatalogDoc('nbs', nebsState.detail?.item.code)}
-                        >
-                            Abrir item NEBS relacionado
-                        </button>
-                    </div>
-                </>
-            ) : (
-                <div className={styles.emptyDetail}>
-                    <strong>Selecione uma nota</strong>
-                    <p>O painel mostra a nota explicativa publicada, a seção de origem e o vínculo com o serviço NEBS.</p>
-                </div>
-            )}
-        </section>
-    );
+          <div className={styles.detailActions}>
+            <button
+              type="button"
+              className={styles.secondaryAction}
+              onClick={() => openCatalogDoc('nbs', nebsState.detail?.item.code)}
+            >
+              Abrir item NEBS relacionado
+            </button>
+          </div>
+        </>
+      ) : (
+        <div className={styles.emptyDetail}>
+          <strong>Selecione uma nota</strong>
+          <p>
+            O painel mostra a nota explicativa publicada, a seção de origem e o
+            vínculo com o serviço NEBS.
+          </p>
+        </div>
+      )}
+    </section>
+  )
 }
 
 interface NebsWorkspaceViewProps {
-    readonly nebsNoteBodyHtml: string;
-    readonly nebsState: ServicesWorkspaceNebsState;
-    readonly onSelectNebs: (code: string) => void;
-    readonly openCatalogDoc: OpenCatalogDoc;
+  readonly nebsNoteBodyHtml: string
+  readonly nebsState: ServicesWorkspaceNebsState
+  readonly onSelectNebs: (code: string) => void
+  readonly openCatalogDoc: OpenCatalogDoc
 }
 
 function NebsWorkspaceView({
-    nebsNoteBodyHtml,
-    nebsState,
-    onSelectNebs,
-    openCatalogDoc,
+  nebsNoteBodyHtml,
+  nebsState,
+  onSelectNebs,
+  openCatalogDoc,
 }: Readonly<NebsWorkspaceViewProps>) {
-    return (
-        <div className={styles.body}>
-            <NebsResultsSection
-                nebsState={nebsState}
-                onSelectNebs={onSelectNebs}
-            />
-            <NebsDetailSection
-                nebsNoteBodyHtml={nebsNoteBodyHtml}
-                nebsState={nebsState}
-                openCatalogDoc={openCatalogDoc}
-            />
-        </div>
-    );
+  return (
+    <div className={styles.body}>
+      <NebsResultsSection nebsState={nebsState} onSelectNebs={onSelectNebs} />
+      <NebsDetailSection
+        nebsNoteBodyHtml={nebsNoteBodyHtml}
+        nebsState={nebsState}
+        openCatalogDoc={openCatalogDoc}
+      />
+    </div>
+  )
 }
 
 export function ServicesWorkspace({
-    doc,
-    nbsState,
-    nebsState,
-    onSelectNbs,
-    onSelectNebs,
-    onSwitchDoc,
-    onOpenDocInNewTab,
+  doc,
+  nbsState,
+  nebsState,
+  onSelectNbs,
+  onSelectNebs,
+  onSwitchDoc,
+  onOpenDocInNewTab,
 }: Readonly<ServicesWorkspaceProps>) {
-    const nbsNoteBodyHtml = useMemo(() => renderNoteHtml(nbsState.detail?.nebs), [nbsState.detail]);
-    const nebsNoteBodyHtml = useMemo(() => renderNoteHtml(nebsState.detail?.entry), [nebsState.detail]);
-    const { openNewTab, nbsPrefixAutoExpand, nbsChapterNotesNewTab } = useSettings();
-    const [isChapterNotesOpen, setIsChapterNotesOpen] = useState(false);
-    const chapterNotesDialogRef = useRef<HTMLDialogElement | null>(null);
-    const nbsNotesContentRef = useRef<HTMLDivElement | null>(null);
-    const chapterCodeSource = doc === 'nbs'
-        ? (nbsState.detail?.item.code || nbsState.selectedCode || (
-            isCodeLikeNbsQuery(nbsState.query) ? nbsState.query : null
-        ))
-        : null;
-    const activeChapterNumber = getNbsChapterNumber(chapterCodeSource);
-    const currentChapterNotesEntry = getNbsChapterNotesEntry(chapterCodeSource);
-    const chapterNotesHtml = currentChapterNotesEntry
-        ? renderNbsChapterNotesHtml(currentChapterNotesEntry)
-        : '';
+  const nbsNoteBodyHtml = useMemo(
+    () => renderNoteHtml(nbsState.detail?.nebs),
+    [nbsState.detail]
+  )
+  const nebsNoteBodyHtml = useMemo(
+    () => renderNoteHtml(nebsState.detail?.entry),
+    [nebsState.detail]
+  )
+  const { openNewTab, nbsPrefixAutoExpand, nbsChapterNotesNewTab } =
+    useSettings()
+  const [isChapterNotesOpen, setIsChapterNotesOpen] = useState(false)
+  const chapterNotesDialogRef = useRef<HTMLDialogElement | null>(null)
+  const nbsNotesContentRef = useRef<HTMLDivElement | null>(null)
+  const chapterCodeSource =
+    doc === 'nbs'
+      ? nbsState.detail?.item.code ||
+        nbsState.selectedCode ||
+        (isCodeLikeNbsQuery(nbsState.query) ? nbsState.query : null)
+      : null
+  const activeChapterNumber = getNbsChapterNumber(chapterCodeSource)
+  const currentChapterNotesEntry = getNbsChapterNotesEntry(chapterCodeSource)
+  const chapterNotesHtml = currentChapterNotesEntry
+    ? renderNbsChapterNotesHtml(currentChapterNotesEntry)
+    : ''
 
-    const openCatalogDoc = (targetDoc: ServiceDocType, query?: string, forceNewTab?: boolean) => {
-        if (!query) return;
+  const openCatalogDoc = (
+    targetDoc: ServiceDocType,
+    query?: string,
+    forceNewTab?: boolean
+  ) => {
+    if (!query) return
 
-        if ((openNewTab || forceNewTab) && onOpenDocInNewTab) {
-            onOpenDocInNewTab(targetDoc, query);
-            return;
-        }
-
-        onSwitchDoc(targetDoc, query);
-    };
-
-    useEffect(() => {
-        const container = nbsNotesContentRef.current;
-        if (!container) return;
-
-        const handlePointer = (event: MouseEvent) => {
-            if (event.type === 'mousedown' && event.button !== 1) {
-                return;
-            }
-
-            const target = event.target;
-            if (!(target instanceof Element)) return;
-
-            const serviceLink = target.closest('.service-smart-link, .service-code-target');
-            if (!(serviceLink instanceof HTMLElement) || !container.contains(serviceLink)) {
-                return;
-            }
-
-            const serviceCode = serviceLink.dataset.serviceCode;
-            if (!serviceCode) return;
-
-            event.preventDefault();
-            event.stopPropagation();
-
-            const forceNewTab = event.metaKey || event.ctrlKey || event.button === 1;
-            openCatalogDoc('nebs', serviceCode, forceNewTab);
-        };
-
-        container.addEventListener('mousedown', handlePointer);
-        container.addEventListener('click', handlePointer);
-
-        return () => {
-            container.removeEventListener('mousedown', handlePointer);
-            container.removeEventListener('click', handlePointer);
-        };
-    }, [openCatalogDoc]);
-
-    useEffect(() => {
-        if (!isChapterNotesOpen || !currentChapterNotesEntry) {
-            if (chapterNotesDialogRef.current?.open) {
-                chapterNotesDialogRef.current.close();
-            }
-            return;
-        }
-
-        const dialog = chapterNotesDialogRef.current;
-        if (!dialog) return;
-
-        if (!dialog.open) {
-            dialog.showModal();
-        }
-    }, [currentChapterNotesEntry, isChapterNotesOpen]);
-
-    useEffect(() => {
-        if (isChapterNotesOpen && !currentChapterNotesEntry) {
-            setIsChapterNotesOpen(false);
-        }
-    }, [currentChapterNotesEntry, isChapterNotesOpen]);
-
-    if (doc === 'nbs') {
-        return (
-            <NbsWorkspaceView
-                activeChapterNumber={activeChapterNumber}
-                chapterNotesDialogRef={chapterNotesDialogRef}
-                chapterNotesHtml={chapterNotesHtml}
-                currentChapterNotesEntry={currentChapterNotesEntry}
-                nbsChapterNotesNewTab={nbsChapterNotesNewTab}
-                nbsNoteBodyHtml={nbsNoteBodyHtml}
-                nbsNotesContentRef={nbsNotesContentRef}
-                nbsPrefixAutoExpand={nbsPrefixAutoExpand}
-                nbsState={nbsState}
-                onSelectNbs={onSelectNbs}
-                openCatalogDoc={openCatalogDoc}
-                setIsChapterNotesOpen={setIsChapterNotesOpen}
-            />
-        );
+    if ((openNewTab || forceNewTab) && onOpenDocInNewTab) {
+      onOpenDocInNewTab(targetDoc, query)
+      return
     }
 
+    onSwitchDoc(targetDoc, query)
+  }
+
+  useEffect(() => {
+    const container = nbsNotesContentRef.current
+    if (!container) return
+
+    const handlePointer = (event: MouseEvent) => {
+      if (event.type === 'mousedown' && event.button !== 1) {
+        return
+      }
+
+      const target = event.target
+      if (!(target instanceof Element)) return
+
+      const serviceLink = target.closest(
+        '.service-smart-link, .service-code-target'
+      )
+      if (
+        !(serviceLink instanceof HTMLElement) ||
+        !container.contains(serviceLink)
+      ) {
+        return
+      }
+
+      const serviceCode = serviceLink.dataset.serviceCode
+      if (!serviceCode) return
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      const forceNewTab = event.metaKey || event.ctrlKey || event.button === 1
+      openCatalogDoc('nebs', serviceCode, forceNewTab)
+    }
+
+    container.addEventListener('mousedown', handlePointer)
+    container.addEventListener('click', handlePointer)
+
+    return () => {
+      container.removeEventListener('mousedown', handlePointer)
+      container.removeEventListener('click', handlePointer)
+    }
+  }, [openCatalogDoc])
+
+  useEffect(() => {
+    if (!isChapterNotesOpen || !currentChapterNotesEntry) {
+      if (chapterNotesDialogRef.current?.open) {
+        chapterNotesDialogRef.current.close()
+      }
+      return
+    }
+
+    const dialog = chapterNotesDialogRef.current
+    if (!dialog) return
+
+    if (!dialog.open) {
+      dialog.showModal()
+    }
+  }, [currentChapterNotesEntry, isChapterNotesOpen])
+
+  useEffect(() => {
+    if (isChapterNotesOpen && !currentChapterNotesEntry) {
+      setIsChapterNotesOpen(false)
+    }
+  }, [currentChapterNotesEntry, isChapterNotesOpen])
+
+  if (doc === 'nbs') {
     return (
-        <NebsWorkspaceView
-            nebsNoteBodyHtml={nebsNoteBodyHtml}
-            nebsState={nebsState}
-            onSelectNebs={onSelectNebs}
-            openCatalogDoc={openCatalogDoc}
-        />
-    );
+      <NbsWorkspaceView
+        activeChapterNumber={activeChapterNumber}
+        chapterNotesDialogRef={chapterNotesDialogRef}
+        chapterNotesHtml={chapterNotesHtml}
+        currentChapterNotesEntry={currentChapterNotesEntry}
+        nbsChapterNotesNewTab={nbsChapterNotesNewTab}
+        nbsNoteBodyHtml={nbsNoteBodyHtml}
+        nbsNotesContentRef={nbsNotesContentRef}
+        nbsPrefixAutoExpand={nbsPrefixAutoExpand}
+        nbsState={nbsState}
+        onSelectNbs={onSelectNbs}
+        setIsChapterNotesOpen={setIsChapterNotesOpen}
+      />
+    )
+  }
+
+  return (
+    <NebsWorkspaceView
+      nebsNoteBodyHtml={nebsNoteBodyHtml}
+      nebsState={nebsState}
+      onSelectNebs={onSelectNebs}
+      openCatalogDoc={openCatalogDoc}
+    />
+  )
 }

--- a/client/src/components/ServicesWorkspace.tsx
+++ b/client/src/components/ServicesWorkspace.tsx
@@ -342,19 +342,22 @@ interface NbsDetailSectionProps {
     readonly nbsNoteBodyHtml: string;
     readonly nbsNotesContentRef: React.RefObject<HTMLDivElement | null>;
     readonly nbsState: ServicesWorkspaceNbsState;
+    readonly openCatalogDoc: OpenCatalogDoc;
 }
 
 function NbsDetailSection({
     nbsNoteBodyHtml,
     nbsNotesContentRef,
     nbsState,
+    openCatalogDoc,
 }: Readonly<NbsDetailSectionProps>) {
     let detailBody: React.ReactNode;
 
     if (nbsState.isLoadingDetail) {
         detailBody = <Loading label="Montando painel..." />;
     } else if (nbsState.detail) {
-        const codeParts = nbsState.detail.item.code.split('.');
+        const detail = nbsState.detail;
+        const codeParts = detail.item.code.split('.');
 
         detailBody = (
             <>
@@ -363,11 +366,11 @@ function NbsDetailSection({
                 <section className={styles.card}>
                     <div className={styles.cardLabel}>Descrição</div>
                     <p>
-                        <strong className={`${styles.interactiveCode} service-code-target`} data-service-code={nbsState.detail.item.code}>
-                            {nbsState.detail.item.code}
+                        <strong className={`${styles.interactiveCode} service-code-target`} data-service-code={detail.item.code}>
+                            {detail.item.code}
                         </strong>
                         {' - '}
-                        {nbsState.detail.item.description}
+                        {detail.item.description}
                     </p>
                 </section>
 
@@ -386,7 +389,7 @@ function NbsDetailSection({
                     </div>
                 </section>
 
-                {nbsState.detail.nebs && (
+                {detail.nebs && (
                     <section className={styles.notesCard} style={{ marginTop: '1rem' }}>
                         <div className={styles.notesHeader}>
                             <span className={styles.notesIcon}>i</span>
@@ -398,6 +401,18 @@ function NbsDetailSection({
                             dangerouslySetInnerHTML={{ __html: nbsNoteBodyHtml }}
                         />
                     </section>
+                )}
+
+                {detail.nebs && (
+                    <div className={styles.detailActions}>
+                        <button
+                            type="button"
+                            className={styles.secondaryAction}
+                            onClick={() => openCatalogDoc('nebs', detail.item.code)}
+                        >
+                            Ver NEBS
+                        </button>
+                    </div>
                 )}
             </>
         );
@@ -489,6 +504,7 @@ interface NbsWorkspaceViewProps {
     readonly nbsPrefixAutoExpand: boolean;
     readonly nbsState: ServicesWorkspaceNbsState;
     readonly onSelectNbs: (code: string) => void;
+    readonly openCatalogDoc: OpenCatalogDoc;
     readonly setIsChapterNotesOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -503,6 +519,7 @@ function NbsWorkspaceView({
     nbsPrefixAutoExpand,
     nbsState,
     onSelectNbs,
+    openCatalogDoc,
     setIsChapterNotesOpen,
 }: Readonly<NbsWorkspaceViewProps>) {
     const chapterButtonLabel = activeChapterNumber
@@ -544,6 +561,7 @@ function NbsWorkspaceView({
                 nbsNoteBodyHtml={nbsNoteBodyHtml}
                 nbsNotesContentRef={nbsNotesContentRef}
                 nbsState={nbsState}
+                openCatalogDoc={openCatalogDoc}
             />
             <NbsChapterNotesDialog
                 chapterNotesDialogRef={chapterNotesDialogRef}
@@ -705,7 +723,7 @@ function NebsDetailSection({
                         className={styles.secondaryAction}
                         onClick={() => openCatalogDoc('nbs', nebsState.detail?.item.code)}
                     >
-                        Abrir item NEBS relacionado
+                        Abrir item NBS relacionado
                     </button>
                 </div>
             </>
@@ -858,6 +876,7 @@ export function ServicesWorkspace({
                 nbsPrefixAutoExpand={nbsPrefixAutoExpand}
                 nbsState={nbsState}
                 onSelectNbs={onSelectNbs}
+                openCatalogDoc={openCatalogDoc}
                 setIsChapterNotesOpen={setIsChapterNotesOpen}
             />
         );
@@ -872,3 +891,10 @@ export function ServicesWorkspace({
         />
     );
 }
+
+
+
+
+
+
+

--- a/client/src/components/ServicesWorkspace.tsx
+++ b/client/src/components/ServicesWorkspace.tsx
@@ -675,7 +675,7 @@ function NebsDetailSection({
                     </p>
                 </div>
 
-                <div className={styles.breadcrumbs} aria-label="Hierarquia NEBS">
+                <div className={styles.breadcrumbs} aria-label="Hierarquia NBS">
                     {nebsState.detail.ancestors.map((ancestor) => (
                         <button
                             key={ancestor.code}
@@ -891,10 +891,3 @@ export function ServicesWorkspace({
         />
     );
 }
-
-
-
-
-
-
-

--- a/client/src/components/ServicesWorkspace.tsx
+++ b/client/src/components/ServicesWorkspace.tsx
@@ -327,7 +327,7 @@ function NbsHierarchySection({
                         <span>{chapterButtonLabel}</span>
                     </button>
                     {' '}
-                    Hierarquia NEBS
+                    Hierarquia NBS
                 </div>
                 <span className={styles.sectionBadge}>
                     {activeChapterNumber ? `Capítulo ${activeChapterNumber} ativo` : 'Capítulo ativo'}
@@ -410,7 +410,7 @@ function NbsDetailSection({
                             className={styles.secondaryAction}
                             onClick={() => openCatalogDoc('nebs', detail.item.code)}
                         >
-                            Ver NEBS
+                            Ver NBS
                         </button>
                     </div>
                 )}
@@ -457,7 +457,7 @@ function NbsChapterNotesDialog({
                 <section className={styles.chapterNotesSheet}>
                     <div className={styles.chapterNotesSheetHeader}>
                         <div className={styles.chapterNotesSheetCopy}>
-                            <span className={styles.chapterNotesSheetEyebrow}>NEBS • Explicações do capítulo</span>
+                            <span className={styles.chapterNotesSheetEyebrow}>NBS • Explicações do capítulo</span>
                             <h3 id="nbs-chapter-notes-title">
                                 Capítulo {currentChapterNotesEntry.chapter} - {currentChapterNotesEntry.title}
                             </h3>
@@ -699,7 +699,7 @@ function NebsDetailSection({
 
                 <div className={styles.detailGrid}>
                     <section className={styles.card}>
-                        <div className={styles.cardLabel}>Servico NEBS vinculado</div>
+                        <div className={styles.cardLabel}>Servico NBS vinculado</div>
                         <p>{nebsState.detail.item.description}</p>
                     </section>
 
@@ -732,7 +732,7 @@ function NebsDetailSection({
         detailBody = (
             <div className={styles.emptyDetail}>
                 <strong>Selecione uma nota</strong>
-                <p>O painel mostra a nota explicativa publicada, a seção de origem e o vínculo com o serviço NEBS.</p>
+                <p>O painel mostra a nota explicativa publicada, a seção de origem e o vínculo com o serviço NBS.</p>
             </div>
         );
     }

--- a/client/src/components/ServicesWorkspace.tsx
+++ b/client/src/components/ServicesWorkspace.tsx
@@ -1,915 +1,874 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
-import DOMPurify from 'dompurify'
-import { marked } from 'marked'
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
 import type {
-  NbsDetailResponse,
-  NbsServiceItem,
-  NebsDetailResponse,
-  NebsSearchItem,
-  ServiceDocType,
-} from '../types/api.types'
-import { Loading } from './Loading'
-import styles from './ServicesWorkspace.module.css'
+    NbsDetailResponse,
+    NbsServiceItem,
+    NebsDetailResponse,
+    NebsSearchItem,
+    ServiceDocType,
+} from '../types/api.types';
+import { Loading } from './Loading';
+import styles from './ServicesWorkspace.module.css';
 
-import { useSettings } from '../context/SettingsContext'
+import { useSettings } from '../context/SettingsContext';
 import {
-  getNbsChapterNotesEntry,
-  getNbsChapterNumber,
-  openNbsChapterNotesTab,
-  renderNbsChapterNotesHtml,
-} from '../utils/nbsChapterNotes'
-import { injectServiceLinks } from '../utils/serviceCodes'
+    getNbsChapterNotesEntry,
+    getNbsChapterNumber,
+    openNbsChapterNotesTab,
+    renderNbsChapterNotesHtml,
+} from '../utils/nbsChapterNotes';
+import { injectServiceLinks } from '../utils/serviceCodes';
 
 export interface ServicesWorkspaceNbsState {
-  readonly results: readonly NbsServiceItem[]
-  readonly selectedCode: string | null
-  readonly detail: NbsDetailResponse | null
-  readonly isSearching: boolean
-  readonly isLoadingDetail: boolean
-  readonly query: string
+    readonly results: readonly NbsServiceItem[];
+    readonly selectedCode: string | null;
+    readonly detail: NbsDetailResponse | null;
+    readonly isSearching: boolean;
+    readonly isLoadingDetail: boolean;
+    readonly query: string;
 }
 
 export interface ServicesWorkspaceNebsState {
-  readonly results: readonly NebsSearchItem[]
-  readonly selectedCode: string | null
-  readonly detail: NebsDetailResponse | null
-  readonly isSearching: boolean
-  readonly isLoadingDetail: boolean
-  readonly hasSearched: boolean
+    readonly results: readonly NebsSearchItem[];
+    readonly selectedCode: string | null;
+    readonly detail: NebsDetailResponse | null;
+    readonly isSearching: boolean;
+    readonly isLoadingDetail: boolean;
+    readonly hasSearched: boolean;
 }
 
 interface ServicesWorkspaceProps {
-  readonly doc: ServiceDocType
-  readonly nbsState: ServicesWorkspaceNbsState
-  readonly nebsState: ServicesWorkspaceNebsState
-  readonly onSelectNbs: (code: string) => void
-  readonly onSelectNebs: (code: string) => void
-  readonly onSwitchDoc: (doc: ServiceDocType, query?: string) => void
-  readonly onOpenDocInNewTab?: (doc: ServiceDocType, query?: string) => void
+    readonly doc: ServiceDocType;
+    readonly nbsState: ServicesWorkspaceNbsState;
+    readonly nebsState: ServicesWorkspaceNebsState;
+    readonly onSelectNbs: (code: string) => void;
+    readonly onSelectNebs: (code: string) => void;
+    readonly onSwitchDoc: (doc: ServiceDocType, query?: string) => void;
+    readonly onOpenDocInNewTab?: (doc: ServiceDocType, query?: string) => void;
 }
 
-type NoteContent =
-  | {
-      readonly body_markdown?: string | null
-      readonly body_text?: string | null
-    }
-  | null
-  | undefined
+type NoteContent = {
+    readonly body_markdown?: string | null;
+    readonly body_text?: string | null;
+} | null | undefined;
 
 type OpenCatalogDoc = (
-  targetDoc: ServiceDocType,
-  query?: string,
-  forceNewTab?: boolean
-) => void
+    targetDoc: ServiceDocType,
+    query?: string,
+    forceNewTab?: boolean,
+) => void;
+
+function getNbsChapterCodeSource(
+    doc: ServiceDocType,
+    nbsState: ServicesWorkspaceNbsState,
+): string | null {
+    if (doc !== 'nbs') return null;
+    if (nbsState.detail?.item.code) return nbsState.detail.item.code;
+    if (nbsState.selectedCode) return nbsState.selectedCode;
+    if (isCodeLikeNbsQuery(nbsState.query)) {
+        return nbsState.query;
+    }
+    return null;
+}
+
+function getVisibleNbsChildren(
+    nbsPrefixAutoExpand: boolean,
+    nbsState: ServicesWorkspaceNbsState,
+): readonly NbsServiceItem[] {
+    const fallbackChildren = nbsState.detail?.children || [];
+    if (!nbsPrefixAutoExpand || !nbsState.detail || !isCodeLikeNbsQuery(nbsState.query)) {
+        return fallbackChildren;
+    }
+
+    const autoExpandedDescendants = getExpandedPrefixBranch(
+        nbsState.detail.chapter_items || nbsState.results,
+        nbsState.query,
+        nbsState.detail.item.code,
+    );
+    if (autoExpandedDescendants.length > 0) {
+        return autoExpandedDescendants;
+    }
+
+    return fallbackChildren;
+}
 
 function escapeHtml(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;')
+    return value
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
 }
 
 function renderPlainTextNoteHtml(noteBody: string): string {
-  const normalizedBody = noteBody.replaceAll(/\r\n?/g, '\n')
+    const normalizedBody = noteBody.replaceAll(/\r\n?/g, '\n');
 
-  return normalizedBody
-    .split(/\n{2,}/)
-    .map(
-      (paragraph) =>
-        `<p>${escapeHtml(paragraph).replaceAll('\n', '<br />')}</p>`
-    )
-    .join('')
+    return normalizedBody
+        .split(/\n{2,}/)
+        .map((paragraph) => `<p>${escapeHtml(paragraph).replaceAll('\n', '<br />')}</p>`)
+        .join('');
 }
 
 function renderNoteHtml(note: NoteContent): string {
-  const markdownBody = note?.body_markdown?.trim()
-  if (markdownBody) {
-    const renderedMarkdown = marked.parse(markdownBody, {
-      async: false,
-      breaks: true,
-      gfm: true,
-    })
+    const markdownBody = note?.body_markdown?.trim();
+    if (markdownBody) {
+        const renderedMarkdown = marked.parse(markdownBody, {
+            async: false,
+            breaks: true,
+            gfm: true,
+        });
 
-    const sanitizedMarkdown = DOMPurify.sanitize(renderedMarkdown, {
-      USE_PROFILES: { html: true },
-    })
+        const sanitizedMarkdown = DOMPurify.sanitize(renderedMarkdown, {
+            USE_PROFILES: { html: true },
+        });
 
-    if (sanitizedMarkdown.trim()) {
-      return injectServiceLinks(sanitizedMarkdown)
+        if (sanitizedMarkdown.trim()) {
+            return injectServiceLinks(sanitizedMarkdown);
+        }
     }
-  }
 
-  const plainTextBody = note?.body_text?.trim()
-  if (!plainTextBody) {
-    return '<p>Sem conteudo detalhado.</p>'
-  }
+    const plainTextBody = note?.body_text?.trim();
+    if (!plainTextBody) {
+        return '<p>Sem conteudo detalhado.</p>';
+    }
 
-  return injectServiceLinks(
-    DOMPurify.sanitize(renderPlainTextNoteHtml(plainTextBody), {
-      USE_PROFILES: { html: true },
-    })
-  )
+    return injectServiceLinks(DOMPurify.sanitize(renderPlainTextNoteHtml(plainTextBody), {
+        USE_PROFILES: { html: true },
+    }));
 }
 
 function isCodeLikeNbsQuery(query: string): boolean {
-  const rawQuery = query.trim()
-  if (!rawQuery) return false
+    const rawQuery = query.trim();
+    if (!rawQuery) return false;
 
-  const cleanQuery = rawQuery.replaceAll(/[^0-9.]/g, '')
-  return (
-    Boolean(cleanQuery) &&
-    [...rawQuery].every(
-      (character) => (character >= '0' && character <= '9') || character === '.'
-    )
-  )
+    const cleanQuery = rawQuery.replaceAll(/[^0-9.]/g, '');
+    return Boolean(cleanQuery) && [...rawQuery].every(
+        (character) => (character >= '0' && character <= '9') || character === '.',
+    );
 }
 
 function getExpandedPrefixBranch(
-  results: readonly NbsServiceItem[],
-  query: string,
-  activeCode: string
+    results: readonly NbsServiceItem[],
+    query: string,
+    activeCode: string,
 ): NbsServiceItem[] {
-  const cleanQuery = query.replaceAll(/[^0-9]/g, '')
-  if (!cleanQuery) return []
+    const cleanQuery = query.replaceAll(/[^0-9]/g, '');
+    if (!cleanQuery) return [];
 
-  return results.filter(
-    (item) => item.code !== activeCode && item.code_clean.startsWith(cleanQuery)
-  )
+    return results.filter((item) => (
+        item.code !== activeCode
+        && item.code_clean.startsWith(cleanQuery)
+    ));
 }
 
 interface NbsHierarchySectionProps {
-  readonly activeChapterNumber: string | null
-  readonly chapterButtonHint: string
-  readonly chapterButtonLabel: string
-  readonly currentChapterNotesEntry: ReturnType<typeof getNbsChapterNotesEntry>
-  readonly nbsState: ServicesWorkspaceNbsState
-  readonly onOpenChapterNotes: () => void
-  readonly onSelectNbs: (code: string) => void
-  readonly visibleChildren: readonly NbsServiceItem[]
+    readonly activeChapterNumber: string | null;
+    readonly chapterButtonHint: string;
+    readonly chapterButtonLabel: string;
+    readonly currentChapterNotesEntry: ReturnType<typeof getNbsChapterNotesEntry>;
+    readonly nbsState: ServicesWorkspaceNbsState;
+    readonly onOpenChapterNotes: () => void;
+    readonly onSelectNbs: (code: string) => void;
+    readonly visibleChildren: readonly NbsServiceItem[];
 }
 
 function NbsHierarchySection({
-  activeChapterNumber,
-  chapterButtonHint,
-  chapterButtonLabel,
-  currentChapterNotesEntry,
-  nbsState,
-  onOpenChapterNotes,
-  onSelectNbs,
-  visibleChildren,
+    activeChapterNumber,
+    chapterButtonHint,
+    chapterButtonLabel,
+    currentChapterNotesEntry,
+    nbsState,
+    onOpenChapterNotes,
+    onSelectNbs,
+    visibleChildren,
 }: Readonly<NbsHierarchySectionProps>) {
-  return (
-    <aside className={styles.leftPanel}>
-      <div className={styles.leftPanelHeader}>
-        <div className={styles.leftPanelTitle}>
-          <button
-            type="button"
-            className={styles.chapterNotesButton}
-            onClick={onOpenChapterNotes}
-            disabled={!currentChapterNotesEntry}
-            title={chapterButtonHint}
-          >
-            <span className={styles.chapterNotesEyebrow}>Explicações</span>
-            <span>{chapterButtonLabel}</span>
-          </button>
-          Hierarquia NEBS
-        </div>
-        <span className={styles.sectionBadge}>
-          {activeChapterNumber
-            ? `Capítulo ${activeChapterNumber} ativo`
-            : 'Capítulo ativo'}
-        </span>
-      </div>
+    let sectionBody: React.ReactNode;
 
-      {nbsState.isSearching ? (
-        <Loading label="Buscando catalogo..." />
-      ) : nbsState.detail ? (
-        <div className={styles.hierarchyList}>
-          {nbsState.detail.ancestors.map((item, index) => (
-            <div
-              key={item.code}
-              className={styles.hierarchyNode}
-              style={{ paddingLeft: `${index * 1.5}rem` }}
-            >
-              <button
-                type="button"
-                className={styles.nodeCard}
-                onClick={() => onSelectNbs(item.code)}
-              >
-                <div className={styles.nodeIcon}>
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <polyline points="8 17 12 21 16 17"></polyline>
-                    <line x1="12" y1="12" x2="12" y2="21"></line>
-                    <path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"></path>
-                  </svg>
-                </div>
-                <div className={styles.nodeContent}>
-                  <span className={styles.nodeLabel}>Nível {item.level}</span>
-                  <strong
-                    className={`${styles.nodeTitle} ${styles.interactiveCode} service-code-target`}
-                    data-service-code={item.code}
-                  >
-                    {item.code} - {item.description}
-                  </strong>
-                </div>
-              </button>
-            </div>
-          ))}
-          <div
-            className={styles.hierarchyNode}
-            style={{
-              paddingLeft: `${nbsState.detail.ancestors.length * 1.5}rem`,
-            }}
-          >
-            <div
-              className={`${styles.nodeCard} ${styles.active}`}
-              data-service-state="active"
-            >
-              <div className={styles.nodeIcon}>
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <polyline points="16 18 22 12 16 6"></polyline>
-                  <polyline points="8 6 2 12 8 18"></polyline>
-                </svg>
-              </div>
-              <div className={styles.nodeContent}>
-                <span className={styles.nodeLabel}>Item Ativo</span>
-                <strong
-                  className={`${styles.nodeTitle} ${styles.interactiveCode} service-code-target`}
-                  data-service-code={nbsState.detail.item.code}
-                >
-                  {nbsState.detail.item.code} -{' '}
-                  {nbsState.detail.item.description}
-                </strong>
-              </div>
-            </div>
-            {visibleChildren.length > 0 && (
-              <div
-                className={styles.peerList}
-                style={{ paddingLeft: '3.5rem' }}
-              >
-                {visibleChildren.map((child) => (
-                  <button
-                    type="button"
-                    key={child.code}
-                    className={styles.peerCard}
-                    onClick={() => onSelectNbs(child.code)}
-                    style={{
-                      marginLeft: `${Math.max(0, child.level - nbsState.detail!.item.level - 1) * 1.25}rem`,
-                    }}
-                  >
-                    <div className={styles.peerIcon}></div>
-                    <span
-                      className={`${styles.nodeTitle} ${styles.interactiveCode} service-code-target`}
-                      data-service-code={child.code}
+    if (nbsState.isSearching) {
+        sectionBody = <Loading label="Buscando catalogo..." />;
+    } else if (nbsState.detail) {
+        sectionBody = (
+            <div className={styles.hierarchyList}>
+                {nbsState.detail.ancestors.map((item, index) => (
+                    <div
+                        key={item.code}
+                        className={styles.hierarchyNode}
+                        style={{ paddingLeft: `${index * 1.5}rem` }}
                     >
-                      {child.code} - {child.description}
-                    </span>
-                  </button>
+                        <button type="button" className={styles.nodeCard} onClick={() => onSelectNbs(item.code)}>
+                            <div className={styles.nodeIcon}>
+                                <svg
+                                    width="16"
+                                    height="16"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth="2"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                >
+                                    <polyline points="8 17 12 21 16 17"></polyline>
+                                    <line x1="12" y1="12" x2="12" y2="21"></line>
+                                    <path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"></path>
+                                </svg>
+                            </div>
+                            <div className={styles.nodeContent}>
+                                <span className={styles.nodeLabel}>Nível {item.level}</span>
+                                <strong
+                                    className={`${styles.nodeTitle} ${styles.interactiveCode} service-code-target`}
+                                    data-service-code={item.code}
+                                >
+                                    {item.code} - {item.description}
+                                </strong>
+                            </div>
+                        </button>
+                    </div>
                 ))}
-              </div>
-            )}
-          </div>
-        </div>
-      ) : nbsState.results.length > 0 ? (
-        <div className={styles.resultList}>
-          {nbsState.results.map((item) => (
-            <button
-              key={item.code}
-              type="button"
-              className={`${styles.resultCard} ${nbsState.selectedCode === item.code ? styles.resultCardActive : ''}`}
-              onClick={() => onSelectNbs(item.code)}
-            >
-              <div className={styles.resultMeta}>
-                <span
-                  className={`${styles.codeBadge} ${styles.interactiveCode} service-code-target`}
-                  data-service-code={item.code}
+                <div
+                    className={styles.hierarchyNode}
+                    style={{ paddingLeft: `${nbsState.detail.ancestors.length * 1.5}rem` }}
                 >
-                  {item.code}
+                    <div className={`${styles.nodeCard} ${styles.active}`} data-service-state="active">
+                        <div className={styles.nodeIcon}>
+                            <svg
+                                width="16"
+                                height="16"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            >
+                                <polyline points="16 18 22 12 16 6"></polyline>
+                                <polyline points="8 6 2 12 8 18"></polyline>
+                            </svg>
+                        </div>
+                        <div className={styles.nodeContent}>
+                            <span className={styles.nodeLabel}>Item Ativo</span>
+                            <strong
+                                className={`${styles.nodeTitle} ${styles.interactiveCode} service-code-target`}
+                                data-service-code={nbsState.detail.item.code}
+                            >
+                                {nbsState.detail.item.code} - {nbsState.detail.item.description}
+                            </strong>
+                        </div>
+                    </div>
+                    {visibleChildren.length > 0 && (
+                        <div className={styles.peerList} style={{ paddingLeft: '3.5rem' }}>
+                            {visibleChildren.map((child) => (
+                                <button
+                                    type="button"
+                                    key={child.code}
+                                    className={styles.peerCard}
+                                    onClick={() => onSelectNbs(child.code)}
+                                    style={{
+                                        marginLeft: `${Math.max(0, child.level - nbsState.detail!.item.level - 1) * 1.25}rem`,
+                                    }}
+                                >
+                                    <div className={styles.peerIcon}></div>
+                                    <span
+                                        className={`${styles.nodeTitle} ${styles.interactiveCode} service-code-target`}
+                                        data-service-code={child.code}
+                                    >
+                                        {child.code} - {child.description}
+                                    </span>
+                                </button>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </div>
+        );
+    } else if (nbsState.results.length > 0) {
+        sectionBody = (
+            <div className={styles.resultList}>
+                {nbsState.results.map((item) => (
+                    <button
+                        key={item.code}
+                        type="button"
+                        className={`${styles.resultCard} ${nbsState.selectedCode === item.code ? styles.resultCardActive : ''}`}
+                        onClick={() => onSelectNbs(item.code)}
+                    >
+                        <div className={styles.resultMeta}>
+                            <span
+                                className={`${styles.codeBadge} ${styles.interactiveCode} service-code-target`}
+                                data-service-code={item.code}
+                            >
+                                {item.code}
+                            </span>
+                            {item.has_nebs && <span className={styles.noteBadge}>NEBS</span>}
+                        </div>
+                        <strong className={`${styles.interactiveCode} service-code-target`} data-service-code={item.code}>
+                            {item.description}
+                        </strong>
+                        <span className={styles.levelHint}>Nivel {item.level}</span>
+                    </button>
+                ))}
+            </div>
+        );
+    } else {
+        sectionBody = (
+            <div className={styles.emptyState}>
+                <strong>Nenhum servico encontrado</strong>
+                <p>Tente outro codigo ou um termo mais amplo.</p>
+            </div>
+        );
+    }
+
+    return (
+        <aside className={styles.leftPanel}>
+            <div className={styles.leftPanelHeader}>
+                <div className={styles.leftPanelTitle}>
+                    <button type="button" className={styles.chapterNotesButton} onClick={onOpenChapterNotes} disabled={!currentChapterNotesEntry} title={chapterButtonHint}>
+                        <span className={styles.chapterNotesEyebrow}>Explicações</span>
+                        <span>{chapterButtonLabel}</span>
+                    </button>
+                    {' '}
+                    Hierarquia NEBS
+                </div>
+                <span className={styles.sectionBadge}>
+                    {activeChapterNumber ? `Capítulo ${activeChapterNumber} ativo` : 'Capítulo ativo'}
                 </span>
-                {item.has_nebs && (
-                  <span className={styles.noteBadge}>NEBS</span>
-                )}
-              </div>
-              <strong
-                className={`${styles.interactiveCode} service-code-target`}
-                data-service-code={item.code}
-              >
-                {item.description}
-              </strong>
-              <span className={styles.levelHint}>Nivel {item.level}</span>
-            </button>
-          ))}
-        </div>
-      ) : (
-        <div className={styles.emptyState}>
-          <strong>Nenhum servico encontrado</strong>
-          <p>Tente outro codigo ou um termo mais amplo.</p>
-        </div>
-      )}
-    </aside>
-  )
+            </div>
+            {sectionBody}
+        </aside>
+    );
 }
 
 interface NbsDetailSectionProps {
-  readonly nbsNoteBodyHtml: string
-  readonly nbsNotesContentRef: React.RefObject<HTMLDivElement | null>
-  readonly nbsState: ServicesWorkspaceNbsState
+    readonly nbsNoteBodyHtml: string;
+    readonly nbsNotesContentRef: React.RefObject<HTMLDivElement | null>;
+    readonly nbsState: ServicesWorkspaceNbsState;
 }
 
 function NbsDetailSection({
-  nbsNoteBodyHtml,
-  nbsNotesContentRef,
-  nbsState,
+    nbsNoteBodyHtml,
+    nbsNotesContentRef,
+    nbsState,
 }: Readonly<NbsDetailSectionProps>) {
-  return (
-    <section className={styles.rightPanel}>
-      {nbsState.isLoadingDetail ? (
-        <Loading label="Montando painel..." />
-      ) : nbsState.detail ? (
-        <>
-          <h3 className={styles.rightPanelTitle}>Detalhamento Técnico</h3>
+    let detailBody: React.ReactNode;
 
-          <section className={styles.card}>
-            <div className={styles.cardLabel}>Descrição</div>
-            <p>
-              <strong
-                className={`${styles.interactiveCode} service-code-target`}
-                data-service-code={nbsState.detail.item.code}
-              >
-                {nbsState.detail.item.code}
-              </strong>
-              {' - '}
-              {nbsState.detail.item.description}
-            </p>
-          </section>
+    if (nbsState.isLoadingDetail) {
+        detailBody = <Loading label="Montando painel..." />;
+    } else if (nbsState.detail) {
+        const codeParts = nbsState.detail.item.code.split('.');
 
-          <section className={styles.codeComposition}>
-            <span className={styles.codeLabel}>COMPOSIÇÃO DO CÓDIGO</span>
-            <div className={styles.codeBoxes}>
-              {nbsState.detail.item.code.split('.').map((part, index) => (
-                <React.Fragment key={index}>
-                  <div className={styles.codeBox}>{part}</div>
-                  {index < nbsState.detail!.item.code.split('.').length - 1 && (
-                    <span className={styles.codeSeparator}>-</span>
-                  )}
-                </React.Fragment>
-              ))}
+        detailBody = (
+            <>
+                <h3 className={styles.rightPanelTitle}>Detalhamento Técnico</h3>
+
+                <section className={styles.card}>
+                    <div className={styles.cardLabel}>Descrição</div>
+                    <p>
+                        <strong className={`${styles.interactiveCode} service-code-target`} data-service-code={nbsState.detail.item.code}>
+                            {nbsState.detail.item.code}
+                        </strong>
+                        {' - '}
+                        {nbsState.detail.item.description}
+                    </p>
+                </section>
+
+                <section className={styles.codeComposition}>
+                    <span className={styles.codeLabel}>COMPOSIÇÃO DO CÓDIGO</span>
+                    <div className={styles.codeBoxes}>
+                        {codeParts.map((part, index) => {
+                            const partKey = codeParts.slice(0, index + 1).join('.');
+                            return (
+                                <React.Fragment key={partKey}>
+                                    <div className={styles.codeBox}>{part}</div>
+                                    {index < codeParts.length - 1 && <span className={styles.codeSeparator}>-</span>}
+                                </React.Fragment>
+                            );
+                        })}
+                    </div>
+                </section>
+
+                {nbsState.detail.nebs && (
+                    <section className={styles.notesCard} style={{ marginTop: '1rem' }}>
+                        <div className={styles.notesHeader}>
+                            <span className={styles.notesIcon}>i</span>
+                            <span>NOTAS EXPLICATIVAS</span>
+                        </div>
+                        <div
+                            ref={nbsNotesContentRef}
+                            className={styles.notesContent}
+                            dangerouslySetInnerHTML={{ __html: nbsNoteBodyHtml }}
+                        />
+                    </section>
+                )}
+            </>
+        );
+    } else {
+        detailBody = (
+            <div className={styles.emptyDetail}>
+                <strong>Selecione um servico</strong>
+                <p>O painel mostra descricao, hierarquia e a disponibilidade de nota explicativa publicada.</p>
             </div>
-          </section>
+        );
+    }
 
-          {nbsState.detail.nebs && (
-            <section className={styles.notesCard} style={{ marginTop: '1rem' }}>
-              <div className={styles.notesHeader}>
-                <span className={styles.notesIcon}>i</span>
-                <span>NOTAS EXPLICATIVAS</span>
-              </div>
-              <div
-                ref={nbsNotesContentRef}
-                className={styles.notesContent}
-                dangerouslySetInnerHTML={{ __html: nbsNoteBodyHtml }}
-              />
-            </section>
-          )}
-        </>
-      ) : (
-        <div className={styles.emptyDetail}>
-          <strong>Selecione um servico</strong>
-          <p>
-            O painel mostra descricao, hierarquia e a disponibilidade de nota
-            explicativa publicada.
-          </p>
-        </div>
-      )}
-    </section>
-  )
+    return (
+        <section className={styles.rightPanel}>
+            {detailBody}
+        </section>
+    );
 }
 
 interface NbsChapterNotesDialogProps {
-  readonly chapterNotesDialogRef: React.RefObject<HTMLDialogElement | null>
-  readonly chapterNotesHtml: string
-  readonly closeChapterNotes: () => void
-  readonly currentChapterNotesEntry: ReturnType<typeof getNbsChapterNotesEntry>
-  readonly onBackdropClick: (event: React.MouseEvent<HTMLDialogElement>) => void
-  readonly onDialogKeyDown: (
-    event: React.KeyboardEvent<HTMLDialogElement>
-  ) => void
+    readonly chapterNotesDialogRef: React.RefObject<HTMLDialogElement | null>;
+    readonly chapterNotesHtml: string;
+    readonly closeChapterNotes: () => void;
+    readonly currentChapterNotesEntry: ReturnType<typeof getNbsChapterNotesEntry>;
 }
 
 function NbsChapterNotesDialog({
-  chapterNotesDialogRef,
-  chapterNotesHtml,
-  closeChapterNotes,
-  currentChapterNotesEntry,
-  onBackdropClick,
-  onDialogKeyDown,
+    chapterNotesDialogRef,
+    chapterNotesHtml,
+    closeChapterNotes,
+    currentChapterNotesEntry,
 }: Readonly<NbsChapterNotesDialogProps>) {
-  return (
-    <dialog
-      ref={chapterNotesDialogRef}
-      className={styles.chapterNotesDialog}
-      aria-labelledby="nbs-chapter-notes-title"
-      onClose={closeChapterNotes}
-      onCancel={closeChapterNotes}
-      onClick={onBackdropClick}
-      onKeyDown={onDialogKeyDown}
-    >
-      {currentChapterNotesEntry && (
-        <section className={styles.chapterNotesSheet}>
-          <div className={styles.chapterNotesSheetHeader}>
-            <div className={styles.chapterNotesSheetCopy}>
-              <span className={styles.chapterNotesSheetEyebrow}>
-                NEBS • Explicações do capítulo
-              </span>
-              <h3 id="nbs-chapter-notes-title">
-                Capítulo {currentChapterNotesEntry.chapter} -{' '}
-                {currentChapterNotesEntry.title}
-              </h3>
-              <p>
-                Notas oficiais extraídas do Anexo I da Portaria Conjunta RFB/SCS
-                nº 1.429, de 12 de setembro de 2018.
-              </p>
-            </div>
-            <button
-              type="button"
-              className={styles.chapterNotesClose}
-              aria-label="Fechar explicações do capítulo"
-              onClick={closeChapterNotes}
-            >
-              ×
-            </button>
-          </div>
+    return (
+        <dialog
+            ref={chapterNotesDialogRef}
+            className={styles.chapterNotesDialog}
+            aria-labelledby="nbs-chapter-notes-title"
+            onClose={closeChapterNotes}
+            onCancel={closeChapterNotes}
+        >
+            {currentChapterNotesEntry && (
+                <section className={styles.chapterNotesSheet}>
+                    <div className={styles.chapterNotesSheetHeader}>
+                        <div className={styles.chapterNotesSheetCopy}>
+                            <span className={styles.chapterNotesSheetEyebrow}>NEBS • Explicações do capítulo</span>
+                            <h3 id="nbs-chapter-notes-title">
+                                Capítulo {currentChapterNotesEntry.chapter} - {currentChapterNotesEntry.title}
+                            </h3>
+                            <p>
+                                Notas oficiais extraídas do Anexo I da Portaria Conjunta RFB/SCS nº 1.429, de 12 de setembro de 2018.
+                            </p>
+                        </div>
+                        <button
+                            type="button"
+                            className={styles.chapterNotesClose}
+                            aria-label="Fechar explicações do capítulo"
+                            onClick={closeChapterNotes}
+                        >
+                            ×
+                        </button>
+                    </div>
 
-          <div className={styles.chapterNotesSheetBody}>
-            <section className={styles.notesCard}>
-              <div className={styles.notesHeader}>
-                <span className={styles.notesIcon}>i</span>
-                <span>NOTAS DO CAPÍTULO</span>
-              </div>
-              <div
-                className={`${styles.notesContent} ${styles.chapterNotesContent}`}
-                dangerouslySetInnerHTML={{ __html: chapterNotesHtml }}
-              />
-            </section>
-          </div>
-        </section>
-      )}
-    </dialog>
-  )
+                    <div className={styles.chapterNotesSheetBody}>
+                        <section className={styles.notesCard}>
+                            <div className={styles.notesHeader}>
+                                <span className={styles.notesIcon}>i</span>
+                                <span>NOTAS DO CAPÍTULO</span>
+                            </div>
+                            <div
+                                className={`${styles.notesContent} ${styles.chapterNotesContent}`}
+                                dangerouslySetInnerHTML={{ __html: chapterNotesHtml }}
+                            />
+                        </section>
+                    </div>
+                </section>
+            )}
+        </dialog>
+    );
 }
 
 interface NbsWorkspaceViewProps {
-  readonly activeChapterNumber: string | null
-  readonly chapterNotesDialogRef: React.RefObject<HTMLDialogElement | null>
-  readonly chapterNotesHtml: string
-  readonly currentChapterNotesEntry: ReturnType<typeof getNbsChapterNotesEntry>
-  readonly nbsChapterNotesNewTab: boolean
-  readonly nbsNoteBodyHtml: string
-  readonly nbsNotesContentRef: React.RefObject<HTMLDivElement | null>
-  readonly nbsPrefixAutoExpand: boolean
-  readonly nbsState: ServicesWorkspaceNbsState
-  readonly onSelectNbs: (code: string) => void
-  readonly setIsChapterNotesOpen: React.Dispatch<React.SetStateAction<boolean>>
+    readonly activeChapterNumber: string | null;
+    readonly chapterNotesDialogRef: React.RefObject<HTMLDialogElement | null>;
+    readonly chapterNotesHtml: string;
+    readonly currentChapterNotesEntry: ReturnType<typeof getNbsChapterNotesEntry>;
+    readonly nbsChapterNotesNewTab: boolean;
+    readonly nbsNoteBodyHtml: string;
+    readonly nbsNotesContentRef: React.RefObject<HTMLDivElement | null>;
+    readonly nbsPrefixAutoExpand: boolean;
+    readonly nbsState: ServicesWorkspaceNbsState;
+    readonly onSelectNbs: (code: string) => void;
+    readonly setIsChapterNotesOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 function NbsWorkspaceView({
-  activeChapterNumber,
-  chapterNotesDialogRef,
-  chapterNotesHtml,
-  currentChapterNotesEntry,
-  nbsChapterNotesNewTab,
-  nbsNoteBodyHtml,
-  nbsNotesContentRef,
-  nbsPrefixAutoExpand,
-  nbsState,
-  onSelectNbs,
-  setIsChapterNotesOpen,
+    activeChapterNumber,
+    chapterNotesDialogRef,
+    chapterNotesHtml,
+    currentChapterNotesEntry,
+    nbsChapterNotesNewTab,
+    nbsNoteBodyHtml,
+    nbsNotesContentRef,
+    nbsPrefixAutoExpand,
+    nbsState,
+    onSelectNbs,
+    setIsChapterNotesOpen,
 }: Readonly<NbsWorkspaceViewProps>) {
-  const chapterButtonLabel = activeChapterNumber
-    ? `Capítulo ${activeChapterNumber}`
-    : 'Explicações do capítulo'
-  const chapterButtonHint = currentChapterNotesEntry?.hasOfficialNotes
-    ? 'Abrir explicações oficiais do capítulo'
-    : 'Abrir resumo do capítulo'
+    const chapterButtonLabel = activeChapterNumber
+        ? `Capítulo ${activeChapterNumber}`
+        : 'Explicações do capítulo';
+    const chapterButtonHint = currentChapterNotesEntry?.hasOfficialNotes
+        ? 'Abrir explicações oficiais do capítulo'
+        : 'Abrir resumo do capítulo';
 
-  const closeChapterNotes = () => {
-    setIsChapterNotesOpen(false)
-  }
+    const closeChapterNotes = () => {
+        setIsChapterNotesOpen(false);
+    };
 
-  const handleChapterNotesDialogKeyDown = (
-    event: React.KeyboardEvent<HTMLDialogElement>
-  ) => {
-    if (event.key === 'Escape') {
-      closeChapterNotes()
-    }
-  }
+    const handleOpenChapterNotes = () => {
+        if (!currentChapterNotesEntry) return;
+        if (nbsChapterNotesNewTab) {
+            openNbsChapterNotesTab(currentChapterNotesEntry);
+            return;
+        }
 
-  const handleChapterNotesBackdropClick = (
-    event: React.MouseEvent<HTMLDialogElement>
-  ) => {
-    if (event.target === event.currentTarget) {
-      closeChapterNotes()
-    }
-  }
+        setIsChapterNotesOpen(true);
+    };
 
-  const handleOpenChapterNotes = () => {
-    if (!currentChapterNotesEntry) return
-    if (nbsChapterNotesNewTab) {
-      openNbsChapterNotesTab(currentChapterNotesEntry)
-      return
-    }
+    const visibleChildren = getVisibleNbsChildren(nbsPrefixAutoExpand, nbsState);
 
-    setIsChapterNotesOpen(true)
-  }
-
-  const autoExpandedDescendants =
-    nbsPrefixAutoExpand && isCodeLikeNbsQuery(nbsState.query) && nbsState.detail
-      ? getExpandedPrefixBranch(
-          nbsState.detail.chapter_items || nbsState.results,
-          nbsState.query,
-          nbsState.detail.item.code
-        )
-      : []
-  const visibleChildren =
-    autoExpandedDescendants.length > 0
-      ? autoExpandedDescendants
-      : nbsState.detail?.children || []
-
-  return (
-    <div className={styles.body}>
-      <NbsHierarchySection
-        activeChapterNumber={activeChapterNumber}
-        chapterButtonHint={chapterButtonHint}
-        chapterButtonLabel={chapterButtonLabel}
-        currentChapterNotesEntry={currentChapterNotesEntry}
-        nbsState={nbsState}
-        onOpenChapterNotes={handleOpenChapterNotes}
-        onSelectNbs={onSelectNbs}
-        visibleChildren={visibleChildren}
-      />
-      <NbsDetailSection
-        nbsNoteBodyHtml={nbsNoteBodyHtml}
-        nbsNotesContentRef={nbsNotesContentRef}
-        nbsState={nbsState}
-      />
-      <NbsChapterNotesDialog
-        chapterNotesDialogRef={chapterNotesDialogRef}
-        chapterNotesHtml={chapterNotesHtml}
-        closeChapterNotes={closeChapterNotes}
-        currentChapterNotesEntry={currentChapterNotesEntry}
-        onBackdropClick={handleChapterNotesBackdropClick}
-        onDialogKeyDown={handleChapterNotesDialogKeyDown}
-      />
-    </div>
-  )
+    return (
+        <div className={styles.body}>
+            <NbsHierarchySection
+                activeChapterNumber={activeChapterNumber}
+                chapterButtonHint={chapterButtonHint}
+                chapterButtonLabel={chapterButtonLabel}
+                currentChapterNotesEntry={currentChapterNotesEntry}
+                nbsState={nbsState}
+                onOpenChapterNotes={handleOpenChapterNotes}
+                onSelectNbs={onSelectNbs}
+                visibleChildren={visibleChildren}
+            />
+            <NbsDetailSection
+                nbsNoteBodyHtml={nbsNoteBodyHtml}
+                nbsNotesContentRef={nbsNotesContentRef}
+                nbsState={nbsState}
+            />
+            <NbsChapterNotesDialog
+                chapterNotesDialogRef={chapterNotesDialogRef}
+                chapterNotesHtml={chapterNotesHtml}
+                closeChapterNotes={closeChapterNotes}
+                currentChapterNotesEntry={currentChapterNotesEntry}
+            />
+        </div>
+    );
 }
 
 interface NebsResultsSectionProps {
-  readonly nebsState: ServicesWorkspaceNebsState
-  readonly onSelectNebs: (code: string) => void
+    readonly nebsState: ServicesWorkspaceNebsState;
+    readonly onSelectNebs: (code: string) => void;
 }
 
 function NebsResultsSection({
-  nebsState,
-  onSelectNebs,
+    nebsState,
+    onSelectNebs,
 }: Readonly<NebsResultsSectionProps>) {
-  return (
-    <aside className={styles.sidebar}>
-      <div className={styles.sidebarHeader}>
-        <span>Resultados</span>
-        <strong>{nebsState.results.length}</strong>
-      </div>
+    let sectionBody: React.ReactNode;
 
-      {nebsState.isSearching ? (
-        <Loading label="Buscando notas..." />
-      ) : !nebsState.hasSearched ? (
-        <div className={styles.emptyState}>
-          <strong>Busque uma nota explicativa</strong>
-          <p>
-            Digite um codigo NEBS ou um termo textual para pesquisar a NEBS.
-          </p>
-        </div>
-      ) : nebsState.results.length > 0 ? (
-        <div className={styles.resultList}>
-          {nebsState.results.map((item) => (
-            <button
-              key={item.code}
-              type="button"
-              className={`${styles.resultCard} ${nebsState.selectedCode === item.code ? styles.resultCardActive : ''}`}
-              onClick={() => onSelectNebs(item.code)}
-            >
-              <div className={styles.resultMeta}>
-                <span
-                  className={`${styles.codeBadge} ${styles.interactiveCode} service-code-target`}
-                  data-service-code={item.code}
-                >
-                  {item.code}
-                </span>
-                <span className={styles.noteBadge}>NEBS</span>
-              </div>
-              <strong
-                className={`${styles.interactiveCode} service-code-target`}
-                data-service-code={item.code}
-              >
-                {item.code} - {item.title}
-              </strong>
-              <span className={styles.resultExcerpt}>{item.excerpt}</span>
-              <span className={styles.levelHint}>
-                Paginas {item.page_start} a {item.page_end}
-              </span>
-            </button>
-          ))}
-        </div>
-      ) : (
-        <div className={styles.emptyState}>
-          <strong>Nenhuma nota encontrada</strong>
-          <p>Tente um termo mais amplo ou um codigo completo.</p>
-        </div>
-      )}
-    </aside>
-  )
+    if (nebsState.isSearching) {
+        sectionBody = <Loading label="Buscando notas..." />;
+    } else if (!nebsState.hasSearched) {
+        sectionBody = (
+            <div className={styles.emptyState}>
+                <strong>Busque uma nota explicativa</strong>
+                <p>Digite um codigo NEBS ou um termo textual para pesquisar a NEBS.</p>
+            </div>
+        );
+    } else if (nebsState.results.length > 0) {
+        sectionBody = (
+            <div className={styles.resultList}>
+                {nebsState.results.map((item) => (
+                    <button
+                        key={item.code}
+                        type="button"
+                        className={`${styles.resultCard} ${nebsState.selectedCode === item.code ? styles.resultCardActive : ''}`}
+                        onClick={() => onSelectNebs(item.code)}
+                    >
+                        <div className={styles.resultMeta}>
+                            <span
+                                className={`${styles.codeBadge} ${styles.interactiveCode} service-code-target`}
+                                data-service-code={item.code}
+                            >
+                                {item.code}
+                            </span>
+                            <span className={styles.noteBadge}>NEBS</span>
+                        </div>
+                        <strong className={`${styles.interactiveCode} service-code-target`} data-service-code={item.code}>
+                            {item.code} - {item.title}
+                        </strong>
+                        <span className={styles.resultExcerpt}>{item.excerpt}</span>
+                        <span className={styles.levelHint}>
+                            Paginas {item.page_start} a {item.page_end}
+                        </span>
+                    </button>
+                ))}
+            </div>
+        );
+    } else {
+        sectionBody = (
+            <div className={styles.emptyState}>
+                <strong>Nenhuma nota encontrada</strong>
+                <p>Tente um termo mais amplo ou um codigo completo.</p>
+            </div>
+        );
+    }
+
+    return (
+        <aside className={styles.sidebar}>
+            <div className={styles.sidebarHeader}>
+                <span>Resultados</span>
+                <strong>{nebsState.results.length}</strong>
+            </div>
+            {sectionBody}
+        </aside>
+    );
 }
 
 interface NebsDetailSectionProps {
-  readonly nebsNoteBodyHtml: string
-  readonly nebsState: ServicesWorkspaceNebsState
-  readonly openCatalogDoc: OpenCatalogDoc
+    readonly nebsNoteBodyHtml: string;
+    readonly nebsState: ServicesWorkspaceNebsState;
+    readonly openCatalogDoc: OpenCatalogDoc;
 }
 
 function NebsDetailSection({
-  nebsNoteBodyHtml,
-  nebsState,
-  openCatalogDoc,
+    nebsNoteBodyHtml,
+    nebsState,
+    openCatalogDoc,
 }: Readonly<NebsDetailSectionProps>) {
-  return (
-    <section className={styles.detailPanel}>
-      {nebsState.isLoadingDetail ? (
-        <Loading label="Montando nota..." />
-      ) : nebsState.detail ? (
-        <>
-          <div className={styles.detailHero}>
-            <div
-              className={`${styles.detailCode} ${styles.interactiveCode} service-code-target`}
-              data-service-code={nebsState.detail.entry.code}
-            >
-              {nebsState.detail.entry.code}
+    let detailBody: React.ReactNode;
+
+    if (nebsState.isLoadingDetail) {
+        detailBody = <Loading label="Montando nota..." />;
+    } else if (nebsState.detail) {
+        detailBody = (
+            <>
+                <div className={styles.detailHero}>
+                    <div
+                        className={`${styles.detailCode} ${styles.interactiveCode} service-code-target`}
+                        data-service-code={nebsState.detail.entry.code}
+                    >
+                        {nebsState.detail.entry.code}
+                    </div>
+                    <h3>{nebsState.detail.entry.title}</h3>
+                    <p className={styles.heroMeta}>
+                        {nebsState.detail.entry.section_title || 'Secao nao informada'} • Paginas {nebsState.detail.entry.page_start} a{' '}
+                        {nebsState.detail.entry.page_end}
+                    </p>
+                </div>
+
+                <div className={styles.breadcrumbs} aria-label="Hierarquia NEBS">
+                    {nebsState.detail.ancestors.map((ancestor) => (
+                        <button
+                            key={ancestor.code}
+                            type="button"
+                            className={`${styles.crumb} ${styles.interactiveCode} service-code-target`}
+                            data-service-code={ancestor.code}
+                            onClick={() => openCatalogDoc('nbs', ancestor.code)}
+                        >
+                            {ancestor.code}
+                        </button>
+                    ))}
+                    <button
+                        type="button"
+                        className={`${styles.crumbCurrentButton} ${styles.interactiveCode} service-code-target`}
+                        data-service-code={nebsState.detail?.item.code}
+                        onClick={() => openCatalogDoc('nbs', nebsState.detail?.item.code)}
+                    >
+                        {nebsState.detail.item.code}
+                    </button>
+                </div>
+
+                <div className={styles.detailGrid}>
+                    <section className={styles.card}>
+                        <div className={styles.cardLabel}>Servico NEBS vinculado</div>
+                        <p>{nebsState.detail.item.description}</p>
+                    </section>
+
+                    <section className={styles.card}>
+                        <div className={styles.cardLabel}>Origem</div>
+                        <p>{nebsState.detail.entry.section_title || 'Secao nao identificada'}</p>
+                    </section>
+                </div>
+
+                <section className={styles.card}>
+                    <div className={styles.cardLabel}>Conteudo da nota</div>
+                    <div
+                        className={styles.noteBody}
+                        dangerouslySetInnerHTML={{ __html: nebsNoteBodyHtml }}
+                    />
+                </section>
+
+                <div className={styles.detailActions}>
+                    <button
+                        type="button"
+                        className={styles.secondaryAction}
+                        onClick={() => openCatalogDoc('nbs', nebsState.detail?.item.code)}
+                    >
+                        Abrir item NEBS relacionado
+                    </button>
+                </div>
+            </>
+        );
+    } else {
+        detailBody = (
+            <div className={styles.emptyDetail}>
+                <strong>Selecione uma nota</strong>
+                <p>O painel mostra a nota explicativa publicada, a seção de origem e o vínculo com o serviço NEBS.</p>
             </div>
-            <h3>{nebsState.detail.entry.title}</h3>
-            <p className={styles.heroMeta}>
-              {nebsState.detail.entry.section_title || 'Secao nao informada'} •
-              Paginas {nebsState.detail.entry.page_start} a{' '}
-              {nebsState.detail.entry.page_end}
-            </p>
-          </div>
+        );
+    }
 
-          <div className={styles.breadcrumbs} aria-label="Hierarquia NEBS">
-            {nebsState.detail.ancestors.map((ancestor) => (
-              <button
-                key={ancestor.code}
-                type="button"
-                className={`${styles.crumb} ${styles.interactiveCode} service-code-target`}
-                data-service-code={ancestor.code}
-                onClick={() => openCatalogDoc('nbs', ancestor.code)}
-              >
-                {ancestor.code}
-              </button>
-            ))}
-            <button
-              type="button"
-              className={`${styles.crumbCurrentButton} ${styles.interactiveCode} service-code-target`}
-              data-service-code={nebsState.detail?.item.code}
-              onClick={() => openCatalogDoc('nbs', nebsState.detail?.item.code)}
-            >
-              {nebsState.detail.item.code}
-            </button>
-          </div>
-
-          <div className={styles.detailGrid}>
-            <section className={styles.card}>
-              <div className={styles.cardLabel}>Servico NEBS vinculado</div>
-              <p>{nebsState.detail.item.description}</p>
-            </section>
-
-            <section className={styles.card}>
-              <div className={styles.cardLabel}>Origem</div>
-              <p>
-                {nebsState.detail.entry.section_title ||
-                  'Secao nao identificada'}
-              </p>
-            </section>
-          </div>
-
-          <section className={styles.card}>
-            <div className={styles.cardLabel}>Conteudo da nota</div>
-            <div
-              className={styles.noteBody}
-              dangerouslySetInnerHTML={{ __html: nebsNoteBodyHtml }}
-            />
-          </section>
-
-          <div className={styles.detailActions}>
-            <button
-              type="button"
-              className={styles.secondaryAction}
-              onClick={() => openCatalogDoc('nbs', nebsState.detail?.item.code)}
-            >
-              Abrir item NEBS relacionado
-            </button>
-          </div>
-        </>
-      ) : (
-        <div className={styles.emptyDetail}>
-          <strong>Selecione uma nota</strong>
-          <p>
-            O painel mostra a nota explicativa publicada, a seção de origem e o
-            vínculo com o serviço NEBS.
-          </p>
-        </div>
-      )}
-    </section>
-  )
+    return (
+        <section className={styles.detailPanel}>
+            {detailBody}
+        </section>
+    );
 }
 
 interface NebsWorkspaceViewProps {
-  readonly nebsNoteBodyHtml: string
-  readonly nebsState: ServicesWorkspaceNebsState
-  readonly onSelectNebs: (code: string) => void
-  readonly openCatalogDoc: OpenCatalogDoc
+    readonly nebsNoteBodyHtml: string;
+    readonly nebsState: ServicesWorkspaceNebsState;
+    readonly onSelectNebs: (code: string) => void;
+    readonly openCatalogDoc: OpenCatalogDoc;
 }
 
 function NebsWorkspaceView({
-  nebsNoteBodyHtml,
-  nebsState,
-  onSelectNebs,
-  openCatalogDoc,
+    nebsNoteBodyHtml,
+    nebsState,
+    onSelectNebs,
+    openCatalogDoc,
 }: Readonly<NebsWorkspaceViewProps>) {
-  return (
-    <div className={styles.body}>
-      <NebsResultsSection nebsState={nebsState} onSelectNebs={onSelectNebs} />
-      <NebsDetailSection
-        nebsNoteBodyHtml={nebsNoteBodyHtml}
-        nebsState={nebsState}
-        openCatalogDoc={openCatalogDoc}
-      />
-    </div>
-  )
+    return (
+        <div className={styles.body}>
+            <NebsResultsSection
+                nebsState={nebsState}
+                onSelectNebs={onSelectNebs}
+            />
+            <NebsDetailSection
+                nebsNoteBodyHtml={nebsNoteBodyHtml}
+                nebsState={nebsState}
+                openCatalogDoc={openCatalogDoc}
+            />
+        </div>
+    );
 }
 
 export function ServicesWorkspace({
-  doc,
-  nbsState,
-  nebsState,
-  onSelectNbs,
-  onSelectNebs,
-  onSwitchDoc,
-  onOpenDocInNewTab,
+    doc,
+    nbsState,
+    nebsState,
+    onSelectNbs,
+    onSelectNebs,
+    onSwitchDoc,
+    onOpenDocInNewTab,
 }: Readonly<ServicesWorkspaceProps>) {
-  const nbsNoteBodyHtml = useMemo(
-    () => renderNoteHtml(nbsState.detail?.nebs),
-    [nbsState.detail]
-  )
-  const nebsNoteBodyHtml = useMemo(
-    () => renderNoteHtml(nebsState.detail?.entry),
-    [nebsState.detail]
-  )
-  const { openNewTab, nbsPrefixAutoExpand, nbsChapterNotesNewTab } =
-    useSettings()
-  const [isChapterNotesOpen, setIsChapterNotesOpen] = useState(false)
-  const chapterNotesDialogRef = useRef<HTMLDialogElement | null>(null)
-  const nbsNotesContentRef = useRef<HTMLDivElement | null>(null)
-  const chapterCodeSource =
-    doc === 'nbs'
-      ? nbsState.detail?.item.code ||
-        nbsState.selectedCode ||
-        (isCodeLikeNbsQuery(nbsState.query) ? nbsState.query : null)
-      : null
-  const activeChapterNumber = getNbsChapterNumber(chapterCodeSource)
-  const currentChapterNotesEntry = getNbsChapterNotesEntry(chapterCodeSource)
-  const chapterNotesHtml = currentChapterNotesEntry
-    ? renderNbsChapterNotesHtml(currentChapterNotesEntry)
-    : ''
+    const nbsNoteBodyHtml = useMemo(() => renderNoteHtml(nbsState.detail?.nebs), [nbsState.detail]);
+    const nebsNoteBodyHtml = useMemo(() => renderNoteHtml(nebsState.detail?.entry), [nebsState.detail]);
+    const { openNewTab, nbsPrefixAutoExpand, nbsChapterNotesNewTab } = useSettings();
+    const [isChapterNotesOpen, setIsChapterNotesOpen] = useState(false);
+    const chapterNotesDialogRef = useRef<HTMLDialogElement | null>(null);
+    const nbsNotesContentRef = useRef<HTMLDivElement | null>(null);
+    const chapterCodeSource = getNbsChapterCodeSource(doc, nbsState);
+    const activeChapterNumber = getNbsChapterNumber(chapterCodeSource);
+    const currentChapterNotesEntry = getNbsChapterNotesEntry(chapterCodeSource);
+    const chapterNotesHtml = currentChapterNotesEntry
+        ? renderNbsChapterNotesHtml(currentChapterNotesEntry)
+        : '';
 
-  const openCatalogDoc = (
-    targetDoc: ServiceDocType,
-    query?: string,
-    forceNewTab?: boolean
-  ) => {
-    if (!query) return
+    const openCatalogDoc = (targetDoc: ServiceDocType, query?: string, forceNewTab?: boolean) => {
+        if (!query) return;
 
-    if ((openNewTab || forceNewTab) && onOpenDocInNewTab) {
-      onOpenDocInNewTab(targetDoc, query)
-      return
+        if ((openNewTab || forceNewTab) && onOpenDocInNewTab) {
+            onOpenDocInNewTab(targetDoc, query);
+            return;
+        }
+
+        onSwitchDoc(targetDoc, query);
+    };
+
+    useEffect(() => {
+        const container = nbsNotesContentRef.current;
+        if (!container) return;
+
+        const handlePointer = (event: MouseEvent) => {
+            if (event.type === 'mousedown' && event.button !== 1) {
+                return;
+            }
+
+            const target = event.target;
+            if (!(target instanceof Element)) return;
+
+            const serviceLink = target.closest('.service-smart-link, .service-code-target');
+            if (!(serviceLink instanceof HTMLElement) || !container.contains(serviceLink)) {
+                return;
+            }
+
+            const serviceCode = serviceLink.dataset.serviceCode;
+            if (!serviceCode) return;
+
+            event.preventDefault();
+            event.stopPropagation();
+
+            const forceNewTab = event.metaKey || event.ctrlKey || event.button === 1;
+            openCatalogDoc('nebs', serviceCode, forceNewTab);
+        };
+
+        container.addEventListener('mousedown', handlePointer);
+        container.addEventListener('click', handlePointer);
+
+        return () => {
+            container.removeEventListener('mousedown', handlePointer);
+            container.removeEventListener('click', handlePointer);
+        };
+    }, [openCatalogDoc]);
+
+    useEffect(() => {
+        if (!isChapterNotesOpen || !currentChapterNotesEntry) {
+            if (chapterNotesDialogRef.current?.open) {
+                chapterNotesDialogRef.current.close();
+            }
+            return;
+        }
+
+        const dialog = chapterNotesDialogRef.current;
+        if (!dialog) return;
+
+        if (!dialog.open) {
+            dialog.showModal();
+        }
+    }, [currentChapterNotesEntry, isChapterNotesOpen]);
+
+    useEffect(() => {
+        if (isChapterNotesOpen && !currentChapterNotesEntry) {
+            setIsChapterNotesOpen(false);
+        }
+    }, [currentChapterNotesEntry, isChapterNotesOpen]);
+
+    if (doc === 'nbs') {
+        return (
+            <NbsWorkspaceView
+                activeChapterNumber={activeChapterNumber}
+                chapterNotesDialogRef={chapterNotesDialogRef}
+                chapterNotesHtml={chapterNotesHtml}
+                currentChapterNotesEntry={currentChapterNotesEntry}
+                nbsChapterNotesNewTab={nbsChapterNotesNewTab}
+                nbsNoteBodyHtml={nbsNoteBodyHtml}
+                nbsNotesContentRef={nbsNotesContentRef}
+                nbsPrefixAutoExpand={nbsPrefixAutoExpand}
+                nbsState={nbsState}
+                onSelectNbs={onSelectNbs}
+                setIsChapterNotesOpen={setIsChapterNotesOpen}
+            />
+        );
     }
 
-    onSwitchDoc(targetDoc, query)
-  }
-
-  useEffect(() => {
-    const container = nbsNotesContentRef.current
-    if (!container) return
-
-    const handlePointer = (event: MouseEvent) => {
-      if (event.type === 'mousedown' && event.button !== 1) {
-        return
-      }
-
-      const target = event.target
-      if (!(target instanceof Element)) return
-
-      const serviceLink = target.closest(
-        '.service-smart-link, .service-code-target'
-      )
-      if (
-        !(serviceLink instanceof HTMLElement) ||
-        !container.contains(serviceLink)
-      ) {
-        return
-      }
-
-      const serviceCode = serviceLink.dataset.serviceCode
-      if (!serviceCode) return
-
-      event.preventDefault()
-      event.stopPropagation()
-
-      const forceNewTab = event.metaKey || event.ctrlKey || event.button === 1
-      openCatalogDoc('nebs', serviceCode, forceNewTab)
-    }
-
-    container.addEventListener('mousedown', handlePointer)
-    container.addEventListener('click', handlePointer)
-
-    return () => {
-      container.removeEventListener('mousedown', handlePointer)
-      container.removeEventListener('click', handlePointer)
-    }
-  }, [openCatalogDoc])
-
-  useEffect(() => {
-    if (!isChapterNotesOpen || !currentChapterNotesEntry) {
-      if (chapterNotesDialogRef.current?.open) {
-        chapterNotesDialogRef.current.close()
-      }
-      return
-    }
-
-    const dialog = chapterNotesDialogRef.current
-    if (!dialog) return
-
-    if (!dialog.open) {
-      dialog.showModal()
-    }
-  }, [currentChapterNotesEntry, isChapterNotesOpen])
-
-  useEffect(() => {
-    if (isChapterNotesOpen && !currentChapterNotesEntry) {
-      setIsChapterNotesOpen(false)
-    }
-  }, [currentChapterNotesEntry, isChapterNotesOpen])
-
-  if (doc === 'nbs') {
     return (
-      <NbsWorkspaceView
-        activeChapterNumber={activeChapterNumber}
-        chapterNotesDialogRef={chapterNotesDialogRef}
-        chapterNotesHtml={chapterNotesHtml}
-        currentChapterNotesEntry={currentChapterNotesEntry}
-        nbsChapterNotesNewTab={nbsChapterNotesNewTab}
-        nbsNoteBodyHtml={nbsNoteBodyHtml}
-        nbsNotesContentRef={nbsNotesContentRef}
-        nbsPrefixAutoExpand={nbsPrefixAutoExpand}
-        nbsState={nbsState}
-        onSelectNbs={onSelectNbs}
-        setIsChapterNotesOpen={setIsChapterNotesOpen}
-      />
-    )
-  }
-
-  return (
-    <NebsWorkspaceView
-      nebsNoteBodyHtml={nebsNoteBodyHtml}
-      nebsState={nebsState}
-      onSelectNebs={onSelectNebs}
-      openCatalogDoc={openCatalogDoc}
-    />
-  )
+        <NebsWorkspaceView
+            nebsNoteBodyHtml={nebsNoteBodyHtml}
+            nebsState={nebsState}
+            onSelectNebs={onSelectNebs}
+            openCatalogDoc={openCatalogDoc}
+        />
+    );
 }

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -33,7 +33,6 @@ interface Chapter {
 interface SidebarProps {
   results: Record<string, Chapter> | null
   onNavigate: (targetId: string) => void
-  isOpen: boolean
   onClose: () => void
   searchQuery?: string
   activeAnchorId?: string | null
@@ -131,7 +130,6 @@ function comparePositionCodes(aCode: string, bCode: string): number {
 export const Sidebar = React.memo(function Sidebar({
   results,
   onNavigate,
-  isOpen,
   onClose,
   searchQuery,
   activeAnchorId,
@@ -336,7 +334,6 @@ export const Sidebar = React.memo(function Sidebar({
   return (
     <>
       <div
-        data-open={isOpen}
         className={`${styles.navSidebar} ${styles.active} ${isTipi ? styles.navSidebarTipi : ''}`}
       >
         <div className={styles.navHeader}>

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -1,127 +1,131 @@
-import React, { useMemo, useEffect, useRef } from "react";
-import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
-import styles from "./Sidebar.module.css";
-import { formatNcmTipi, generateAnchorId, normalizeNCMQuery } from "../utils/id_utils";
-import { debug } from "../utils/debug";
+import React, { useMemo, useEffect, useRef } from 'react'
+import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
+import styles from './Sidebar.module.css'
+import {
+  formatNcmTipi,
+  generateAnchorId,
+  normalizeNCMQuery,
+} from '../utils/id_utils'
+import { debug } from '../utils/debug'
 
 interface Position {
-  codigo: string;
-  descricao: string;
-  anchor_id?: string;
-  nivel?: number;
-  aliquota?: string;
+  codigo: string
+  descricao: string
+  anchor_id?: string
+  nivel?: number
+  aliquota?: string
 }
 
 interface ChapterSections {
-  titulo?: string | null;
-  notas?: string | null;
-  consideracoes?: string | null;
-  definicoes?: string | null;
+  titulo?: string | null
+  notas?: string | null
+  consideracoes?: string | null
+  definicoes?: string | null
 }
 
 interface Chapter {
-  capitulo: string;
-  posicoes: Position[];
-  notas_gerais?: string | null;
-  secoes?: ChapterSections;
+  capitulo: string
+  posicoes: Position[]
+  notas_gerais?: string | null
+  secoes?: ChapterSections
 }
 
 interface SidebarProps {
-  results: Record<string, Chapter> | null;
-  onNavigate: (targetId: string) => void;
-  isOpen: boolean;
-  onClose: () => void;
-  searchQuery?: string;
-  activeAnchorId?: string | null;
+  results: Record<string, Chapter> | null
+  onNavigate: (targetId: string) => void
+  isOpen: boolean
+  onClose: () => void
+  searchQuery?: string
+  activeAnchorId?: string | null
 }
 
 // Section navigation item types
-type SectionType = "titulo" | "notas" | "consideracoes" | "definicoes";
+type SectionType = 'titulo' | 'notas' | 'consideracoes' | 'definicoes'
 
 // Flat list types (Header, Section, or Item)
 type SidebarItem =
-  | { type: "header"; capitulo: string; count: number }
+  | { type: 'header'; capitulo: string; count: number }
   | {
-      type: "section";
-      sectionType: SectionType;
-      capitulo: string;
-      label: string;
-      icon: string;
+      type: 'section'
+      sectionType: SectionType
+      capitulo: string
+      label: string
+      icon: string
     }
-  | { type: "item"; pos: Position };
+  | { type: 'item'; pos: Position }
 
 // Section metadata for navigation
 const SECTION_CONFIG: Record<SectionType, { label: string; icon: string }> = {
-  titulo: { label: "Título do Capítulo", icon: "📖" },
-  notas: { label: "Notas do Capítulo", icon: "📝" },
-  consideracoes: { label: "Considerações Gerais", icon: "📚" },
-  definicoes: { label: "Definições Técnicas", icon: "📋" },
-};
+  titulo: { label: 'Título do Capítulo', icon: '📖' },
+  notas: { label: 'Notas do Capítulo', icon: '📝' },
+  consideracoes: { label: 'Considerações Gerais', icon: '📚' },
+  definicoes: { label: 'Definições Técnicas', icon: '📋' },
+}
 
 function toCodeSortSegments(code: string): number[] {
-  const normalized = formatNcmTipi(code);
-  const [firstSegment = "", ...otherSegments] = normalized.split(".");
-  const firstDigits = firstSegment.replaceAll(/\D/g, "");
+  const normalized = formatNcmTipi(code)
+  const [firstSegment = '', ...otherSegments] = normalized.split('.')
+  const firstDigits = firstSegment.replaceAll(/\D/g, '')
 
-  const normalizedSegments: string[] = [];
+  const normalizedSegments: string[] = []
   if (firstDigits.length === 4) {
-    normalizedSegments.push(firstDigits.slice(0, 2), firstDigits.slice(2, 4));
+    normalizedSegments.push(firstDigits.slice(0, 2), firstDigits.slice(2, 4))
   } else if (firstDigits.length > 0) {
-    normalizedSegments.push(firstDigits);
+    normalizedSegments.push(firstDigits)
   }
 
   otherSegments.forEach((segment) => {
-    const segmentDigits = segment.replaceAll(/\D/g, "");
+    const segmentDigits = segment.replaceAll(/\D/g, '')
     if (segmentDigits) {
-      normalizedSegments.push(segmentDigits);
+      normalizedSegments.push(segmentDigits)
     }
-  });
+  })
 
   const segments = normalizedSegments
     .map((segment) => Number.parseInt(segment, 10))
-    .filter((segment) => Number.isFinite(segment));
+    .filter((segment) => Number.isFinite(segment))
 
   if (segments.length > 0) {
-    return segments;
+    return segments
   }
 
-  const digits = code.replaceAll(/\D/g, "");
+  const digits = code.replaceAll(/\D/g, '')
   if (!digits) {
-    return [];
+    return []
   }
 
   if (digits.length >= 4) {
-    const grouped: string[] = [digits.slice(0, 2), digits.slice(2, 4)];
+    const grouped: string[] = [digits.slice(0, 2), digits.slice(2, 4)]
     for (let index = 4; index < digits.length; index += 2) {
-      grouped.push(digits.slice(index, index + 2));
+      grouped.push(digits.slice(index, index + 2))
     }
     return grouped
       .map((segment) => Number.parseInt(segment, 10))
-      .filter((segment) => Number.isFinite(segment));
+      .filter((segment) => Number.isFinite(segment))
   }
 
-  return [Number.parseInt(digits, 10)];
+  return [Number.parseInt(digits, 10)]
 }
 
 function comparePositionCodes(aCode: string, bCode: string): number {
-  const aSegments = toCodeSortSegments(aCode);
-  const bSegments = toCodeSortSegments(bCode);
-  const maxLength = Math.max(aSegments.length, bSegments.length);
+  const aSegments = toCodeSortSegments(aCode)
+  const bSegments = toCodeSortSegments(bCode)
+  const maxLength = Math.max(aSegments.length, bSegments.length)
 
   for (let index = 0; index < maxLength; index += 1) {
-    const aValue = aSegments[index];
-    const bValue = bSegments[index];
+    const aValue = aSegments[index]
+    const bValue = bSegments[index]
 
-    if (aValue === undefined && bValue === undefined) break;
-    if (aValue === undefined) return -1;
-    if (bValue === undefined) return 1;
-    if (aValue !== bValue) return aValue - bValue;
+    if (aValue === undefined && bValue === undefined) break
+    if (aValue === undefined) return -1
+    if (bValue === undefined) return 1
+    if (aValue !== bValue) return aValue - bValue
   }
 
-  return formatNcmTipi(aCode).localeCompare(formatNcmTipi(bCode), "pt-BR", {
+  return formatNcmTipi(aCode).localeCompare(formatNcmTipi(bCode), 'pt-BR', {
     numeric: true,
-    sensitivity: "base",
-  });
+    sensitivity: 'base',
+  })
 }
 
 export const Sidebar = React.memo(function Sidebar({
@@ -133,207 +137,207 @@ export const Sidebar = React.memo(function Sidebar({
   activeAnchorId,
 }: SidebarProps) {
   debug.log(
-    "[Sidebar] Rendering with results keys:",
-    results ? Object.keys(results).length : "null",
-  );
+    '[Sidebar] Rendering with results keys:',
+    results ? Object.keys(results).length : 'null'
+  )
 
   const isTipi = useMemo(() => {
-    if (!results) return false;
+    if (!results) return false
     return Object.values(results).some(
       (chapter: any) =>
         Array.isArray(chapter?.posicoes) &&
-        chapter.posicoes.some(
-          (pos: any) => "nivel" in pos || "aliquota" in pos,
-        ),
-    );
-  }, [results]);
+        chapter.posicoes.some((pos: any) => 'nivel' in pos || 'aliquota' in pos)
+    )
+  }, [results])
 
-  const virtuosoRef = useRef<VirtuosoHandle>(null);
-  const lastScrolledQueryRef = useRef<string | null>(null);
-  const lastSearchScrollAtRef = useRef<number>(0);
+  const virtuosoRef = useRef<VirtuosoHandle>(null)
+  const lastScrolledQueryRef = useRef<string | null>(null)
+  const lastSearchScrollAtRef = useRef<number>(0)
 
   useEffect(() => {
-    lastScrolledQueryRef.current = null;
-  }, [results, searchQuery]);
+    lastScrolledQueryRef.current = null
+  }, [results, searchQuery])
 
   // 1. Flatten Data & Build Index Map
   const { items, codeToIndex, anchorToIndex } = useMemo(() => {
-    if (!results) return { items: [], codeToIndex: {}, anchorToIndex: {} };
+    if (!results) return { items: [], codeToIndex: {}, anchorToIndex: {} }
 
     const sortedChapters = Object.values(results).sort(
-      (a, b) => Number.parseInt(a.capitulo, 10) - Number.parseInt(b.capitulo, 10),
-    );
+      (a, b) =>
+        Number.parseInt(a.capitulo, 10) - Number.parseInt(b.capitulo, 10)
+    )
 
-    const flatList: SidebarItem[] = [];
-    const indexMap: Record<string, number> = {};
-    const anchorMap: Record<string, number> = {};
+    const flatList: SidebarItem[] = []
+    const indexMap: Record<string, number> = {}
+    const anchorMap: Record<string, number> = {}
 
     sortedChapters.forEach((chapter) => {
       // Add Header
       flatList.push({
-        type: "header",
+        type: 'header',
         capitulo: chapter.capitulo,
         count: chapter.posicoes.length,
-      });
+      })
 
       // Add structured section items (NESH only)
-      const secoes = chapter.secoes;
+      const secoes = chapter.secoes
       if (secoes) {
         const sectionOrder: SectionType[] = [
-          "titulo",
-          "notas",
-          "consideracoes",
-          "definicoes",
-        ];
+          'titulo',
+          'notas',
+          'consideracoes',
+          'definicoes',
+        ]
         sectionOrder.forEach((sectionType) => {
           if (secoes[sectionType]) {
-            const config = SECTION_CONFIG[sectionType];
-            const currentIndex = flatList.length;
+            const config = SECTION_CONFIG[sectionType]
+            const currentIndex = flatList.length
             flatList.push({
-              type: "section",
+              type: 'section',
               sectionType,
               capitulo: chapter.capitulo,
               label: config.label,
               icon: config.icon,
-            });
-            const sectionAnchorId = `chapter-${chapter.capitulo}-${sectionType}`;
-            anchorMap[sectionAnchorId] = currentIndex;
+            })
+            const sectionAnchorId = `chapter-${chapter.capitulo}-${sectionType}`
+            anchorMap[sectionAnchorId] = currentIndex
           }
-        });
+        })
       } else if (chapter.notas_gerais) {
         // Legacy: single notes item
-        const currentIndex = flatList.length;
+        const currentIndex = flatList.length
         flatList.push({
-          type: "section",
-          sectionType: "notas",
+          type: 'section',
+          sectionType: 'notas',
           capitulo: chapter.capitulo,
           label: SECTION_CONFIG.notas.label,
           icon: SECTION_CONFIG.notas.icon,
-        });
-        const sectionAnchorId = `chapter-${chapter.capitulo}-notas`;
-        anchorMap[sectionAnchorId] = currentIndex;
+        })
+        const sectionAnchorId = `chapter-${chapter.capitulo}-notas`
+        anchorMap[sectionAnchorId] = currentIndex
       }
 
       // Add Positions (stable sort by normalized code segments for mixed TIPI/NESH formats)
       const sortedPositions = chapter.posicoes
         .map((pos, originalIndex) => ({ pos, originalIndex }))
         .sort((a, b) => {
-          const byCode = comparePositionCodes(a.pos.codigo, b.pos.codigo);
-          if (byCode !== 0) return byCode;
-          return a.originalIndex - b.originalIndex;
+          const byCode = comparePositionCodes(a.pos.codigo, b.pos.codigo)
+          if (byCode !== 0) return byCode
+          return a.originalIndex - b.originalIndex
         })
-        .map(({ pos }) => pos);
+        .map(({ pos }) => pos)
       sortedPositions.forEach((pos) => {
-        const currentIndex = flatList.length;
-        flatList.push({ type: "item", pos });
+        const currentIndex = flatList.length
+        flatList.push({ type: 'item', pos })
 
         // Map normalize code to index for fast lookup
         // Store both raw "8417.10" and clean "841710"
-        indexMap[pos.codigo] = currentIndex;
-        indexMap[pos.codigo.replaceAll(".", "")] = currentIndex;
-        anchorMap[generateAnchorId(pos.codigo)] = currentIndex;
-      });
-    });
+        indexMap[pos.codigo] = currentIndex
+        indexMap[pos.codigo.replaceAll('.', '')] = currentIndex
+        anchorMap[generateAnchorId(pos.codigo)] = currentIndex
+      })
+    })
 
     debug.log(
-      `[Sidebar] Flattened ${flatList.length} items from ${sortedChapters.length} chapters.`,
-    );
-    return { items: flatList, codeToIndex: indexMap, anchorToIndex: anchorMap };
-  }, [results]);
+      `[Sidebar] Flattened ${flatList.length} items from ${sortedChapters.length} chapters.`
+    )
+    return { items: flatList, codeToIndex: indexMap, anchorToIndex: anchorMap }
+  }, [results])
 
   const [highlightedIndex, setHighlightedIndex] = React.useState<number | null>(
-    null,
-  );
+    null
+  )
 
   // Sync active anchor from main content to sidebar highlight
   useEffect(() => {
-    if (!activeAnchorId) return;
-    const idx = anchorToIndex[activeAnchorId];
+    if (!activeAnchorId) return
+    const idx = anchorToIndex[activeAnchorId]
     if (idx !== undefined) {
-      setHighlightedIndex(idx);
+      setHighlightedIndex(idx)
       // Optional: Auto-follow? Maybe too aggressive.
       // But highlighting is good.
     }
-  }, [activeAnchorId, anchorToIndex]);
+  }, [activeAnchorId, anchorToIndex])
 
   // 2. Handle Auto-Scroll using Virtuoso (Robust Implementation)
   useEffect(() => {
-    if (!searchQuery || items.length === 0) return;
+    if (!searchQuery || items.length === 0) return
 
-    const rawQuery = searchQuery.trim();
-    if (!rawQuery) return;
+    const rawQuery = searchQuery.trim()
+    if (!rawQuery) return
 
-    const normalizedQuery = isTipi ? rawQuery : normalizeNCMQuery(rawQuery);
+    const normalizedQuery = isTipi ? rawQuery : normalizeNCMQuery(rawQuery)
     // Guard: Check normalized query to prevent loops if format changes slightly
-    if (lastScrolledQueryRef.current === normalizedQuery) return; // Prevent re-scroll on same query
+    if (lastScrolledQueryRef.current === normalizedQuery) return // Prevent re-scroll on same query
 
     const cleanQuery = isTipi
-      ? rawQuery.replaceAll(/\D/g, "")
-      : normalizedQuery.replaceAll(".", "");
+      ? rawQuery.replaceAll(/\D/g, '')
+      : normalizedQuery.replaceAll('.', '')
 
-    debug.log("[Sidebar Autoscroll] Look for:", normalizedQuery);
+    debug.log('[Sidebar Autoscroll] Look for:', normalizedQuery)
 
-    const cleanRaw = rawQuery.replaceAll(/\D/g, "");
+    const cleanRaw = rawQuery.replaceAll(/\D/g, '')
     // Strategy:
     // 1. Exact Code Match needed? Check indexMap
     // 2. Fallback to clean codes
-    let targetIndex = codeToIndex[rawQuery] ?? codeToIndex[cleanRaw];
+    let targetIndex = codeToIndex[rawQuery] ?? codeToIndex[cleanRaw]
 
     if (targetIndex === undefined) {
       // 3. Fallback: Prefix Match (4 digits)
       const positionDigits =
-        !isTipi && cleanRaw.length >= 4 ? cleanRaw.slice(0, 4) : cleanRaw;
+        !isTipi && cleanRaw.length >= 4 ? cleanRaw.slice(0, 4) : cleanRaw
       const positionDotted =
         !isTipi && positionDigits.length === 4
           ? `${positionDigits.slice(0, 2)}.${positionDigits.slice(2)}`
-          : positionDigits;
+          : positionDigits
 
-      targetIndex = codeToIndex[positionDigits] ?? codeToIndex[positionDotted];
+      targetIndex = codeToIndex[positionDigits] ?? codeToIndex[positionDotted]
     }
 
     if (targetIndex === undefined) {
       // 4. Normalized Query Match
-      targetIndex = codeToIndex[normalizedQuery] ?? codeToIndex[cleanQuery];
+      targetIndex = codeToIndex[normalizedQuery] ?? codeToIndex[cleanQuery]
     }
 
     if (targetIndex === undefined) {
       // 5. Scan for startsWith (Last Resort)
       const foundItemIndex = items.findIndex(
         (item) =>
-          item.type === "item" &&
-          item.pos.codigo.replaceAll(/\D/g, "").startsWith(cleanQuery),
-      );
-      if (foundItemIndex !== -1) targetIndex = foundItemIndex;
+          item.type === 'item' &&
+          item.pos.codigo.replaceAll(/\D/g, '').startsWith(cleanQuery)
+      )
+      if (foundItemIndex !== -1) targetIndex = foundItemIndex
     }
 
     if (targetIndex !== undefined) {
-      debug.log("[Sidebar Autoscroll] Scrolling to index:", targetIndex);
-      lastScrolledQueryRef.current = normalizedQuery;
-      lastSearchScrollAtRef.current = Date.now();
+      debug.log('[Sidebar Autoscroll] Scrolling to index:', targetIndex)
+      lastScrolledQueryRef.current = normalizedQuery
+      lastSearchScrollAtRef.current = Date.now()
 
       // Direct Scroll - Trust Virtuoso
       virtuosoRef.current?.scrollToIndex({
         index: targetIndex,
-        align: "center",
-        behavior: "auto",
-      });
+        align: 'center',
+        behavior: 'auto',
+      })
 
-      setHighlightedIndex(targetIndex);
+      setHighlightedIndex(targetIndex)
 
       // Clear highlight after delay
       const timer = setTimeout(() => {
-        setHighlightedIndex(null);
-      }, 2500);
-      return () => clearTimeout(timer);
+        setHighlightedIndex(null)
+      }, 2500)
+      return () => clearTimeout(timer)
     }
-  }, [searchQuery, items, codeToIndex, isTipi]);
+  }, [searchQuery, items, codeToIndex, isTipi])
 
-  if (!results || Object.keys(results).length === 0) return null;
+  if (!results || Object.keys(results).length === 0) return null
 
   return (
     <>
       <div
-        className={`${styles.navSidebar} ${styles.active} ${isTipi ? styles.navSidebarTipi : ""}`}
+        data-open={isOpen}
+        className={`${styles.navSidebar} ${styles.active} ${isTipi ? styles.navSidebarTipi : ''}`}
       >
         <div className={styles.navHeader}>
           <h3>Navegação</h3>
@@ -354,81 +358,81 @@ export const Sidebar = React.memo(function Sidebar({
             overscan={
               200
             } /* Pre-render 200px above/below viewport for smoother scroll */
-            className={`${styles.virtualList} ${isTipi ? styles.virtualListTipi : ""}`}
+            className={`${styles.virtualList} ${isTipi ? styles.virtualListTipi : ''}`}
             itemContent={(index, item) => {
-              if (item.type === "header") {
+              if (item.type === 'header') {
                 return (
                   <div
-                    className={`${styles.chapterTitle} ${isTipi ? styles.chapterTitleTipi : ""}`}
+                    className={`${styles.chapterTitle} ${isTipi ? styles.chapterTitleTipi : ''}`}
                   >
                     <span>Capítulo {item.capitulo}</span>
                     <span className={styles.chapterBadge}>{item.count}</span>
                   </div>
-                );
+                )
               }
 
-              if (item.type === "section") {
-                const sectionAnchorId = `chapter-${item.capitulo}-${item.sectionType}`;
+              if (item.type === 'section') {
+                const sectionAnchorId = `chapter-${item.capitulo}-${item.sectionType}`
                 const styleClass =
                   styles[
                     `sectionItem${item.sectionType.charAt(0).toUpperCase() + item.sectionType.slice(1)}` as keyof typeof styles
-                  ] || styles.notesItem;
-                const isHighlighted = index === highlightedIndex;
+                  ] || styles.notesItem
+                const isHighlighted = index === highlightedIndex
                 return (
                   <button
-                    className={`${styles.item} ${styles.sectionItem} ${styleClass} ${isHighlighted ? styles.itemHighlight : ""}`}
+                    className={`${styles.item} ${styles.sectionItem} ${styleClass} ${isHighlighted ? styles.itemHighlight : ''}`}
                     onClick={() => {
                       debug.log(
-                        "[Sidebar] Navigating to section:",
-                        sectionAnchorId,
-                      );
-                      onNavigate(sectionAnchorId);
-                      if (window.innerWidth < 768) onClose();
+                        '[Sidebar] Navigating to section:',
+                        sectionAnchorId
+                      )
+                      onNavigate(sectionAnchorId)
+                      if (window.innerWidth < 768) onClose()
                     }}
                     title={item.label}
                   >
                     <span className={styles.itemCode}>{item.icon}</span>
                     <span className={styles.itemDesc}>{item.label}</span>
                   </button>
-                );
+                )
               }
 
-              const { pos } = item;
-              const isHighlighted = index === highlightedIndex;
+              const { pos } = item
+              const isHighlighted = index === highlightedIndex
               const level =
-                typeof pos.nivel === "number" ? Math.min(pos.nivel, 5) : null;
+                typeof pos.nivel === 'number' ? Math.min(pos.nivel, 5) : null
               const levelClass = level
                 ? styles[`tipiLevel${level}` as keyof typeof styles]
-                : "";
+                : ''
 
               return (
                 <button
-                  className={`${styles.item} ${isTipi ? styles.itemTipi : ""} ${levelClass} ${isHighlighted ? styles.itemHighlight : ""}`}
+                  className={`${styles.item} ${isTipi ? styles.itemTipi : ''} ${levelClass} ${isHighlighted ? styles.itemHighlight : ''}`}
                   onClick={() => {
                     const targetId =
-                      pos.anchor_id || generateAnchorId(pos.codigo);
-                    debug.log("[Sidebar] Navigating to:", targetId);
-                    onNavigate(targetId);
-                    if (window.innerWidth < 768) onClose();
+                      pos.anchor_id || generateAnchorId(pos.codigo)
+                    debug.log('[Sidebar] Navigating to:', targetId)
+                    onNavigate(targetId)
+                    if (window.innerWidth < 768) onClose()
                   }}
                   title={pos.descricao}
                 >
                   <span
-                    className={`${styles.itemCode} ${isTipi ? styles.itemCodeTipi : ""}`}
+                    className={`${styles.itemCode} ${isTipi ? styles.itemCodeTipi : ''}`}
                   >
                     {pos.codigo}
                   </span>
                   <span
-                    className={`${styles.itemDesc} ${isTipi ? styles.itemDescTipi : ""}`}
+                    className={`${styles.itemDesc} ${isTipi ? styles.itemDescTipi : ''}`}
                   >
                     {pos.descricao}
                   </span>
                 </button>
-              );
+              )
             }}
           />
         </div>
       </div>
     </>
-  );
-});
+  )
+})

--- a/client/tests/e2e/services-tabs.flow.test.tsx
+++ b/client/tests/e2e/services-tabs.flow.test.tsx
@@ -182,7 +182,8 @@ describe('services tabs flow', () => {
     render(<ServicesTabsHarness initialDoc="nbs" initialQuery="1.0101.11.00" />);
 
     await screen.findByText('Resultados NBS');
-    fireEvent.click(screen.getByRole('button', { name: 'Ver NBS' }));
+    const verNbsButton = await screen.findByRole('button', { name: 'Ver NBS' });
+    fireEvent.click(verNbsButton);
 
     await waitFor(() => {
       expect(screen.getByTestId('tab-list')).toHaveAttribute('data-count', '1');
@@ -196,7 +197,10 @@ describe('services tabs flow', () => {
     render(<ServicesTabsHarness initialDoc="nebs" initialQuery="1.0101.11.00" />);
 
     await screen.findByText('Resultados NEBS');
-    fireEvent.click(screen.getByRole('button', { name: 'Abrir item NBS relacionado' }));
+    const openNbsRelatedButton = await screen.findByRole('button', {
+      name: 'Abrir item NBS relacionado',
+    });
+    fireEvent.click(openNbsRelatedButton);
 
     await waitFor(() => {
       expect(screen.getByTestId('tab-list')).toHaveAttribute('data-count', '1');
@@ -210,7 +214,8 @@ describe('services tabs flow', () => {
     render(<ServicesTabsHarness initialDoc="nbs" initialQuery="1.0101.11.00" />);
 
     await screen.findByText('Resultados NBS');
-    fireEvent.click(screen.getByRole('button', { name: 'Ver NBS' }));
+    const verNbsButton = await screen.findByRole('button', { name: 'Ver NBS' });
+    fireEvent.click(verNbsButton);
 
     await waitFor(() => {
       expect(screen.getByTestId('active-tab-meta')).toHaveTextContent('nebs:1.0101.11.00');
@@ -235,8 +240,10 @@ describe('services tabs flow', () => {
       />,
     );
 
-    await screen.findByRole('button', { name: 'Abrir item NBS relacionado' });
-    fireEvent.click(screen.getByRole('button', { name: 'Abrir item NBS relacionado' }));
+    const openNbsRelatedButton = await screen.findByRole('button', {
+      name: 'Abrir item NBS relacionado',
+    });
+    fireEvent.click(openNbsRelatedButton);
 
     expect(onOpenDocInNewTab).toHaveBeenCalledWith('nbs', '1.0101.11.00');
   });
@@ -254,7 +261,8 @@ describe('services tabs flow', () => {
     );
 
     await screen.findByText('Resultados NBS');
-    fireEvent.click(screen.getByRole('button', { name: 'Ver NBS' }));
+    const verNbsButton = await screen.findByRole('button', { name: 'Ver NBS' });
+    fireEvent.click(verNbsButton);
 
     expect(onOpenDocInNewTab).toHaveBeenCalledWith('nebs', '1.0101.11.00');
   });
@@ -263,7 +271,8 @@ describe('services tabs flow', () => {
     render(<ServicesTabsHarness initialDoc="nebs" initialQuery="1.0101.11.00" />);
 
     await screen.findByText('Resultados NEBS');
-    fireEvent.click(screen.getByRole('button', { name: '1.01' }));
+    const breadcrumbButton = await screen.findByRole('button', { name: '1.01' });
+    fireEvent.click(breadcrumbButton);
 
     await waitFor(() => {
       expect(screen.getByTestId('tab-list')).toHaveAttribute('data-count', '1');
@@ -284,7 +293,8 @@ describe('services tabs flow', () => {
     );
 
     await screen.findByText('Resultados NEBS');
-    fireEvent.click(screen.getByRole('button', { name: '1.01' }));
+    const breadcrumbButton = await screen.findByRole('button', { name: '1.01' });
+    fireEvent.click(breadcrumbButton);
 
     expect(onOpenDocInNewTab).toHaveBeenCalledWith('nbs', '1.01');
     expect(screen.getByTestId('active-tab-meta')).toHaveTextContent('nebs:1.0101.11.00');

--- a/client/tests/e2e/services-tabs.flow.test.tsx
+++ b/client/tests/e2e/services-tabs.flow.test.tsx
@@ -182,7 +182,7 @@ describe('services tabs flow', () => {
     render(<ServicesTabsHarness initialDoc="nbs" initialQuery="1.0101.11.00" />);
 
     await screen.findByText('Resultados NBS');
-    fireEvent.click(screen.getByRole('button', { name: 'Ver NEBS' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Ver NBS' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('tab-list')).toHaveAttribute('data-count', '1');
@@ -192,7 +192,7 @@ describe('services tabs flow', () => {
     expect(screen.getByText('Esta subposição inclui serviços de novas construções e reparo.')).toBeInTheDocument();
   });
 
-  it('switches back to NBS results when the user clicks the NEBS header action', async () => {
+  it('switches back to NBS results when the user clicks the NBS header action', async () => {
     render(<ServicesTabsHarness initialDoc="nebs" initialQuery="1.0101.11.00" />);
 
     await screen.findByText('Resultados NEBS');
@@ -203,14 +203,14 @@ describe('services tabs flow', () => {
       expect(screen.getByTestId('active-tab-meta')).toHaveTextContent('nbs:1.0101.11.00');
     });
     expect(await screen.findByText('Resultados NBS')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Ver NEBS' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Ver NBS' })).toBeInTheDocument();
   });
 
   it('preserves the current query when toggling between NBS and NEBS results', async () => {
     render(<ServicesTabsHarness initialDoc="nbs" initialQuery="1.0101.11.00" />);
 
     await screen.findByText('Resultados NBS');
-    fireEvent.click(screen.getByRole('button', { name: 'Ver NEBS' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Ver NBS' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('active-tab-meta')).toHaveTextContent('nebs:1.0101.11.00');
@@ -241,7 +241,7 @@ describe('services tabs flow', () => {
     expect(onOpenDocInNewTab).toHaveBeenCalledWith('nbs', '1.0101.11.00');
   });
 
-  it('opens NEBS in a new tab when clicking Ver NEBS and preference is enabled', async () => {
+  it('opens NEBS in a new tab when clicking Ver NBS and preference is enabled', async () => {
     const onOpenDocInNewTab = vi.fn();
     refs.openNewTab = true;
 
@@ -254,7 +254,7 @@ describe('services tabs flow', () => {
     );
 
     await screen.findByText('Resultados NBS');
-    fireEvent.click(screen.getByRole('button', { name: 'Ver NEBS' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Ver NBS' }));
 
     expect(onOpenDocInNewTab).toHaveBeenCalledWith('nebs', '1.0101.11.00');
   });

--- a/client/tests/playwright/services-tabs.resilience.spec.ts
+++ b/client/tests/playwright/services-tabs.resilience.spec.ts
@@ -69,7 +69,7 @@ test('shows the NEBS empty/error state after a linked NEBS search fails', async 
 
   await openServicesModal(page);
   await searchServices(page, '1.0101.11.00');
-  const openNebsButton = page.getByRole('button', { name: /Ver NEBS/ });
+  const openNebsButton = page.getByRole('button', { name: /Ver NBS/ });
   await expect(openNebsButton).toBeVisible();
 
   const nebsRequest = page.waitForRequest((request) =>

--- a/client/tests/playwright/services-tabs.spec.ts
+++ b/client/tests/playwright/services-tabs.spec.ts
@@ -57,7 +57,7 @@ test('loads NBS search results and the linked detail panel', async ({ page }) =>
   await expect(page.getByRole('heading', { name: 'Resultados NBS' })).toBeVisible();
   await expect(page.getByRole('button', { name: /Serviços de construção de edificações residenciais/ })).toBeVisible();
   await expect(page.getByText('NOTAS EXPLICATIVAS')).toBeVisible();
-  await expect(page.getByRole('button', { name: /Ver NEBS/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Ver NBS/ })).toBeVisible();
 });
 
 test('switches from an NBS detail to the linked NEBS detail', async ({ page }) => {
@@ -69,7 +69,7 @@ test('switches from an NBS detail to the linked NEBS detail', async ({ page }) =
     && new URL(request.url()).searchParams.get('q') === '1.0101.11.00',
   );
 
-  await page.getByRole('button', { name: /Ver NEBS/ }).click();
+  await page.getByRole('button', { name: /Ver NBS/ }).click();
   await nebsRequest;
 
   await expect(page.getByRole('heading', { name: 'Resultados NEBS' })).toBeVisible();
@@ -80,7 +80,7 @@ test('switches from an NBS detail to the linked NEBS detail', async ({ page }) =
 test('returns from a NEBS detail to the linked NBS detail', async ({ page }) => {
   await openServicesModal(page);
   await searchServices(page, '1.0101.11.00');
-  await page.getByRole('button', { name: /Ver NEBS/ }).click();
+  await page.getByRole('button', { name: /Ver NBS/ }).click();
   await expect(page.getByRole('heading', { name: 'Resultados NEBS' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Abrir item NBS relacionado' })).toBeVisible();
 
@@ -93,7 +93,7 @@ test('returns from a NEBS detail to the linked NBS detail', async ({ page }) => 
   await nbsRequest;
 
   await expect(page.getByRole('heading', { name: 'Resultados NBS' })).toBeVisible();
-  await expect(page.getByRole('button', { name: /Ver NEBS/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Ver NBS/ })).toBeVisible();
 });
 
 test('updates NBS detail when clicking an ancestor in the hierarchy', async ({ page }) => {
@@ -218,7 +218,7 @@ test('opens smart-link target in a new tab with middle-click', async ({ page }) 
 test('navigates from NEBS breadcrumbs back to NBS detail in the same tab', async ({ page }) => {
   await openServicesModal(page);
   await searchServices(page, '1.0101.11.00');
-  await page.getByRole('button', { name: /Ver NEBS/ }).click();
+  await page.getByRole('button', { name: /Ver NBS/ }).click();
   await expect(page.getByRole('heading', { name: 'Resultados NEBS' })).toBeVisible();
 
   const nbsRequest = page.waitForRequest((request) =>
@@ -235,7 +235,7 @@ test('navigates from NEBS breadcrumbs back to NBS detail in the same tab', async
 test('opens NEBS breadcrumb navigation in a new tab when preference is enabled', async ({ page }) => {
   await openServicesModal(page);
   await searchServices(page, '1.0101.11.00');
-  await page.getByRole('button', { name: /Ver NEBS/ }).click();
+  await page.getByRole('button', { name: /Ver NBS/ }).click();
   await expect(page.getByRole('heading', { name: 'Resultados NEBS' })).toBeVisible();
 
   const initialTabCount = await page.locator('div[draggable="true"][data-document]').count();
@@ -256,7 +256,7 @@ test('opens NEBS breadcrumb navigation in a new tab when preference is enabled',
 test('opens linked NBS detail in a new tab when preference is enabled', async ({ page }) => {
   await openServicesModal(page);
   await searchServices(page, '1.0101.11.00');
-  await page.getByRole('button', { name: /Ver NEBS/ }).click();
+  await page.getByRole('button', { name: /Ver NBS/ }).click();
   await expect(page.getByRole('heading', { name: 'Resultados NEBS' })).toBeVisible();
 
   const initialTabCount = await page.locator('div[draggable="true"][data-document]').count();

--- a/client/tests/unit/Header.test.tsx
+++ b/client/tests/unit/Header.test.tsx
@@ -145,9 +145,9 @@ describe('Header', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'NEBS' }));
+    fireEvent.click(screen.getByRole('button', { name: 'NBS' }));
 
-    expect(setDoc).toHaveBeenCalledWith('nebs');
+    expect(setDoc).toHaveBeenCalledWith('nbs');
     expect(screen.getByText('Classificação Brasileira de Serviços')).toBeInTheDocument();
   });
 
@@ -214,7 +214,7 @@ describe('Header', () => {
     render(
       <Header
         onSearch={vi.fn()}
-        doc="nebs"
+        doc="nbs"
         setDoc={setDoc}
         searchKey="search-1"
         onOpenSettings={vi.fn()}
@@ -351,3 +351,4 @@ describe('Header', () => {
     expect(setDoc).not.toHaveBeenCalled();
   });
 });
+

--- a/client/tests/unit/Header.test.tsx
+++ b/client/tests/unit/Header.test.tsx
@@ -123,7 +123,7 @@ describe('Header', () => {
     expect(screen.getByText('Notas Explicativas do Sistema Harmonizado')).toBeInTheDocument();
   });
 
-  it('uses NBS and NEBS in the selector when the active document is a service tab', () => {
+  it('uses NEBS in the selector when the active document is NBS', () => {
     const setDoc = vi.fn();
 
     render(
@@ -208,36 +208,39 @@ describe('Header', () => {
     expect(screen.getByText('Tabela de Incidência do IPI')).toBeInTheDocument();
   });
 
-  it('shows menu shortcuts to return to NESH and TIPI from service tabs', () => {
-    const setDoc = vi.fn();
+  it.each(['nbs', 'nebs'] as const)(
+    'shows menu shortcuts to return to NESH and TIPI from service tabs when doc=%s',
+    (doc) => {
+      const setDoc = vi.fn();
 
-    render(
-      <Header
-        onSearch={vi.fn()}
-        doc="nbs"
-        setDoc={setDoc}
-        searchKey="search-1"
-        onOpenSettings={vi.fn()}
-        onOpenTutorial={vi.fn()}
-        onOpenStats={vi.fn()}
-        onOpenComparator={vi.fn()}
-        onOpenModerate={vi.fn()}
-        onOpenProfile={vi.fn()}
-        history={[]}
-        onClearHistory={vi.fn()}
-        onRemoveHistory={vi.fn()}
-        onMenuOpen={vi.fn()}
-      />,
-    );
+      render(
+        <Header
+          onSearch={vi.fn()}
+          doc={doc}
+          setDoc={setDoc}
+          searchKey="search-1"
+          onOpenSettings={vi.fn()}
+          onOpenTutorial={vi.fn()}
+          onOpenStats={vi.fn()}
+          onOpenComparator={vi.fn()}
+          onOpenModerate={vi.fn()}
+          onOpenProfile={vi.fn()}
+          history={[]}
+          onClearHistory={vi.fn()}
+          onRemoveHistory={vi.fn()}
+          onMenuOpen={vi.fn()}
+        />,
+      );
 
-    openMenu();
-    fireEvent.click(screen.getByText('Voltar para NESH').closest('button') as HTMLButtonElement);
-    fireEvent.click(getMenuButton());
-    fireEvent.click(screen.getByText('Ir para TIPI').closest('button') as HTMLButtonElement);
+      openMenu();
+      fireEvent.click(screen.getByText('Voltar para NESH').closest('button') as HTMLButtonElement);
+      fireEvent.click(getMenuButton());
+      fireEvent.click(screen.getByText('Ir para TIPI').closest('button') as HTMLButtonElement);
 
-    expect(setDoc).toHaveBeenNthCalledWith(1, 'nesh');
-    expect(setDoc).toHaveBeenNthCalledWith(2, 'tipi');
-  });
+      expect(setDoc).toHaveBeenNthCalledWith(1, 'nesh');
+      expect(setDoc).toHaveBeenNthCalledWith(2, 'tipi');
+    },
+  );
 
   it('renders fallback user labels when auth profile is missing', () => {
     userNameRef.value = null;

--- a/client/tests/unit/Header.test.tsx
+++ b/client/tests/unit/Header.test.tsx
@@ -145,9 +145,9 @@ describe('Header', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'NBS' }));
+    fireEvent.click(screen.getByRole('button', { name: 'NEBS' }));
 
-    expect(setDoc).toHaveBeenCalledWith('nbs');
+    expect(setDoc).toHaveBeenCalledWith('nebs');
     expect(screen.getByText('Classificação Brasileira de Serviços')).toBeInTheDocument();
   });
 
@@ -351,4 +351,3 @@ describe('Header', () => {
     expect(setDoc).not.toHaveBeenCalled();
   });
 });
-

--- a/client/tests/unit/ResultDisplay.advanced.test.tsx
+++ b/client/tests/unit/ResultDisplay.advanced.test.tsx
@@ -315,50 +315,62 @@ describe('ResultDisplay advanced behavior', () => {
   });
 
   it('renders TIPI fallback, applies aliquot classes and toggles sidebar', async () => {
-    render(
-      <ResultDisplay
-        data={{
-          type: 'code',
-          query: '1001',
-          resultados: {
-            '10': {
-              capitulo: '10',
-              titulo: 'Cereais',
-              posicoes: [
-                { codigo: '10.01', ncm: '10.01', descricao: 'Zero', aliquota: '0', nivel: 1 },
-                { codigo: '10.02', ncm: '10.02', descricao: 'NT', aliquota: 'NT', nivel: 2 },
-                { codigo: '10.03', ncm: '10.03', descricao: 'Baixa', aliquota: '3', nivel: 3 },
-                { codigo: '10.04', ncm: '10.04', descricao: 'Media', aliquota: '8', nivel: 4 },
-                { codigo: '10.05', ncm: '10.05', descricao: 'Alta', aliquota: '15', nivel: 7 },
-                { codigo: '10.06', ncm: '10.06', descricao: 'Texto', aliquota: 'abc', nivel: 1 },
-              ],
-            },
-          },
-        }}
-        mobileMenuOpen={true}
-        onCloseMobileMenu={vi.fn()}
-        isActive={true}
-        tabId="tab-tipi"
-        isNewSearch={false}
-        onConsumeNewSearch={vi.fn()}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText('Cereais')).toBeInTheDocument();
-      expect(screen.getByTestId('sidebar-mock')).toBeInTheDocument();
+    const originalInnerWidth = Object.getOwnPropertyDescriptor(window, 'innerWidth');
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 1440,
     });
 
-    expect(document.querySelector('.aliquot-zero')).toBeTruthy();
-    expect(document.querySelector('.aliquot-nt')).toBeTruthy();
-    expect(document.querySelector('.aliquot-low')).toBeTruthy();
-    expect(document.querySelector('.aliquot-med')).toBeTruthy();
-    expect(document.querySelector('.aliquot-high')).toBeTruthy();
-    expect(document.querySelector('.tipi-nivel-5')).toBeTruthy();
+    try {
+      render(
+        <ResultDisplay
+          data={{
+            type: 'code',
+            query: '1001',
+            resultados: {
+              '10': {
+                capitulo: '10',
+                titulo: 'Cereais',
+                posicoes: [
+                  { codigo: '10.01', ncm: '10.01', descricao: 'Zero', aliquota: '0', nivel: 1 },
+                  { codigo: '10.02', ncm: '10.02', descricao: 'NT', aliquota: 'NT', nivel: 2 },
+                  { codigo: '10.03', ncm: '10.03', descricao: 'Baixa', aliquota: '3', nivel: 3 },
+                  { codigo: '10.04', ncm: '10.04', descricao: 'Media', aliquota: '8', nivel: 4 },
+                  { codigo: '10.05', ncm: '10.05', descricao: 'Alta', aliquota: '15', nivel: 7 },
+                  { codigo: '10.06', ncm: '10.06', descricao: 'Texto', aliquota: 'abc', nivel: 1 },
+                ],
+              },
+            },
+          }}
+          mobileMenuOpen={true}
+          onCloseMobileMenu={vi.fn()}
+          isActive={true}
+          tabId="tab-tipi"
+          isNewSearch={false}
+          onConsumeNewSearch={vi.fn()}
+        />,
+      );
 
-    const toggle = screen.getByRole('button', { name: 'Recolher navegação' });
-    fireEvent.click(toggle);
-    expect(screen.getByRole('button', { name: 'Expandir navegação' })).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('Cereais')).toBeInTheDocument();
+        expect(screen.getByTestId('sidebar-mock')).toBeInTheDocument();
+      });
+
+      expect(document.querySelector('.aliquot-zero')).toBeTruthy();
+      expect(document.querySelector('.aliquot-nt')).toBeTruthy();
+      expect(document.querySelector('.aliquot-low')).toBeTruthy();
+      expect(document.querySelector('.aliquot-med')).toBeTruthy();
+      expect(document.querySelector('.aliquot-high')).toBeTruthy();
+      expect(document.querySelector('.tipi-nivel-5')).toBeTruthy();
+
+      const toggle = screen.getByRole('button', { name: 'Recolher navegação' });
+      fireEvent.click(toggle);
+      expect(screen.getByRole('button', { name: 'Expandir navegação' })).toBeInTheDocument();
+    } finally {
+      if (originalInnerWidth) {
+        Object.defineProperty(window, 'innerWidth', originalInnerWidth);
+      }
+    }
   });
 
   it('keeps TIPI sidebar highlight on the clicked item while smooth scroll settles', async () => {

--- a/scripts/report_long_functions.py
+++ b/scripts/report_long_functions.py
@@ -76,16 +76,17 @@ def _statement_start_line(statement: ast.stmt) -> int:
     line_numbers = [getattr(statement, "lineno", None)]
 
     decorators = getattr(statement, "decorator_list", None) or []
-    line_numbers.extend(
-        getattr(decorator, "lineno", None) for decorator in decorators
-    )
+    line_numbers.extend(getattr(decorator, "lineno", None) for decorator in decorators)
 
     valid_lines = [line for line in line_numbers if line is not None]
     return min(valid_lines) if valid_lines else 0
 
 
 def _statement_end_line(statement: ast.stmt) -> int:
-    line_numbers = [getattr(statement, "end_lineno", None), getattr(statement, "lineno", None)]
+    line_numbers = [
+        getattr(statement, "end_lineno", None),
+        getattr(statement, "lineno", None),
+    ]
 
     decorators = getattr(statement, "decorator_list", None) or []
     line_numbers.extend(
@@ -203,7 +204,9 @@ def _collect_module_level_findings(
     return findings
 
 
-def _sort_findings(findings: Iterable[LongFunctionFinding]) -> list[LongFunctionFinding]:
+def _sort_findings(
+    findings: Iterable[LongFunctionFinding],
+) -> list[LongFunctionFinding]:
     return sorted(
         findings,
         key=lambda finding: (
@@ -237,7 +240,7 @@ def scan_tree(root: Path | str, threshold: int = DEFAULT_THRESHOLD) -> ScanRepor
             continue
 
         try:
-            tree = ast.parse(source, filename=str(file_path))
+            ast.parse(source, filename=str(file_path))
         except SyntaxError as exc:
             issues.append(
                 ScanIssue(
@@ -252,7 +255,10 @@ def scan_tree(root: Path | str, threshold: int = DEFAULT_THRESHOLD) -> ScanRepor
         )
 
     findings = _sort_findings(collected_findings)
-    numbered_findings = [replace(finding, item_id=f"ITEM_{index:04d}") for index, finding in enumerate(findings, start=1)]
+    numbered_findings = [
+        replace(finding, item_id=f"ITEM_{index:04d}")
+        for index, finding in enumerate(findings, start=1)
+    ]
 
     return ScanReport(
         root=root_path,

--- a/tests/integration/test_search_route_contracts.py
+++ b/tests/integration/test_search_route_contracts.py
@@ -30,10 +30,7 @@ class _FakeNeshServiceCode:
 
 
 def test_search_handler_keeps_legacy_alias_to_canonical_name():
-    assert (
-        search_route.search
-        is search_route.handleGlobalFiscalSearchRequest
-    )
+    assert search_route.search is search_route.handleGlobalFiscalSearchRequest
 
 
 class _FakeNeshServiceText:

--- a/tests/unit/test_app_lifespan_additional.py
+++ b/tests/unit/test_app_lifespan_additional.py
@@ -197,7 +197,9 @@ def test_configure_routes_keeps_fallback_when_frontend_index_missing(tmp_path):
 
     app_module._configure_routes(app, str(tmp_path), app_module.logger)
 
-    assert not any(getattr(route, "name", None) == "static" for route in app.router.routes)
+    assert not any(
+        getattr(route, "name", None) == "static" for route in app.router.routes
+    )
     assert any(
         getattr(route, "path", None) == "/"
         and getattr(route, "name", None) == "_read_root"
@@ -525,7 +527,9 @@ def test_build_content_security_policy_keeps_local_origins_in_development(monkey
     assert "https://cdn.jsdelivr.net" in csp
 
 
-def test_build_cors_configuration_defaults_to_localhost_only_in_development(monkeypatch):
+def test_build_cors_configuration_defaults_to_localhost_only_in_development(
+    monkeypatch,
+):
     monkeypatch.setattr(app_module.settings.server, "env", "development", raising=False)
     monkeypatch.setattr(
         app_module.settings.server, "cors_allowed_origins", None, raising=False

--- a/tests/unit/test_cache_key_normalization.py
+++ b/tests/unit/test_cache_key_normalization.py
@@ -114,7 +114,10 @@ class TestSearchCacheRequestContext:
         assert context.normalized_query == "8517"
         assert context.payload_cache_key is not None
         assert context.payload_cache_key.endswith(":8517:full")
-        assert context.cache_headers["Vary"] == "Authorization, X-Tenant-Id, Accept-Encoding"
+        assert (
+            context.cache_headers["Vary"]
+            == "Authorization, X-Tenant-Id, Accept-Encoding"
+        )
 
     def test_builds_text_query_context_without_payload_key(self):
         request = _build_request_with_accept_encoding("gzip")

--- a/tests/unit/test_db_engine.py
+++ b/tests/unit/test_db_engine.py
@@ -133,7 +133,9 @@ async def test_get_session_and_get_db_use_tenant_context(monkeypatch) -> None:
 
     try:
         settings.database.engine = "postgresql"
-        monkeypatch.setattr(db_engine, "get_session_maker", lambda: _FakeSessionMaker(fake_session))
+        monkeypatch.setattr(
+            db_engine, "get_session_maker", lambda: _FakeSessionMaker(fake_session)
+        )
 
         async with db_engine.get_session() as session:
             assert session is fake_session

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -104,9 +104,10 @@ def test_sanitizers_redact_nested_sensitive_values():
     sensitive_key = "".join(["pass", "word"])
     assert logging_config._is_sensitive_key("api-key") is True
     assert logging_config._is_sensitive_key("visible") is False
-    assert logging_config._sanitize_string(
-        f"token=abc {sensitive_key}=xyz"
-    ) == f"token=[REDACTED] {sensitive_key}=[REDACTED]"
+    assert (
+        logging_config._sanitize_string(f"token=abc {sensitive_key}=xyz")
+        == f"token=[REDACTED] {sensitive_key}=[REDACTED]"
+    )
 
     sanitized = logging_config._sanitize_value(
         {

--- a/tests/unit/test_middleware_additional.py
+++ b/tests/unit/test_middleware_additional.py
@@ -921,10 +921,7 @@ def test_is_recently_provisioned_treats_zero_timestamp_as_valid():
     cache_key = ("org1", "u1")
     cache = {cache_key: 0.0}
 
-    assert (
-        middleware._is_recently_provisioned(cache_key, 10.0, cache, 30.0)
-        is True
-    )
+    assert middleware._is_recently_provisioned(cache_key, 10.0, cache, 30.0) is True
     assert middleware._is_recently_provisioned(cache_key, 10.0, {}, 30.0) is False
 
 

--- a/tests/unit/test_report_long_functions.py
+++ b/tests/unit/test_report_long_functions.py
@@ -40,7 +40,7 @@ def test_scan_tree_reports_only_module_level_functions_and_skips_generated_dirs(
         project_root.mkdir()
 
         source = textwrap.dedent(
-            '''
+            """
             def short_function():
                 return 1
 
@@ -63,7 +63,7 @@ def test_scan_tree_reports_only_module_level_functions_and_skips_generated_dirs(
                     value = 1
                     value += 2
                     return value
-            '''
+            """
         )
         (project_root / "module.py").write_text(source, encoding="utf-8")
 
@@ -93,7 +93,7 @@ def test_write_json_report_exports_root_object_keyed_by_item_ids():
         project_root.mkdir()
 
         source = textwrap.dedent(
-            '''
+            """
             def first():
                 a = 1
                 b = 2
@@ -104,7 +104,7 @@ def test_write_json_report_exports_root_object_keyed_by_item_ids():
                 value += 2
                 value += 3
                 return value
-            '''
+            """
         )
         (project_root / "module.py").write_text(source, encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1352,11 +1352,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fresh branch from `main` after the accidental merge path was reverted.

This draft reapplies the current renderer smart-link fallback work on a clean branch so follow-up fixes on the same files can continue without touching `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Ver NBS" action button to open NBS catalog documents when available.

* **Changes**
  * Updated UI terminology from "NEBS" to "NBS" across labels, breadcrumbs, buttons and empty states.
  * Header document selector now treats both NBS and NEBS as service documents and adjusts primary selector labels accordingly.
  * Results header now shows "Resultados NBS" for NBS documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->