### PR TITLE
[codex] Clean up NEBS migration paths

### DIFF
--- a/client/src/components/ServicesWorkspace.tsx
+++ b/client/src/components/ServicesWorkspace.tsx
@@ -122,7 +122,6 @@ export function ServicesWorkspace({
             nbsPrefixAutoExpand={nbsPrefixAutoExpand}
             nbsState={nbsState}
             onSelectNbs={onSelectNbs}
-            openCatalogDoc={openCatalogDoc}
             setIsChapterNotesOpen={setIsChapterNotesOpen}
         />
     );

--- a/client/src/components/ServicesWorkspace/NbsWorkspaceView.tsx
+++ b/client/src/components/ServicesWorkspace/NbsWorkspaceView.tsx
@@ -10,7 +10,6 @@ import {
 
 import { getExpandedPrefixBranch, isCodeLikeNbsQuery } from './noteRendering';
 import type {
-    OpenCatalogDoc,
     ServicesWorkspaceNbsState,
 } from './types';
 
@@ -135,14 +134,12 @@ interface NbsDetailSectionProps {
     readonly nbsNoteBodyHtml: string;
     readonly nbsNotesContentRef: React.RefObject<HTMLDivElement | null>;
     readonly nbsState: ServicesWorkspaceNbsState;
-    readonly openCatalogDoc: OpenCatalogDoc;
 }
 
 function NbsDetailSection({
     nbsNoteBodyHtml,
     nbsNotesContentRef,
     nbsState,
-    openCatalogDoc,
 }: Readonly<NbsDetailSectionProps>) {
     const codeParts = nbsState.detail?.item.code.split('.') ?? [];
 
@@ -192,17 +189,6 @@ function NbsDetailSection({
                         </section>
                     )}
 
-                    {nbsState.detail.nebs && (
-                        <div className={styles.detailActions}>
-                            <button
-                                type="button"
-                                className={styles.secondaryAction}
-                                onClick={() => openCatalogDoc('nbs', nbsState.detail!.item.code)}
-                            >
-                                Ver NBS
-                            </button>
-                        </div>
-                    )}
                 </>
             ) : (
                 <div className={styles.emptyDetail}>
@@ -292,7 +278,6 @@ interface NbsWorkspaceViewProps {
     readonly nbsPrefixAutoExpand: boolean;
     readonly nbsState: ServicesWorkspaceNbsState;
     readonly onSelectNbs: (code: string) => void;
-    readonly openCatalogDoc: OpenCatalogDoc;
     readonly setIsChapterNotesOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -307,7 +292,6 @@ export function NbsWorkspaceView({
     nbsPrefixAutoExpand,
     nbsState,
     onSelectNbs,
-    openCatalogDoc,
     setIsChapterNotesOpen,
 }: Readonly<NbsWorkspaceViewProps>) {
     const sanitizedChapterNotesHtml = React.useMemo(
@@ -384,7 +368,6 @@ export function NbsWorkspaceView({
                 nbsNoteBodyHtml={nbsNoteBodyHtml}
                 nbsNotesContentRef={nbsNotesContentRef}
                 nbsState={nbsState}
-                openCatalogDoc={openCatalogDoc}
             />
             <NbsChapterNotesDialog
                 chapterNotesDialogRef={chapterNotesDialogRef}

--- a/client/tests/playwright/helpers/offlineHarness.ts
+++ b/client/tests/playwright/helpers/offlineHarness.ts
@@ -73,12 +73,10 @@ export async function installOfflineApiMock(page: Page, counters: OfflineApiCoun
           database: { status: 'online', latency_ms: 1 },
           tipi: { status: 'online' },
           nbs: { status: 'online' },
-          nebs: { status: 'online' },
           catalogs: {
             nesh: { status: 'online', latency_ms: 1 },
             tipi: { status: 'online' },
             nbs: { status: 'online' },
-            nebs: { status: 'online' },
           },
         }),
       });

--- a/client/tests/playwright/helpers/offlineHarness.ts
+++ b/client/tests/playwright/helpers/offlineHarness.ts
@@ -136,6 +136,33 @@ export async function installOfflineWorkerMock(page: Page) {
       worker.listeners.forEach((listener) => listener(event));
     }
 
+    function getInstalledStatusPayload() {
+      const installedMeta = readInstalledMeta();
+      if (!installedMeta?.version) {
+        return { status: 'not_installed' };
+      }
+
+      return {
+        status: 'ready',
+        version: installedMeta.version,
+        sizeBytes: installedMeta.size_bytes || 0,
+      };
+    }
+
+    function emitInstalledStatus(
+      worker: {
+        onmessage: ((event: MessageEvent<WorkerMessage>) => void) | null;
+        listeners: Set<(event: MessageEvent<WorkerMessage>) => void>;
+      },
+      id: string | null,
+    ) {
+      emitToWorker(worker, {
+        type: 'STATUS',
+        id,
+        payload: getInstalledStatusPayload(),
+      });
+    }
+
     class MockOfflineWorker {
       public onmessage: ((event: MessageEvent<WorkerMessage>) => void) | null = null;
 
@@ -170,24 +197,7 @@ export async function installOfflineWorkerMock(page: Page) {
 
         try {
           if (type === 'INIT') {
-            const installedMeta = readInstalledMeta();
-            if (installedMeta?.version) {
-              emitToWorker(this, {
-                type: 'STATUS',
-                id,
-                payload: {
-                  status: 'ready',
-                  version: installedMeta.version,
-                  sizeBytes: installedMeta.size_bytes || 0,
-                },
-              });
-            } else {
-              emitToWorker(this, {
-                type: 'STATUS',
-                id,
-                payload: { status: 'not_installed' },
-              });
-            }
+            emitInstalledStatus(this, id);
             return;
           }
 
@@ -257,18 +267,7 @@ export async function installOfflineWorkerMock(page: Page) {
           }
 
           if (type === 'GET_STATUS') {
-            const installedMeta = readInstalledMeta();
-            emitToWorker(this, {
-              type: 'STATUS',
-              id,
-              payload: installedMeta?.version
-                ? {
-                  status: 'ready',
-                  version: installedMeta.version,
-                  sizeBytes: installedMeta.size_bytes || 0,
-                }
-                : { status: 'not_installed' },
-            });
+            emitInstalledStatus(this, id);
             return;
           }
 

--- a/migrations/versions/013_search_resource_optimizations.py
+++ b/migrations/versions/013_search_resource_optimizations.py
@@ -11,7 +11,7 @@ from alembic import op
 
 logger = logging.getLogger(__name__)
 
-revision = "013_search_resource_optimizations"
+revision = "013_search_resource_opts"
 down_revision = "012_services_catalog_postgres"
 branch_labels = None
 depends_on = None

--- a/scripts/build_offline_db.py
+++ b/scripts/build_offline_db.py
@@ -283,8 +283,8 @@ def _consolidate_databases(output_path: Path) -> None:
 
     # === Populate from source databases ===
 
-    # NBS + NEBS from services.db
-    _log(f"Reading NBS/NEBS from {SERVICES_DB}...")
+    # NBS from services.db
+    _log(f"Reading NBS from {SERVICES_DB}...")
     cursor.execute("ATTACH DATABASE ? AS svc", (str(SERVICES_DB),))  # nosec B608
 
     cursor.execute("""
@@ -297,7 +297,6 @@ def _consolidate_databases(output_path: Path) -> None:
     nbs_count = cursor.rowcount
     _log(f"  Inserted {nbs_count} NBS items")
 
-    # Check if nebs_entries table exists in services.db
     cursor.execute(
         "SELECT 1 FROM svc.sqlite_master WHERE type='table' AND name='nebs_entries' LIMIT 1"
     )

--- a/scripts/migrate_to_postgres.py
+++ b/scripts/migrate_to_postgres.py
@@ -566,7 +566,6 @@ async def migrate_nbs_items(csv_path: Path, pg_session: AsyncSession) -> list:
     return items
 
 
-
 async def update_search_vectors(pg_session: AsyncSession) -> None:
     """Refresh PostgreSQL tsvector columns after bulk loads."""
     print("\nAtualizando search_vectors...")
@@ -603,7 +602,6 @@ async def update_search_vectors(pg_session: AsyncSession) -> None:
             """
         )
     )
-
 
     print("  OK search vectors atualizados")
 

--- a/scripts/migrate_to_postgres.py
+++ b/scripts/migrate_to_postgres.py
@@ -4,7 +4,6 @@ This script loads:
 - NESH from the legacy SQLite database
 - TIPI from the legacy TIPI SQLite database
 - NBS from ``data/nbs.csv``
-- NEBS from ``data/nebs.pdf`` (trusted entries only)
 
 It also refreshes PostgreSQL FTS vectors and persists load metadata into
 ``catalog_metadata`` so the runtime health endpoints can expose freshness.
@@ -37,21 +36,15 @@ from backend.domain.sqlmodels import (  # noqa: E402
     ChapterNotes,
     Glossary,
     NbsItem,
-    NebsEntry,
     Position,
     TipiPosition,
 )
 from backend.infrastructure.db_engine import get_session  # noqa: E402
 from backend.utils.hash_util import calculate_file_sha256  # noqa: E402
 from backend.utils.nbs_parser import build_nbs_items, iter_nbs_rows  # noqa: E402
-from backend.utils.nebs_parser import parse_nebs_pdf, write_nebs_audit_report  # noqa: E402
 
 DATA_DIR = PROJECT_ROOT / "data"
-REPORTS_DIR = PROJECT_ROOT / "reports" / "nebs"
 NBS_CSV_PATH = DATA_DIR / "nbs.csv"
-NEBS_PDF_PATH = DATA_DIR / "nebs.pdf"
-NEBS_AUDIT_CSV_PATH = REPORTS_DIR / "nebs_audit.csv"
-NEBS_AUDIT_JSON_PATH = REPORTS_DIR / "nebs_audit.json"
 
 
 def _mask_database_url(url: str | None) -> str:
@@ -134,9 +127,8 @@ async def _replace_metadata(
 async def _reset_runtime_catalog(pg_session: AsyncSession) -> None:
     """Clear global/runtime catalog rows so imports stay idempotent."""
     statements = (
-        "DELETE FROM nebs_entries WHERE tenant_id IS NULL",
         "DELETE FROM nbs_items WHERE tenant_id IS NULL",
-        "DELETE FROM catalog_metadata WHERE key LIKE 'nesh_%' OR key LIKE 'tipi_%' OR key LIKE 'nbs_%' OR key LIKE 'nebs_%'",
+        "DELETE FROM catalog_metadata WHERE key LIKE 'nesh_%' OR key LIKE 'tipi_%' OR key LIKE 'nbs_%'",
         "DELETE FROM chapter_notes WHERE tenant_id IS NULL",
         "DELETE FROM positions WHERE tenant_id IS NULL",
         "DELETE FROM chapters WHERE tenant_id IS NULL",
@@ -165,7 +157,6 @@ async def _load_runtime_counts(pg_session: AsyncSession) -> dict[str, int]:
         "nesh_chapters": "SELECT COUNT(*) FROM chapters WHERE tenant_id IS NULL",
         "tipi_positions": "SELECT COUNT(*) FROM tipi_positions",
         "nbs_items": "SELECT COUNT(*) FROM nbs_items WHERE tenant_id IS NULL",
-        "nebs_entries": "SELECT COUNT(*) FROM nebs_entries WHERE tenant_id IS NULL",
     }
     counts: dict[str, int] = {}
     for key, sql in queries.items():
@@ -182,13 +173,11 @@ async def _catalog_sync_reasons(pg_session: AsyncSession) -> list[str]:
         "nesh_source_hash": calculate_file_sha256(settings.database.path),
         "tipi_source_hash": calculate_file_sha256(settings.database.tipi_path),
         "nbs_source_hash": calculate_file_sha256(NBS_CSV_PATH),
-        "nebs_source_hash": calculate_file_sha256(NEBS_PDF_PATH),
     }
     count_requirements = {
         "nesh_chapters": 1,
         "tipi_positions": 1,
         "nbs_items": 1,
-        "nebs_entries": 1,
     }
 
     reasons: list[str] = []
@@ -214,7 +203,6 @@ async def check_sync_needed() -> int:
         Path(settings.database.path),
         Path(settings.database.tipi_path),
         NBS_CSV_PATH,
-        NEBS_PDF_PATH,
     )
     missing_sources = [str(path) for path in required_sources if not path.exists()]
     if missing_sources:
@@ -536,7 +524,6 @@ async def migrate_nbs_items(csv_path: Path, pg_session: AsyncSession) -> list:
                 "level": item.level,
                 "source_order": item.source_order,
                 "sort_path": item.sort_path,
-                "has_nebs": bool(item.has_nebs),
                 "tenant_id": None,
             }
         )
@@ -552,7 +539,6 @@ async def migrate_nbs_items(csv_path: Path, pg_session: AsyncSession) -> list:
                     "level": stmt.excluded.level,
                     "source_order": stmt.excluded.source_order,
                     "sort_path": stmt.excluded.sort_path,
-                    "has_nebs": stmt.excluded.has_nebs,
                     "tenant_id": None,
                 },
             )
@@ -571,7 +557,6 @@ async def migrate_nbs_items(csv_path: Path, pg_session: AsyncSession) -> list:
                 "level": stmt.excluded.level,
                 "source_order": stmt.excluded.source_order,
                 "sort_path": stmt.excluded.sort_path,
-                "has_nebs": stmt.excluded.has_nebs,
                 "tenant_id": None,
             },
         )
@@ -580,105 +565,6 @@ async def migrate_nbs_items(csv_path: Path, pg_session: AsyncSession) -> list:
     print(f"  OK {len(items)} itens NBS migrados")
     return items
 
-
-async def migrate_nebs_entries(
-    pdf_path: Path,
-    *,
-    valid_nbs_items: dict[str, str],
-    pg_session: AsyncSession,
-) -> dict[str, int]:
-    """Load trusted NEBS entries into PostgreSQL and persist audit artifacts."""
-    if not pdf_path.exists():
-        raise FileNotFoundError(f"Arquivo NEBS não encontrado: {pdf_path}")
-
-    outcome = parse_nebs_pdf(pdf_path, valid_nbs_items=valid_nbs_items)
-    write_nebs_audit_report(
-        outcome,
-        csv_path=NEBS_AUDIT_CSV_PATH,
-        json_path=NEBS_AUDIT_JSON_PATH,
-    )
-
-    batch: list[dict[str, str | int | datetime | None]] = []
-    for entry in outcome.entries:
-        batch.append(
-            {
-                "code": entry.code,
-                "code_clean": entry.code_clean,
-                "title": entry.title,
-                "title_normalized": entry.title_normalized,
-                "body_text": entry.body_text,
-                "body_markdown": entry.body_markdown,
-                "body_normalized": entry.body_normalized,
-                "section_title": entry.section_title,
-                "page_start": entry.page_start,
-                "page_end": entry.page_end,
-                "parser_status": entry.parser_status,
-                "parse_warnings": entry.parse_warnings,
-                "source_hash": entry.source_hash,
-                "updated_at": _coerce_pg_timestamp(entry.updated_at),
-                "tenant_id": None,
-            }
-        )
-        if len(batch) >= 500:
-            stmt = pg_insert(NebsEntry).values(batch)
-            stmt = stmt.on_conflict_do_update(
-                index_elements=["code"],
-                set_={
-                    "code_clean": stmt.excluded.code_clean,
-                    "title": stmt.excluded.title,
-                    "title_normalized": stmt.excluded.title_normalized,
-                    "body_text": stmt.excluded.body_text,
-                    "body_markdown": stmt.excluded.body_markdown,
-                    "body_normalized": stmt.excluded.body_normalized,
-                    "section_title": stmt.excluded.section_title,
-                    "page_start": stmt.excluded.page_start,
-                    "page_end": stmt.excluded.page_end,
-                    "parser_status": stmt.excluded.parser_status,
-                    "parse_warnings": stmt.excluded.parse_warnings,
-                    "source_hash": stmt.excluded.source_hash,
-                    "updated_at": stmt.excluded.updated_at,
-                    "tenant_id": None,
-                },
-            )
-            await pg_session.execute(stmt)
-            batch = []
-
-    if batch:
-        stmt = pg_insert(NebsEntry).values(batch)
-        stmt = stmt.on_conflict_do_update(
-            index_elements=["code"],
-            set_={
-                "code_clean": stmt.excluded.code_clean,
-                "title": stmt.excluded.title,
-                "title_normalized": stmt.excluded.title_normalized,
-                "body_text": stmt.excluded.body_text,
-                "body_markdown": stmt.excluded.body_markdown,
-                "body_normalized": stmt.excluded.body_normalized,
-                "section_title": stmt.excluded.section_title,
-                "page_start": stmt.excluded.page_start,
-                "page_end": stmt.excluded.page_end,
-                "parser_status": stmt.excluded.parser_status,
-                "parse_warnings": stmt.excluded.parse_warnings,
-                "source_hash": stmt.excluded.source_hash,
-                "updated_at": stmt.excluded.updated_at,
-                "tenant_id": None,
-            },
-        )
-        await pg_session.execute(stmt)
-
-    trusted_codes = [entry.code for entry in outcome.entries]
-    if trusted_codes:
-        await pg_session.execute(
-            text("UPDATE nbs_items SET has_nebs = false WHERE tenant_id IS NULL")
-        )
-        await pg_session.execute(
-            text("UPDATE nbs_items SET has_nebs = true WHERE code = ANY(:codes)"),
-            {"codes": trusted_codes},
-        )
-
-    print(f"  OK {outcome.counts['trusted']} entradas NEBS confiáveis migradas")
-    print(f"  OK auditoria NEBS atualizada em {NEBS_AUDIT_CSV_PATH}")
-    return outcome.counts
 
 
 async def update_search_vectors(pg_session: AsyncSession) -> None:
@@ -717,21 +603,7 @@ async def update_search_vectors(pg_session: AsyncSession) -> None:
             """
         )
     )
-    await pg_session.execute(
-        text(
-            """
-            UPDATE nebs_entries
-            SET search_vector = to_tsvector(
-                'portuguese',
-                trim(
-                    COALESCE(title, '') || ' ' ||
-                    COALESCE(section_title, '') || ' ' ||
-                    COALESCE(body_text, '')
-                )
-            )
-            """
-        )
-    )
+
 
     print("  OK search vectors atualizados")
 
@@ -753,7 +625,6 @@ async def run_full_migration() -> int:
         "nesh_sqlite": Path(settings.database.path),
         "tipi_sqlite": Path(settings.database.tipi_path),
         "nbs_csv": NBS_CSV_PATH,
-        "nebs_pdf": NEBS_PDF_PATH,
     }
     missing_sources = [
         f"{name}: {path}"
@@ -769,13 +640,11 @@ async def run_full_migration() -> int:
     print(f"\nSQLite NESH source: {settings.database.path}")
     print(f"SQLite TIPI source: {settings.database.tipi_path}")
     print(f"NBS source: {NBS_CSV_PATH}")
-    print(f"NEBS source: {NEBS_PDF_PATH}")
     print(f"PostgreSQL target: {_mask_database_url(settings.database.postgres_url)}")
 
     nesh_updated_at = _now_iso()
     tipi_updated_at = _now_iso()
     nbs_updated_at = _now_iso()
-    nebs_updated_at = _now_iso()
 
     try:
         async with get_session() as session:
@@ -826,27 +695,6 @@ async def run_full_migration() -> int:
                     "source_hash": calculate_file_sha256(NBS_CSV_PATH),
                     "row_count": str(len(nbs_items)),
                     "updated_at": nbs_updated_at,
-                },
-            )
-
-            print("\nMigrando NEBS...")
-            nebs_counts = await migrate_nebs_entries(
-                NEBS_PDF_PATH,
-                valid_nbs_items={item.code: item.description for item in nbs_items},
-                pg_session=session,
-            )
-            await _replace_metadata(
-                session,
-                prefix="nebs",
-                values={
-                    "source_path": str(NEBS_PDF_PATH),
-                    "source_hash": calculate_file_sha256(NEBS_PDF_PATH),
-                    "trusted_count": str(nebs_counts.get("trusted", 0)),
-                    "suspect_count": str(nebs_counts.get("suspect", 0)),
-                    "rejected_count": str(nebs_counts.get("rejected", 0)),
-                    "updated_at": nebs_updated_at,
-                    "audit_csv": str(NEBS_AUDIT_CSV_PATH),
-                    "audit_json": str(NEBS_AUDIT_JSON_PATH),
                 },
             )
 

--- a/testar_tudo_local.bat
+++ b/testar_tudo_local.bat
@@ -31,9 +31,26 @@ echo.
 :: [2] Subir Backend Python
 :: -----------------------------------------------------------
 echo [2/3] Iniciando Backend FastAPI (porta 8000)...
-if exist "%~dp0.venv\Scripts\python.exe" (
+:: Verifica se o venv existe e esta funcional
+set "USE_UV=1"
+if exist "%~dp0.venv\pyvenv.cfg" (
+    if exist "%~dp0.venv\Scripts\python.exe" (
+        "%~dp0.venv\Scripts\python.exe" -c "import fastapi" >nul 2>&1
+        if !errorlevel! equ 0 set "USE_UV=0"
+    )
+)
+if "!USE_UV!"=="1" (
+    echo    Ambiente Python incompleto. Recriando venv com uv...
+    uv sync --reinstall >nul 2>&1
+    if exist "%~dp0.venv\Scripts\python.exe" (
+        "%~dp0.venv\Scripts\python.exe" -c "import fastapi" >nul 2>&1
+        if !errorlevel! equ 0 set "USE_UV=0"
+    )
+)
+if "!USE_UV!"=="0" (
     start "Nesh Backend" /D "%~dp0" cmd /k "set CACHE__ENABLE_REDIS=false& .venv\Scripts\python.exe Nesh.py"
 ) else (
+    echo    Usando uv run como fallback...
     start "Nesh Backend" /D "%~dp0" cmd /k "set CACHE__ENABLE_REDIS=false& uv run Nesh.py"
 )
 echo    Backend iniciado. Aguarde alguns segundos para ele subir.

--- a/tests/unit/test_middleware_jwt_cache.py
+++ b/tests/unit/test_middleware_jwt_cache.py
@@ -59,10 +59,7 @@ def test_public_path_matching_does_not_allow_similar_prefixes():
         middleware.TenantMiddleware._is_public_path("/api/services/nbs/search") is True
     )
     assert middleware.TenantMiddleware._is_public_path("/api/services/nbs/1.01") is True
-    assert (
-        middleware.TenantMiddleware._is_public_path("/api/services/nebs/search")
-        is False
-    )
+
     assert (
         middleware.TenantMiddleware._is_public_path("/api/webhooks-malicious") is False
     )

--- a/tests/unit/test_redis_client.py
+++ b/tests/unit/test_redis_client.py
@@ -234,7 +234,7 @@ async def test_services_and_status_helpers_use_expected_keys(monkeypatch):
 
     versions = {
         "meta:catalog-version:nbs:tenant-a": "v7",
-        "meta:catalog-version:nebs:tenant-b": "v3",
+
     }
 
     async def _fake_get_version(key):
@@ -261,17 +261,6 @@ async def test_services_and_status_helpers_use_expected_keys(monkeypatch):
         "services:nbs:search:v7:tenant-a:search-key",
         {"items": 1},
         cache.services_search_ttl,
-    )
-
-    got_detail = await cache.get_services_detail("nebs", "tenant-b", "detail-key")
-    assert got_detail == {"ok": True}
-    assert seen["get"] == "services:nebs:detail:v3:tenant-b:detail-key"
-
-    await cache.set_services_detail("nebs", "tenant-b", "detail-key", {"entry": 1})
-    assert seen["set"] == (
-        "services:nebs:detail:v3:tenant-b:detail-key",
-        {"entry": 1},
-        cache.services_detail_ttl,
     )
 
     got_status = await cache.get_status_snapshot("public")

--- a/tests/unit/test_redis_client.py
+++ b/tests/unit/test_redis_client.py
@@ -234,7 +234,6 @@ async def test_services_and_status_helpers_use_expected_keys(monkeypatch):
 
     versions = {
         "meta:catalog-version:nbs:tenant-a": "v7",
-
     }
 
     async def _fake_get_version(key):


### PR DESCRIPTION
## Summary

- Remove NEBS-specific load/reset/search-vector handling from the Postgres migration script and related service cache tests.
- Remove the NBS detail action that depended on `detail.nebs`/catalog doc handoff and adjust mocked service status payloads.
- Shorten the Alembic revision id and make `testar_tudo_local.bat` more resilient by recreating an incomplete Python venv with `uv`.

## Notes

- This PR intentionally keeps the NEBS/data-contract cleanup isolated because it changes catalog migration behavior and should be reviewed as a data/product decision.

## Validation

- `pytest tests/unit/test_middleware_jwt_cache.py tests/unit/test_redis_client.py`