### PR TITLE
[codex] Add NBS Postgres fallback

### DIFF
--- a/backend/server/app_lifecycle.py
+++ b/backend/server/app_lifecycle.py
@@ -231,6 +231,23 @@ async def _postgres_tipi_has_data() -> bool:
         return False
 
 
+async def _postgres_nbs_has_data() -> bool:
+    try:
+        from backend.infrastructure.db_engine import get_session
+        from sqlalchemy import text
+
+        async with get_session() as session:
+            result = await session.execute(
+                text("SELECT EXISTS(SELECT 1 FROM nbs_items)")
+            )
+            has_data = bool(result.scalar())
+        logger.info("NBS PostgreSQL data available: %s", has_data)
+        return has_data
+    except Exception as exc:
+        logger.warning("Could not check nbs_items table: %s", exc)
+        return False
+
+
 async def _init_tipi_service(app: FastAPI) -> None:
     if not settings.database.is_postgres:
         app.state.tipi_service = TipiService()
@@ -252,7 +269,7 @@ async def _init_tipi_service(app: FastAPI) -> None:
 
 
 async def _init_nbs_service(app: FastAPI) -> None:
-    if settings.database.is_postgres:
+    if settings.database.is_postgres and await _postgres_nbs_has_data():
         try:
             app.state.nbs_service = (
                 await NbsService.initializeNbsServiceWithPostgresRepository()

--- a/tests/unit/test_app_lifecycle_nbs.py
+++ b/tests/unit/test_app_lifecycle_nbs.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+import pytest
+
+from backend.server import app_lifecycle
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_init_nbs_service_falls_back_to_sqlite_when_postgres_has_no_nbs_data(
+    monkeypatch,
+):
+    app = SimpleNamespace(state=SimpleNamespace())
+    sqlite_service = object()
+
+    async def _no_nbs_data():
+        return False
+
+    class _FakeNbsService:
+        def __new__(cls):
+            return sqlite_service
+
+        @classmethod
+        async def initializeNbsServiceWithPostgresRepository(cls):
+            raise AssertionError("Postgres repository should not be initialized")
+
+    monkeypatch.setattr(app_lifecycle.settings.database, "engine", "postgresql")
+    monkeypatch.setattr(app_lifecycle, "_postgres_nbs_has_data", _no_nbs_data)
+    monkeypatch.setattr(app_lifecycle, "NbsService", _FakeNbsService)
+
+    await app_lifecycle._init_nbs_service(app)
+
+    assert app.state.nbs_service is sqlite_service
+
+
+@pytest.mark.asyncio
+async def test_init_nbs_service_uses_postgres_when_nbs_data_exists(monkeypatch):
+    app = SimpleNamespace(state=SimpleNamespace())
+    postgres_service = object()
+
+    async def _has_nbs_data():
+        return True
+
+    class _FakeNbsService:
+        @classmethod
+        async def initializeNbsServiceWithPostgresRepository(cls):
+            return postgres_service
+
+    monkeypatch.setattr(app_lifecycle.settings.database, "engine", "postgresql")
+    monkeypatch.setattr(app_lifecycle, "_postgres_nbs_has_data", _has_nbs_data)
+    monkeypatch.setattr(app_lifecycle, "NbsService", _FakeNbsService)
+
+    await app_lifecycle._init_nbs_service(app)
+
+    assert app.state.nbs_service is postgres_service

--- a/tests/unit/test_app_lifespan_additional.py
+++ b/tests/unit/test_app_lifespan_additional.py
@@ -377,10 +377,19 @@ async def test_lifespan_postgres_redis_prewarm_failure_and_tipi_repository(
 async def test_lifespan_postgres_tipi_count_failure_falls_back_to_sqlite_mode(
     monkeypatch, core_mocks
 ):
+    class _ScalarResult:
+        def __init__(self, value):
+            self._value = value
+
+        def scalar(self):
+            return self._value
+
     class _BrokenSession:
-        async def execute(self, _query):
+        async def execute(self, query):
             await asyncio.sleep(0)
-            raise RuntimeError("tipi count failed")
+            if "tipi_positions" in str(query):
+                raise RuntimeError("tipi count failed")
+            return _ScalarResult(True)
 
     @asynccontextmanager
     async def _broken_get_session():


### PR DESCRIPTION
## Summary

- Check whether the Postgres `nbs_items` table has data before initializing the NBS service with the Postgres repository.
- Fall back to the SQLite-backed NBS service when Postgres is configured but empty or unavailable for NBS.
- Add unit coverage for both fallback and Postgres-backed initialization paths.

## Validation

- `pytest tests/unit/test_app_lifecycle_nbs.py`