### PR TITLE
[codex] Make offline database download public

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,12 @@ Arquivos gerados:
 
 Esses dois arquivos sao o pacote offline usado pelo botao de instalacao no navegador.
 
+Contrato publico do banco offline:
+
+- O pacote offline (`fiscal_offline.enc` + `fiscal_offline.meta`) e considerado publico. Ele pode ser baixado sem login por meio das rotas `/api/database/version`, `/api/database/token` e `/api/database/download`; o token efemero existe para limitar reuso/abuso do download, nao para transformar o pacote em dado privado.
+- A criptografia do pacote offline protege integridade/formato de distribuicao, mas nao deve ser tratada como controle de acesso a dados sigilosos. Nao incluir informacao privada, segredos, dados de usuarios ou conteudo restrito dentro do bundle offline.
+- O conteudo NEBS associado a NBS faz parte do contrato do catalogo offline e online. A descricao/entrada explicativa NEBS vinculada ao item NBS deve permanecer no banco, no bundle offline e no detalhe da NBS; nao remover `has_nebs`, `nebs_entries` nem o payload `detail.nebs` sem substituir o fluxo por equivalente compativel.
+
 Comportamento esperado do fluxo:
 
 - o frontend consulta `GET /api/database/version`

--- a/backend/server/middleware.py
+++ b/backend/server/middleware.py
@@ -352,6 +352,8 @@ class TenantMiddleware:
         "/api/tipi/chapters",
         "/api/webhooks",
         "/api/database/version",
+        "/api/database/token",
+        "/api/database/download",
     }
     PUBLIC_PREFIX_PATHS = (
         "/api/webhooks/",

--- a/client/src/components/DatabaseInstaller.tsx
+++ b/client/src/components/DatabaseInstaller.tsx
@@ -227,7 +227,7 @@ export default function DatabaseInstaller() {
       <p className={styles.cardDescription}>
         Instale o banco de dados localmente para buscar NBS, TIPI e NESH
         instantaneamente, sem depender de conexão de internet. O download é feito
-        uma única vez (~3-5 MB).
+        uma única vez{dbSizeBytes ? ` (~${formatBytes(dbSizeBytes)})` : " (~24 MB)"}.
       </p>
 
       <div className={styles.actions}>

--- a/client/src/context/offlineDatabase.types.ts
+++ b/client/src/context/offlineDatabase.types.ts
@@ -96,7 +96,7 @@ export type OfflineDatabaseWorkerRequest =
     | {
         type: 'INIT';
         id: string | null;
-        payload: { chunkSize: number; pbkdf2Iterations: number };
+        payload: { chunkSize: number; pbkdf2Iterations: number; seed?: string };
     }
     | {
         type: 'INSTALL';
@@ -158,6 +158,7 @@ export type OfflineDatabaseWorkerStatusMessage = {
         version?: string | null;
         sizeBytes?: number | null;
         error?: unknown;
+        seed?: string;
     };
 };
 

--- a/client/src/context/offlineDatabaseMutations.ts
+++ b/client/src/context/offlineDatabaseMutations.ts
@@ -4,7 +4,7 @@ import {
     compareOfflineVersions,
     formatOfflineDatabaseErrorMessage,
 } from '../utils/offlineDatabase';
-import { getRegisteredClerkToken } from '../services/api';
+
 import {
     clearOfflineDatabaseInstallLock,
     getOfflineDatabaseInstallLock,
@@ -84,17 +84,14 @@ export function useOfflineDatabaseMutations({
             }
 
             runOfflineDatabaseTaskInBackground(primeOfflineShellCache());
-            const clerkToken = await getRegisteredClerkToken({ skipCache: true });
-            if (!clerkToken) {
-                throw new Error('Faça login para instalar o banco offline.');
-            }
+
             await sendToWorker(
                 {
                     type: 'INSTALL',
                     id: null,
                     payload: {
                         apiBase: getOfflineDatabaseApiBaseUrl(),
-                        clerkToken,
+                        clerkToken: '',
                     },
                 },
                 180_000,
@@ -158,6 +155,7 @@ export function useOfflineDatabaseMutations({
                 10_000,
             );
             persistStoredOfflineDatabaseMetadata(null);
+            sessionStorage.removeItem('offline_db_seed');
             setLocalVersion(null);
             setRemoteVersion(remoteMetadataRef.current?.version ?? null);
             setDbSizeBytes(null);

--- a/client/src/context/offlineDatabaseRuntime.ts
+++ b/client/src/context/offlineDatabaseRuntime.ts
@@ -132,11 +132,15 @@ export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
             const initMetadata =
                 metadata ?? remoteMetaRef.current ?? readStoredOfflineDatabaseMetadata();
             try {
+                const seed = sessionStorage.getItem('offline_db_seed');
                 await sendToWorker(
                     {
                         type: 'INIT',
                         id: null,
-                        payload: buildOfflineDatabaseInitPayload(initMetadata),
+                        payload: {
+                            ...buildOfflineDatabaseInitPayload(initMetadata),
+                            seed: seed || undefined,
+                        },
                     },
                     30_000,
                 );

--- a/client/src/context/offlineDatabaseRuntime/useOfflineDatabaseWorkerBridge.ts
+++ b/client/src/context/offlineDatabaseRuntime/useOfflineDatabaseWorkerBridge.ts
@@ -30,6 +30,31 @@ type UseOfflineDatabaseWorkerBridgeArgs = {
     setDbSizeBytes: Dispatch<SetStateAction<number | null>>;
 };
 
+type OfflineDatabaseRefreshTokenResponsePayload = Extract<
+    OfflineDatabaseWorkerRequest,
+    { type: 'TOKEN_RESPONSE' }
+>['payload'];
+
+type OfflineDatabaseStatusResponse = Extract<
+    OfflineDatabaseWorkerResponse,
+    { type: 'STATUS' }
+>;
+
+type HandleWorkerStatusMessageArgs = Pick<
+    UseOfflineDatabaseWorkerBridgeArgs,
+    | 'setDbSizeBytes'
+    | 'setError'
+    | 'setLocalVersion'
+    | 'setProgress'
+    | 'setProgressStep'
+    | 'setStatus'
+> & {
+    id: string | null;
+    pending: PendingOfflineDatabaseRequest | undefined;
+    pendingRequests: Map<string, PendingOfflineDatabaseRequest>;
+    response: OfflineDatabaseWorkerResponse;
+};
+
 function resolvePendingWorkerRequest(
     pendingRequests: Map<string, PendingOfflineDatabaseRequest>,
     id: string | null,
@@ -56,6 +81,97 @@ function rejectPendingWorkerRequest(
 
 function shouldResolveStatusRequest(status: OfflineDatabaseStatus): boolean {
     return status === 'ready' || status === 'not_installed';
+}
+
+function buildTokenRefreshErrorPayload(err: unknown): OfflineDatabaseRefreshTokenResponsePayload {
+    if (err instanceof Error) {
+        return {
+            error: err.message,
+            errorName: err.name,
+            errorStack: err.stack,
+        };
+    }
+
+    return {
+        error: 'Token refresh failed',
+        errorValue: String(err),
+    };
+}
+
+function handleRefreshTokenMessage(id: string | null, worker: Worker | null): void {
+    if (!id) {
+        console.warn('[LocalDatabase] REFRESH_TOKEN message missing id');
+        return;
+    }
+
+    getRegisteredClerkToken({ skipCache: true })
+        .then((token) => {
+            worker?.postMessage({
+                type: 'TOKEN_RESPONSE',
+                id,
+                payload: { clerkToken: token ?? null },
+            });
+        })
+        .catch((err: unknown) => {
+            worker?.postMessage({
+                type: 'TOKEN_RESPONSE',
+                id,
+                payload: buildTokenRefreshErrorPayload(err),
+            });
+        });
+}
+
+function handleReadyStatus(
+    payload: OfflineDatabaseStatusResponse['payload'],
+    {
+        setError,
+        setProgress,
+        setProgressStep,
+    }: Pick<
+        UseOfflineDatabaseWorkerBridgeArgs,
+        'setError' | 'setProgress' | 'setProgressStep'
+    >,
+): void {
+    setProgress(100);
+    setProgressStep('done');
+    setError(null);
+    if (payload.seed) {
+        sessionStorage.setItem('offline_db_seed', payload.seed);
+    }
+}
+
+function handleWorkerStatusMessage(
+    payload: OfflineDatabaseStatusResponse['payload'],
+    args: HandleWorkerStatusMessageArgs,
+): void {
+    const {
+        id,
+        pending,
+        pendingRequests,
+        response,
+        setDbSizeBytes,
+        setError,
+        setLocalVersion,
+        setProgress,
+        setProgressStep,
+        setStatus,
+    } = args;
+
+    setStatus(payload.status);
+    setLocalVersion(payload.version ?? null);
+    setDbSizeBytes(payload.sizeBytes ?? null);
+
+    if (payload.status === 'error') {
+        setError(formatOfflineDatabaseErrorMessage(payload.error));
+    }
+
+    if (payload.status === 'ready') {
+        handleReadyStatus(payload, { setError, setProgress, setProgressStep });
+    }
+
+    if (shouldResolveStatusRequest(payload.status)) {
+        resolvePendingWorkerRequest(pendingRequests, id, pending, response);
+    }
 }
 
 export interface OfflineDatabaseWorkerBridgeValue {
@@ -99,45 +215,7 @@ export function useOfflineDatabaseWorkerBridge({
             const pending = id ? pendingRef.current.get(id) : undefined;
 
             if (type === 'REFRESH_TOKEN') {
-                if (!id) {
-                    console.warn('[LocalDatabase] REFRESH_TOKEN message missing id');
-                    return;
-                }
-                getRegisteredClerkToken({ skipCache: true })
-                    .then((token) => {
-                        workerRef.current?.postMessage({
-                            type: 'TOKEN_RESPONSE',
-                            id,
-                            payload: { clerkToken: token ?? null },
-                        });
-                    })
-                    .catch((err: unknown) => {
-                        const errorDetails: {
-                            message: string;
-                            name?: string;
-                            stack?: string;
-                            value?: string;
-                        } = err instanceof Error
-                            ? {
-                                message: err.message,
-                                name: err.name,
-                                stack: err.stack,
-                            }
-                            : {
-                                message: 'Token refresh failed',
-                                value: String(err),
-                            };
-                        workerRef.current?.postMessage({
-                            type: 'TOKEN_RESPONSE',
-                            id,
-                            payload: {
-                                error: errorDetails.message,
-                                errorName: errorDetails.name,
-                                errorStack: errorDetails.stack,
-                                errorValue: errorDetails.value,
-                            },
-                        });
-                    });
+                handleRefreshTokenMessage(id, workerRef.current);
                 return;
             }
 
@@ -148,28 +226,18 @@ export function useOfflineDatabaseWorkerBridge({
             }
 
             if (type === 'STATUS') {
-                setStatus(payload.status);
-                setLocalVersion(payload.version ?? null);
-                setDbSizeBytes(payload.sizeBytes ?? null);
-                if (payload.status === 'error') {
-                    setError(formatOfflineDatabaseErrorMessage(payload.error));
-                }
-                if (payload.status === 'ready') {
-                    setProgress(100);
-                    setProgressStep('done');
-                    setError(null);
-                    if (payload.seed) {
-                        sessionStorage.setItem('offline_db_seed', payload.seed);
-                    }
-                }
-                if (shouldResolveStatusRequest(payload.status)) {
-                    resolvePendingWorkerRequest(
-                        pendingRef.current,
-                        id,
-                        pending,
-                        event.data,
-                    );
-                }
+                handleWorkerStatusMessage(payload, {
+                    id,
+                    pending,
+                    pendingRequests: pendingRef.current,
+                    response: event.data,
+                    setDbSizeBytes,
+                    setError,
+                    setLocalVersion,
+                    setProgress,
+                    setProgressStep,
+                    setStatus,
+                });
                 return;
             }
 

--- a/client/src/context/offlineDatabaseRuntime/useOfflineDatabaseWorkerBridge.ts
+++ b/client/src/context/offlineDatabaseRuntime/useOfflineDatabaseWorkerBridge.ts
@@ -158,6 +158,9 @@ export function useOfflineDatabaseWorkerBridge({
                     setProgress(100);
                     setProgressStep('done');
                     setError(null);
+                    if (payload.seed) {
+                        sessionStorage.setItem('offline_db_seed', payload.seed);
+                    }
                 }
                 if (shouldResolveStatusRequest(payload.status)) {
                     resolvePendingWorkerRequest(

--- a/client/src/services/api/authLogging.ts
+++ b/client/src/services/api/authLogging.ts
@@ -2,7 +2,7 @@ import type { InternalAxiosRequestConfig } from 'axios';
 
 import type { ClerkTokenGetterOptions } from './authTypes';
 
-const PUBLIC_ROUTES = ['/status', '/glossary', '/services/'];
+const PUBLIC_ROUTES = ['/status', '/glossary', '/services/', '/database/'];
 const JWT_DEBUG_FIELDS = ['iss', 'sub', 'sid', 'azp', 'aud', 'org_id', 'exp', 'iat', 'nbf'] as const;
 
 export const AUTH_DEBUG_ENABLED =

--- a/client/src/workers/dbWorker/messages.js
+++ b/client/src/workers/dbWorker/messages.js
@@ -17,7 +17,7 @@ import { clearSearchCache, closeWorkerDb, getWorkerDb, getWorkerStatus, getWorke
 async function handleInitMessage(id, payload) {
   const encData = await readFromOpfs();
   const version = await readVersion();
-  const seed = await readSeed();
+  const seed = payload?.seed || (await readSeed());
 
   if (!encData || !version || !seed) {
     setWorkerStatus("not_installed");
@@ -63,6 +63,7 @@ async function handleInitMessage(id, payload) {
     status: "ready",
     version,
     sizeBytes: encData.length,
+    seed,
   });
 }
 
@@ -207,6 +208,7 @@ async function handleInstallMessage(id, payload) {
       status: "ready",
       version: getWorkerVersion(),
       sizeBytes: encryptedBlob.length,
+      seed: appSeed,
     });
   } catch (error) {
     setWorkerStatus("error");

--- a/client/src/workers/dbWorker/messages.js
+++ b/client/src/workers/dbWorker/messages.js
@@ -17,7 +17,9 @@ import { clearSearchCache, closeWorkerDb, getWorkerDb, getWorkerStatus, getWorke
 async function handleInitMessage(id, payload) {
   const encData = await readFromOpfs();
   const version = await readVersion();
-  const seed = payload?.seed || (await readSeed());
+  const opfsSeed = await readSeed();
+  const seed = opfsSeed || payload?.seed;
+  const usedPayloadSeedFallback = !opfsSeed && Boolean(payload?.seed);
 
   if (!encData || !version || !seed) {
     setWorkerStatus("not_installed");
@@ -44,7 +46,9 @@ async function handleInitMessage(id, payload) {
     closeWorkerDb();
     setWorkerVersion(null);
     setWorkerStatus("error");
-    await removeFromOpfs();
+    if (usedPayloadSeedFallback) {
+      await removeFromOpfs();
+    }
     const message = error instanceof Error ? error.message : "Unknown error";
     const recoverableMessage = `${message}. Reinstale o banco offline para continuar.`;
     postWorkerStatus(id, {

--- a/client/tests/unit/api.service.test.ts
+++ b/client/tests/unit/api.service.test.ts
@@ -119,6 +119,20 @@ function swapLocation(url: string) {
   };
 }
 
+async function expectRequestToSkipAuth(
+  url: string,
+  getter: ReturnType<typeof vi.fn>,
+  headers: { set: ReturnType<typeof vi.fn> },
+) {
+  getter.mockClear();
+  headers.set.mockClear();
+
+  await mockAxios.handlers.requestFulfilled?.({ url, headers });
+
+  expect(getter).not.toHaveBeenCalled();
+  expect(headers.set).not.toHaveBeenCalledWith('Authorization', 'Bearer jwt-token');
+}
+
 describe('api service', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -172,26 +186,9 @@ describe('api service', () => {
     expect(getter).toHaveBeenCalledTimes(1);
     expect(headers.set).toHaveBeenCalledWith('Authorization', 'Bearer jwt-token');
 
-    getter.mockClear();
-    headers.set.mockClear();
-
-    await mockAxios.handlers.requestFulfilled?.({ url: 'https://example.com/status', headers });
-    expect(getter).not.toHaveBeenCalled();
-    expect(headers.set).not.toHaveBeenCalledWith('Authorization', 'Bearer jwt-token');
-
-    getter.mockClear();
-    headers.set.mockClear();
-
-    await mockAxios.handlers.requestFulfilled?.({ url: '/services/nbs/search?q=construcao', headers });
-    expect(getter).not.toHaveBeenCalled();
-    expect(headers.set).not.toHaveBeenCalledWith('Authorization', 'Bearer jwt-token');
-
-    getter.mockClear();
-    headers.set.mockClear();
-
-    await mockAxios.handlers.requestFulfilled?.({ url: '/database/token', headers });
-    expect(getter).not.toHaveBeenCalled();
-    expect(headers.set).not.toHaveBeenCalledWith('Authorization', 'Bearer jwt-token');
+    await expectRequestToSkipAuth('https://example.com/status', getter, headers);
+    await expectRequestToSkipAuth('/services/nbs/search?q=construcao', getter, headers);
+    await expectRequestToSkipAuth('/database/token', getter, headers);
 
     apiModule.unregisterClerkTokenGetter();
   });

--- a/client/tests/unit/api.service.test.ts
+++ b/client/tests/unit/api.service.test.ts
@@ -186,6 +186,13 @@ describe('api service', () => {
     expect(getter).not.toHaveBeenCalled();
     expect(headers.set).not.toHaveBeenCalledWith('Authorization', 'Bearer jwt-token');
 
+    getter.mockClear();
+    headers.set.mockClear();
+
+    await mockAxios.handlers.requestFulfilled?.({ url: '/database/token', headers });
+    expect(getter).not.toHaveBeenCalled();
+    expect(headers.set).not.toHaveBeenCalledWith('Authorization', 'Bearer jwt-token');
+
     apiModule.unregisterClerkTokenGetter();
   });
 

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -57,6 +57,7 @@ export default defineConfig(({ mode }) => {
       globals: true,
       environment: 'jsdom',
       setupFiles: './src/setupTests.ts',
+      testTimeout: 15000,
       css: true,
       exclude: [
         '**/node_modules/**',

--- a/tests/unit/test_database_download_route.py
+++ b/tests/unit/test_database_download_route.py
@@ -13,6 +13,7 @@ from starlette.requests import Request
 
 from backend.presentation.routes import database_download
 from backend.server import app_security
+from backend.server.middleware import TenantMiddleware
 
 pytestmark = pytest.mark.unit
 
@@ -118,6 +119,34 @@ async def test_download_accepts_fresh_token(offline_bundle):
 
     assert Path(response.path).read_bytes() == b"encrypted-bundle"
     assert response.headers["Cross-Origin-Resource-Policy"] == "same-origin"
+
+
+@pytest.mark.asyncio
+async def test_download_token_flow_does_not_require_authorization_header(
+    offline_bundle,
+):
+    token_request = _build_request(
+        "/api/database/token",
+        headers={"Authorization": ""},
+    )
+    token_payload = await database_download.create_download_token(token_request)
+
+    response = await database_download.download_database(
+        _build_request(
+            "/api/database/download",
+            headers={"Authorization": ""},
+            client_host="127.0.0.1",
+        ),
+        database_download.DownloadDatabaseRequest(token=token_payload["token"]),
+    )
+
+    assert Path(response.path).read_bytes() == b"encrypted-bundle"
+
+
+def test_database_download_token_routes_are_public_middleware_paths():
+    assert TenantMiddleware._is_public_path("/api/database/version") is True
+    assert TenantMiddleware._is_public_path("/api/database/token") is True
+    assert TenantMiddleware._is_public_path("/api/database/download") is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_database_download_route.py
+++ b/tests/unit/test_database_download_route.py
@@ -23,10 +23,14 @@ def _build_request(
     *,
     method: str = "POST",
     headers: dict[str, str] | None = None,
+    auth_header: str | None = "Bearer test-token",
     client_host: str = "127.0.0.1",
     scheme: str = "http",
 ) -> Request:
-    headers = {"Authorization": "Bearer test-token", **(headers or {})}
+    headers = {
+        **({"Authorization": auth_header} if auth_header else {}),
+        **(headers or {}),
+    }
     scope_headers = [
         (key.lower().encode("latin-1"), value.encode("latin-1"))
         for key, value in headers.items()
@@ -127,14 +131,14 @@ async def test_download_token_flow_does_not_require_authorization_header(
 ):
     token_request = _build_request(
         "/api/database/token",
-        headers={"Authorization": ""},
+        auth_header=None,
     )
     token_payload = await database_download.create_download_token(token_request)
 
     response = await database_download.download_database(
         _build_request(
             "/api/database/download",
-            headers={"Authorization": ""},
+            auth_header=None,
             client_host="127.0.0.1",
         ),
         database_download.DownloadDatabaseRequest(token=token_payload["token"]),


### PR DESCRIPTION
## Summary

- Treat the offline database package as a public downloadable artifact behind the existing ephemeral token flow.
- Stop attaching Clerk JWTs to `/database/*` requests and allow the token/download routes through tenant middleware.
- Preserve the offline worker seed across reloads and document the public offline bundle contract.

## Validation

- `pytest tests/unit/test_database_download_route.py`
- `cd client && npm test -- tests/unit/api.service.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline database downloads are publicly accessible without authentication.
  * Installer shows actual bundle size when available (falls back to a new (~24 MB) estimate).

* **Bug Fixes / Improvements**
  * Installation flow persists and clears an installer seed in session storage to improve install/resume behavior and cleanup.
  * Download/token endpoints treated as public to allow unauthenticated token/download flows.

* **Documentation**
  * Added public-contract docs specifying allowed bundle contents and catalog consistency rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->