### PR TITLE
[codex] Persist search history by document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ raw_data/
 raw_data/nesh.md
 
 # Node / Vite
+node_modules/
 client/node_modules/
 client/dist/
 client/.vite/
@@ -50,6 +51,10 @@ Thumbs.db
 test_results*.txt
 *_runs.txt
 git_diff.txt
+backend_diff.txt
+local_diff.patch
+pr*.diff
+pytest_errors.txt
 .coverage
 .coverage.*
 coverage.xml
@@ -79,6 +84,7 @@ test_output.txt
 # Scripts
 verify_redis.py
 scripts/god_module_guardrail.py
+scratch_search.py
 pull request pendences.md
 
 # Generated results / snapshots (local-only)

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ raw_data/
 raw_data/nesh.md
 
 # Node / Vite
-node_modules/
+/node_modules/
 client/node_modules/
 client/dist/
 client/.vite/
@@ -51,10 +51,10 @@ Thumbs.db
 test_results*.txt
 *_runs.txt
 git_diff.txt
-backend_diff.txt
-local_diff.patch
-pr*.diff
-pytest_errors.txt
+/backend_diff.txt
+/local_diff.patch
+/pr*.diff
+/pytest_errors.txt
 .coverage
 .coverage.*
 coverage.xml
@@ -84,7 +84,7 @@ test_output.txt
 # Scripts
 verify_redis.py
 scripts/god_module_guardrail.py
-scratch_search.py
+/scratch_search.py
 pull request pendences.md
 
 # Generated results / snapshots (local-only)

--- a/client/src/hooks/useHistory.test.tsx
+++ b/client/src/hooks/useHistory.test.tsx
@@ -127,6 +127,19 @@ describe('useHistory', () => {
         expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
     });
 
+    it('keeps legacy history when the new NESH key is malformed', async () => {
+        localStorage.setItem(NESH_KEY, '{not-json');
+        localStorage.setItem(LEGACY_KEY, JSON.stringify([{ term: 'legacy', timestamp: 123 }]));
+
+        const { result } = renderHook(() => useHistory());
+
+        await waitFor(() => {
+            expect(result.current.getHistoryForDoc('nesh')).toEqual([{ term: 'legacy', timestamp: 123 }]);
+        });
+        expect(JSON.parse(localStorage.getItem(NESH_KEY) || '[]')).toEqual([{ term: 'legacy', timestamp: 123 }]);
+        expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+    });
+
     it('ignores malformed stored history without crashing', async () => {
         localStorage.setItem(NESH_KEY, '{not-json');
 

--- a/client/src/hooks/useHistory.test.tsx
+++ b/client/src/hooks/useHistory.test.tsx
@@ -1,0 +1,140 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useHistory } from './useHistory';
+
+const NESH_KEY = 'fiscal_search_history_v1_nesh';
+const TIPI_KEY = 'fiscal_search_history_v1_tipi';
+const NBS_KEY = 'fiscal_search_history_v1_nbs';
+const LEGACY_KEY = 'nesh_search_history';
+
+describe('useHistory', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
+    it('loads from localStorage instead of sessionStorage', async () => {
+        localStorage.setItem(NESH_KEY, JSON.stringify([{ term: '8413', timestamp: 100 }]));
+        sessionStorage.setItem(NESH_KEY, JSON.stringify([{ term: 'wrong', timestamp: 200 }]));
+
+        const { result } = renderHook(() => useHistory());
+
+        await waitFor(() => {
+            expect(result.current.getHistoryForDoc('nesh')).toEqual([{ term: '8413', timestamp: 100 }]);
+        });
+    });
+
+    it('persists history across hook remounts', async () => {
+        const first = renderHook(() => useHistory());
+
+        await act(async () => {
+            first.result.current.addToHistory('nesh', '8413');
+        });
+
+        first.unmount();
+        const second = renderHook(() => useHistory());
+
+        await waitFor(() => {
+            expect(second.result.current.getHistoryForDoc('nesh')).toEqual([
+                expect.objectContaining({ term: '8413' }),
+            ]);
+        });
+    });
+
+    it('saves NESH, TIPI, and NBS histories under separate keys', async () => {
+        const { result } = renderHook(() => useHistory());
+
+        await act(async () => {
+            result.current.addToHistory('nesh', '8413');
+            result.current.addToHistory('tipi', '8501');
+            result.current.addToHistory('nbs', '1.0101');
+        });
+
+        expect(JSON.parse(localStorage.getItem(NESH_KEY) || '[]')).toEqual([
+            expect.objectContaining({ term: '8413' }),
+        ]);
+        expect(JSON.parse(localStorage.getItem(TIPI_KEY) || '[]')).toEqual([
+            expect.objectContaining({ term: '8501' }),
+        ]);
+        expect(JSON.parse(localStorage.getItem(NBS_KEY) || '[]')).toEqual([
+            expect.objectContaining({ term: '1.0101' }),
+        ]);
+    });
+
+    it('deletes one item only from the selected document history', async () => {
+        const { result } = renderHook(() => useHistory());
+
+        await act(async () => {
+            result.current.addToHistory('nesh', '8413');
+            result.current.addToHistory('nesh', '8501');
+            result.current.addToHistory('tipi', '8413');
+            result.current.removeFromHistory('nesh', '8413');
+        });
+
+        expect(result.current.getHistoryForDoc('nesh')).toEqual([
+            expect.objectContaining({ term: '8501' }),
+        ]);
+        expect(result.current.getHistoryForDoc('tipi')).toEqual([
+            expect.objectContaining({ term: '8413' }),
+        ]);
+    });
+
+    it('clears one document history without clearing the others', async () => {
+        const { result } = renderHook(() => useHistory());
+
+        await act(async () => {
+            result.current.addToHistory('nesh', '8413');
+            result.current.addToHistory('tipi', '8501');
+            result.current.clearHistory('nesh');
+        });
+
+        expect(result.current.getHistoryForDoc('nesh')).toEqual([]);
+        expect(result.current.getHistoryForDoc('tipi')).toEqual([
+            expect.objectContaining({ term: '8501' }),
+        ]);
+        expect(localStorage.getItem(NESH_KEY)).toBeNull();
+        expect(localStorage.getItem(TIPI_KEY)).not.toBeNull();
+    });
+
+    it('deduplicates terms case-insensitively within the same document only', async () => {
+        const { result } = renderHook(() => useHistory());
+
+        await act(async () => {
+            result.current.addToHistory('nesh', 'abc');
+            result.current.addToHistory('nesh', 'ABC');
+            result.current.addToHistory('tipi', 'abc');
+        });
+
+        expect(result.current.getHistoryForDoc('nesh')).toEqual([
+            expect.objectContaining({ term: 'ABC' }),
+        ]);
+        expect(result.current.getHistoryForDoc('tipi')).toEqual([
+            expect.objectContaining({ term: 'abc' }),
+        ]);
+    });
+
+    it('migrates the legacy shared history only to NESH', async () => {
+        localStorage.setItem(LEGACY_KEY, JSON.stringify([{ term: 'legacy', timestamp: 123 }]));
+
+        const { result } = renderHook(() => useHistory());
+
+        await waitFor(() => {
+            expect(result.current.getHistoryForDoc('nesh')).toEqual([{ term: 'legacy', timestamp: 123 }]);
+        });
+        expect(result.current.getHistoryForDoc('tipi')).toEqual([]);
+        expect(result.current.getHistoryForDoc('nbs')).toEqual([]);
+        expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+    });
+
+    it('ignores malformed stored history without crashing', async () => {
+        localStorage.setItem(NESH_KEY, '{not-json');
+
+        const { result } = renderHook(() => useHistory());
+
+        await waitFor(() => {
+            expect(result.current.getHistoryForDoc('nesh')).toEqual([]);
+        });
+        expect(localStorage.getItem(NESH_KEY)).toBeNull();
+    });
+});

--- a/client/src/hooks/useHistory.ts
+++ b/client/src/hooks/useHistory.ts
@@ -62,9 +62,26 @@ function parseHistory(storage: Storage, key: string): HistoryItem[] {
     }
 }
 
+function isValidStoredHistory(saved: string | null): boolean {
+    if (!saved) {
+        return false;
+    }
+
+    try {
+        const parsed = JSON.parse(saved);
+        return Array.isArray(parsed) && parsed.some((item) => (
+            item &&
+            typeof item.term === 'string' &&
+            typeof item.timestamp === 'number'
+        ));
+    } catch {
+        return false;
+    }
+}
+
 function migrateLegacyHistory(storage: Storage): void {
     const legacySaved = storage.getItem(LEGACY_STORAGE_KEY);
-    const hasNewNeshHistory = storage.getItem(STORAGE_KEYS.nesh) !== null;
+    const hasNewNeshHistory = isValidStoredHistory(storage.getItem(STORAGE_KEYS.nesh));
 
     if (!legacySaved) {
         return;
@@ -93,13 +110,35 @@ function loadHistoryByDoc(storage: Storage): HistoryByDoc {
 
 export function useHistory() {
     const [historyByDoc, setHistoryByDoc] = useState<HistoryByDoc>(createEmptyHistory);
+    const [hasLoadedHistory, setHasLoadedHistory] = useState(false);
 
     useEffect(() => {
         const storage = getHistoryStorage();
         if (storage) {
             setHistoryByDoc(loadHistoryByDoc(storage));
         }
+        setHasLoadedHistory(true);
     }, []);
+
+    useEffect(() => {
+        if (!hasLoadedHistory) {
+            return;
+        }
+
+        const storage = getHistoryStorage();
+        if (!storage) {
+            return;
+        }
+
+        DOC_TYPES.forEach((doc) => {
+            const history = historyByDoc[doc] ?? [];
+            if (history.length > 0) {
+                storage.setItem(STORAGE_KEYS[doc], JSON.stringify(history));
+            } else {
+                storage.removeItem(STORAGE_KEYS[doc]);
+            }
+        });
+    }, [historyByDoc, hasLoadedHistory]);
 
     const getHistoryForDoc = useCallback((doc: DocType) => historyByDoc[doc] ?? [], [historyByDoc]);
 
@@ -118,7 +157,6 @@ export function useHistory() {
 
             const updated = [newItem, ...filtered].slice(0, MAX_HISTORY);
 
-            getHistoryStorage()?.setItem(STORAGE_KEYS[doc], JSON.stringify(updated));
             return {
                 ...prev,
                 [doc]: updated,
@@ -128,7 +166,6 @@ export function useHistory() {
 
     const clearHistory = useCallback((doc: DocType) => {
         setHistoryByDoc(prev => {
-            getHistoryStorage()?.removeItem(STORAGE_KEYS[doc]);
             return {
                 ...prev,
                 [doc]: [],
@@ -139,7 +176,6 @@ export function useHistory() {
     const removeFromHistory = useCallback((doc: DocType, termToRemove: string) => {
         setHistoryByDoc(prev => {
             const updated = (prev[doc] ?? []).filter(item => item.term !== termToRemove);
-            getHistoryStorage()?.setItem(STORAGE_KEYS[doc], JSON.stringify(updated));
             return {
                 ...prev,
                 [doc]: updated,

--- a/client/src/hooks/useHistory.ts
+++ b/client/src/hooks/useHistory.ts
@@ -1,14 +1,24 @@
 import { useState, useEffect, useCallback } from 'react';
+import type { DocType } from './useTabs';
 
 const MAX_HISTORY = 10;
-const STORAGE_KEY = 'nesh_search_history';
+const LEGACY_STORAGE_KEY = 'nesh_search_history';
+const DOC_TYPES: DocType[] = ['nesh', 'tipi', 'nbs'];
+
+const STORAGE_KEYS: Record<DocType, string> = {
+    nesh: 'fiscal_search_history_v1_nesh',
+    tipi: 'fiscal_search_history_v1_tipi',
+    nbs: 'fiscal_search_history_v1_nbs',
+};
+
+type HistoryByDoc = Record<DocType, HistoryItem[]>;
 
 function getHistoryStorage(): Storage | null {
     try {
         if (typeof window === 'undefined') {
             return null;
         }
-        return window.sessionStorage;
+        return window.localStorage;
     } catch {
         return null;
     }
@@ -19,27 +29,87 @@ export interface HistoryItem {
     timestamp: number;
 }
 
-export function useHistory() {
-    const [history, setHistory] = useState<HistoryItem[]>([]);
+function createEmptyHistory(): HistoryByDoc {
+    return {
+        nesh: [],
+        tipi: [],
+        nbs: [],
+    };
+}
 
-    // Load from session storage on mount to avoid persisting search behavior across browser sessions.
+function parseHistory(storage: Storage, key: string): HistoryItem[] {
+    const saved = storage.getItem(key);
+    if (!saved) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(saved);
+        if (!Array.isArray(parsed)) {
+            storage.removeItem(key);
+            return [];
+        }
+
+        return parsed.filter((item): item is HistoryItem => (
+            item &&
+            typeof item.term === 'string' &&
+            typeof item.timestamp === 'number'
+        ));
+    } catch (e) {
+        console.error('Failed to parse history', e);
+        storage.removeItem(key);
+        return [];
+    }
+}
+
+function migrateLegacyHistory(storage: Storage): void {
+    const legacySaved = storage.getItem(LEGACY_STORAGE_KEY);
+    const hasNewNeshHistory = storage.getItem(STORAGE_KEYS.nesh) !== null;
+
+    if (!legacySaved) {
+        return;
+    }
+
+    if (hasNewNeshHistory) {
+        storage.removeItem(LEGACY_STORAGE_KEY);
+        return;
+    }
+
+    const legacyHistory = parseHistory(storage, LEGACY_STORAGE_KEY);
+    if (legacyHistory.length > 0) {
+        storage.setItem(STORAGE_KEYS.nesh, JSON.stringify(legacyHistory.slice(0, MAX_HISTORY)));
+    }
+    storage.removeItem(LEGACY_STORAGE_KEY);
+}
+
+function loadHistoryByDoc(storage: Storage): HistoryByDoc {
+    migrateLegacyHistory(storage);
+
+    return DOC_TYPES.reduce<HistoryByDoc>((acc, doc) => {
+        acc[doc] = parseHistory(storage, STORAGE_KEYS[doc]).slice(0, MAX_HISTORY);
+        return acc;
+    }, createEmptyHistory());
+}
+
+export function useHistory() {
+    const [historyByDoc, setHistoryByDoc] = useState<HistoryByDoc>(createEmptyHistory);
+
     useEffect(() => {
-        const saved = getHistoryStorage()?.getItem(STORAGE_KEY);
-        if (saved) {
-            try {
-                setHistory(JSON.parse(saved));
-            } catch (e) {
-                console.error("Failed to parse history", e);
-            }
+        const storage = getHistoryStorage();
+        if (storage) {
+            setHistoryByDoc(loadHistoryByDoc(storage));
         }
     }, []);
 
-    const addToHistory = useCallback((term: string) => {
+    const getHistoryForDoc = useCallback((doc: DocType) => historyByDoc[doc] ?? [], [historyByDoc]);
+
+    const addToHistory = useCallback((doc: DocType, term: string) => {
         if (!term) return;
 
-        setHistory(prev => {
+        setHistoryByDoc(prev => {
+            const previousDocHistory = prev[doc] ?? [];
             // Remove duplicates (case insensitive) and keep only unique recent
-            const filtered = prev.filter(item => item.term.toLowerCase() !== term.toLowerCase());
+            const filtered = previousDocHistory.filter(item => item.term.toLowerCase() !== term.toLowerCase());
 
             const newItem: HistoryItem = {
                 term,
@@ -48,27 +118,38 @@ export function useHistory() {
 
             const updated = [newItem, ...filtered].slice(0, MAX_HISTORY);
 
-            // Persist
-            getHistoryStorage()?.setItem(STORAGE_KEY, JSON.stringify(updated));
-            return updated;
+            getHistoryStorage()?.setItem(STORAGE_KEYS[doc], JSON.stringify(updated));
+            return {
+                ...prev,
+                [doc]: updated,
+            };
         });
     }, []);
 
-    const clearHistory = useCallback(() => {
-        setHistory([]);
-        getHistoryStorage()?.removeItem(STORAGE_KEY);
+    const clearHistory = useCallback((doc: DocType) => {
+        setHistoryByDoc(prev => {
+            getHistoryStorage()?.removeItem(STORAGE_KEYS[doc]);
+            return {
+                ...prev,
+                [doc]: [],
+            };
+        });
     }, []);
 
-    const removeFromHistory = useCallback((termToRemove: string) => {
-        setHistory(prev => {
-            const updated = prev.filter(item => item.term !== termToRemove);
-            getHistoryStorage()?.setItem(STORAGE_KEY, JSON.stringify(updated));
-            return updated;
+    const removeFromHistory = useCallback((doc: DocType, termToRemove: string) => {
+        setHistoryByDoc(prev => {
+            const updated = (prev[doc] ?? []).filter(item => item.term !== termToRemove);
+            getHistoryStorage()?.setItem(STORAGE_KEYS[doc], JSON.stringify(updated));
+            return {
+                ...prev,
+                [doc]: updated,
+            };
         });
     }, []);
 
     return {
-        history,
+        history: historyByDoc.nesh,
+        getHistoryForDoc,
         addToHistory,
         clearHistory,
         removeFromHistory

--- a/client/src/hooks/useSearch.ts
+++ b/client/src/hooks/useSearch.ts
@@ -122,7 +122,8 @@ export function useSearch(
     const executeSearchForTab = useCallback(async (tabId: string, doc: DocType, query: string, saveHistory: boolean = true) => {
         if (!query) return;
 
-        if (saveHistory) addToHistory(doc, query);
+        const trimmedQuery = query.trim();
+        if (saveHistory && trimmedQuery) addToHistory(doc, trimmedQuery);
 
         // Localiza a aba atual para consultar capítulos carregados
         const currentTab = tabsByIdRef.current.get(tabId);

--- a/client/src/hooks/useSearch.ts
+++ b/client/src/hooks/useSearch.ts
@@ -122,7 +122,7 @@ export function useSearch(
     const executeSearchForTab = useCallback(async (tabId: string, doc: DocType, query: string, saveHistory: boolean = true) => {
         if (!query) return;
 
-        if (saveHistory) addToHistory(query);
+        if (saveHistory) addToHistory(doc, query);
 
         // Localiza a aba atual para consultar capítulos carregados
         const currentTab = tabsByIdRef.current.get(tabId);

--- a/client/src/useAppInteractions.ts
+++ b/client/src/useAppInteractions.ts
@@ -116,7 +116,7 @@ export function useAppInteractions({
 }: UseAppInteractionsArgs): AppInteractionsState {
     const { sidebarPosition } = useSettings();
     const { status: localDbStatus, install, progress } = useLocalDatabase();
-    const { history, addToHistory, removeFromHistory, clearHistory } = useHistory();
+    const { getHistoryForDoc, addToHistory, removeFromHistory, clearHistory } = useHistory();
     const { ensureServicesSearchAccess, servicesUnavailableReason } = useServicesAccess();
     const { executeSearchForTab } = useSearch(tabsById, updateTab, addToHistory);
     const { fetchNotes: fetchCrossChapterNotes } = useCrossChapterNotes();
@@ -128,6 +128,16 @@ export function useAppInteractions({
     const openServiceResultInNewTabRef = useRef<(code: string, textQuery?: string, activate?: boolean) => Promise<void> | void>(() => {});
 
     activeTabRef.current = activeTab;
+    const activeHistoryDoc = (activeTab?.document || 'nesh') as DocType;
+    const history = getHistoryForDoc(activeHistoryDoc);
+
+    const clearActiveHistory = useCallback(() => {
+        clearHistory(activeHistoryDoc);
+    }, [activeHistoryDoc, clearHistory]);
+
+    const removeFromActiveHistory = useCallback((term: string) => {
+        removeFromHistory(activeHistoryDoc, term);
+    }, [activeHistoryDoc, removeFromHistory]);
 
     const runNonBlockingTask = useCallback((task: Promise<unknown> | void, context: string) => {
         Promise.resolve(task).catch((error) => {
@@ -545,8 +555,8 @@ if (!content) {
         localDbStatus,
         progress,
         history,
-        clearHistory,
-        removeFromHistory,
+        clearHistory: clearActiveHistory,
+        removeFromHistory: removeFromActiveHistory,
         servicesUnavailableReason,
         triggerInstall,
         handleSearch,

--- a/client/tests/integration/AppSearch.test.tsx
+++ b/client/tests/integration/AppSearch.test.tsx
@@ -11,6 +11,7 @@ vi.mock('../../src/services/api');
 vi.mock('../../src/hooks/useHistory', () => ({
     useHistory: () => ({
         history: [],
+        getHistoryForDoc: vi.fn(() => []),
         addToHistory: vi.fn(),
         removeFromHistory: vi.fn(),
         clearHistory: vi.fn(),

--- a/client/tests/integration/SameChapterNavigation.test.tsx
+++ b/client/tests/integration/SameChapterNavigation.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../../src/hooks/useSearch');
 vi.mock('../../src/hooks/useHistory', () => ({
     useHistory: () => ({
         history: [],
+        getHistoryForDoc: vi.fn(() => []),
         addToHistory: vi.fn(),
         removeFromHistory: vi.fn(),
         clearHistory: vi.fn(),

--- a/client/tests/unit/App.behavior.test.tsx
+++ b/client/tests/unit/App.behavior.test.tsx
@@ -319,6 +319,7 @@ vi.mock('../../src/hooks/useSearch', () => ({
 vi.mock('../../src/hooks/useHistory', () => ({
   useHistory: () => ({
     history: mocks.historyRef.value,
+    getHistoryForDoc: vi.fn(() => mocks.historyRef.value),
     addToHistory: mocks.addToHistoryMock,
     removeFromHistory: mocks.removeFromHistoryMock,
     clearHistory: mocks.clearHistoryMock,
@@ -870,8 +871,8 @@ describe('App behavior', () => {
 
     fireEvent.click(screen.getByTestId('layout-clear-history'));
     fireEvent.click(screen.getByTestId('layout-remove-history'));
-    expect(mocks.clearHistoryMock).toHaveBeenCalledTimes(1);
-    expect(mocks.removeFromHistoryMock).toHaveBeenCalledWith('8517');
+    expect(mocks.clearHistoryMock).toHaveBeenCalledWith('nesh');
+    expect(mocks.removeFromHistoryMock).toHaveBeenCalledWith('nesh', '8517');
 
     fireEvent.click(screen.getByTestId('modal-open-doc-current'));
     expect(mocks.updateTabMock).toHaveBeenCalledWith(

--- a/client/tests/unit/ContextSwitch.test.tsx
+++ b/client/tests/unit/ContextSwitch.test.tsx
@@ -71,6 +71,7 @@ vi.mock('../../src/context/AuthContext', () => ({
 vi.mock('../../src/hooks/useHistory', () => ({
     useHistory: () => ({
         history: [],
+        getHistoryForDoc: vi.fn(() => []),
         addToHistory: vi.fn(),
         removeFromHistory: vi.fn(),
         clearHistory: vi.fn()

--- a/client/tests/unit/TabsPersistence.test.tsx
+++ b/client/tests/unit/TabsPersistence.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../../src/context/AuthContext', () => ({
 vi.mock('../../src/hooks/useHistory', () => ({
     useHistory: () => ({
         history: [],
+        getHistoryForDoc: vi.fn(() => []),
         addToHistory: vi.fn(),
         removeFromHistory: vi.fn(),
         clearHistory: vi.fn()

--- a/client/tests/unit/useHistory.test.tsx
+++ b/client/tests/unit/useHistory.test.tsx
@@ -3,14 +3,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useHistory } from '../../src/hooks/useHistory';
 
+const NESH_KEY = 'fiscal_search_history_v1_nesh';
+const TIPI_KEY = 'fiscal_search_history_v1_tipi';
+const LEGACY_KEY = 'nesh_search_history';
+
 describe('useHistory', () => {
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
   });
 
-  it('loads persisted history from sessionStorage on mount', async () => {
-    sessionStorage.setItem('nesh_search_history', JSON.stringify([
+  it('loads persisted NESH history from localStorage on mount', async () => {
+    localStorage.setItem(NESH_KEY, JSON.stringify([
       { term: '8517', timestamp: 1 },
       { term: '8471', timestamp: 2 },
     ]));
@@ -22,11 +26,15 @@ describe('useHistory', () => {
         { term: '8517', timestamp: 1 },
         { term: '8471', timestamp: 2 },
       ]);
+      expect(result.current.getHistoryForDoc('nesh')).toEqual([
+        { term: '8517', timestamp: 1 },
+        { term: '8471', timestamp: 2 },
+      ]);
     });
   });
 
   it('logs parse failures and keeps an empty history when persisted data is invalid', async () => {
-    sessionStorage.setItem('nesh_search_history', '{invalid-json');
+    localStorage.setItem(NESH_KEY, '{invalid-json');
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     try {
@@ -36,6 +44,7 @@ describe('useHistory', () => {
         expect(consoleErrorSpy).toHaveBeenCalled();
       });
       expect(result.current.history).toEqual([]);
+      expect(localStorage.getItem(NESH_KEY)).toBeNull();
     } finally {
       consoleErrorSpy.mockRestore();
     }
@@ -45,37 +54,61 @@ describe('useHistory', () => {
     const { result } = renderHook(() => useHistory());
 
     act(() => {
-      result.current.addToHistory('');
+      result.current.addToHistory('nesh', '');
       for (let index = 0; index < 11; index += 1) {
-        result.current.addToHistory(`84${index}`);
+        result.current.addToHistory('nesh', `84${index}`);
       }
-      result.current.addToHistory('840');
+      result.current.addToHistory('nesh', '840');
     });
 
     expect(result.current.history).toHaveLength(10);
     expect(result.current.history[0].term).toBe('840');
     expect(result.current.history.map((item) => item.term)).not.toContain('8400');
-    expect(JSON.parse(sessionStorage.getItem('nesh_search_history') || '[]')).toHaveLength(10);
+    expect(JSON.parse(localStorage.getItem(NESH_KEY) || '[]')).toHaveLength(10);
   });
 
   it('removes individual terms and clears the full history', () => {
     const { result } = renderHook(() => useHistory());
 
     act(() => {
-      result.current.addToHistory('8517');
-      result.current.addToHistory('8471');
-      result.current.removeFromHistory('8517');
+      result.current.addToHistory('nesh', '8517');
+      result.current.addToHistory('nesh', '8471');
+      result.current.addToHistory('tipi', '8517');
+      result.current.removeFromHistory('nesh', '8517');
     });
 
     expect(result.current.history).toEqual([
       expect.objectContaining({ term: '8471' }),
     ]);
+    expect(result.current.getHistoryForDoc('tipi')).toEqual([
+      expect.objectContaining({ term: '8517' }),
+    ]);
 
     act(() => {
-      result.current.clearHistory();
+      result.current.clearHistory('nesh');
     });
 
     expect(result.current.history).toEqual([]);
-    expect(sessionStorage.getItem('nesh_search_history')).toBeNull();
+    expect(result.current.getHistoryForDoc('tipi')).toEqual([
+      expect.objectContaining({ term: '8517' }),
+    ]);
+    expect(localStorage.getItem(NESH_KEY)).toBeNull();
+    expect(localStorage.getItem(TIPI_KEY)).not.toBeNull();
+  });
+
+  it('migrates legacy localStorage history only to NESH', async () => {
+    localStorage.setItem(LEGACY_KEY, JSON.stringify([
+      { term: 'legacy', timestamp: 1 },
+    ]));
+
+    const { result } = renderHook(() => useHistory());
+
+    await waitFor(() => {
+      expect(result.current.getHistoryForDoc('nesh')).toEqual([
+        { term: 'legacy', timestamp: 1 },
+      ]);
+    });
+    expect(result.current.getHistoryForDoc('tipi')).toEqual([]);
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Persist search history in localStorage so it survives refreshes and redeploys on the same origin.
- Store NESH, TIPI, and NBS histories separately with a migration from the legacy shared key.
- Ignore local debug artifacts such as ad hoc diffs, pytest output, scratch scripts, and root node_modules.

## Test Plan
- npm test -- src/hooks/useHistory.test.tsx
- npm test
- npm run type-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search history now persists across browser sessions using local storage.
  * Search history is stored separately by document type.
  * Legacy search history is automatically migrated to the new system.

* **Bug Fixes**
  * Corrupted stored history data is now properly removed without causing crashes.

* **Tests**
  * Added comprehensive test suite for search history functionality.
  * Updated existing tests to reflect API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->