### PR TITLE
[codex] Improve offline database download compatibility

### DIFF
--- a/backend/presentation/routes/database_download.py
+++ b/backend/presentation/routes/database_download.py
@@ -229,9 +229,13 @@ async def get_database_version():
     return {
         "version": meta.get("version"),
         "size_bytes": meta.get("size_bytes"),
+        "sha256": meta.get("sha256"),
+        "encrypted_sha256": meta.get("encrypted_sha256"),
         "updated_at": meta.get("built_at"),
         "built_at": meta.get("built_at"),
         "format_version": meta.get("format_version", 1),
+        "chunk_size": meta.get("chunk_size", 65536),
+        "pbkdf2_iterations": meta.get("pbkdf2_iterations", 600_000),
     }
 
 

--- a/client/src/context/offlineDatabaseMutations.ts
+++ b/client/src/context/offlineDatabaseMutations.ts
@@ -94,7 +94,7 @@ export function useOfflineDatabaseMutations({
                         clerkToken: '',
                     },
                 },
-                180_000,
+                600_000,
             );
 
             const effectiveMetadata =

--- a/client/src/context/offlineDatabaseSync.ts
+++ b/client/src/context/offlineDatabaseSync.ts
@@ -3,6 +3,7 @@ import { sanitizeOfflineMetadata, type OfflineDatabaseMetadata } from '../utils/
 
 export const OFFLINE_CHANNEL_NAME = 'offline-db-channel';
 export const OFFLINE_WAIT_TIMEOUT_MS = 240_000;
+const OFFLINE_METADATA_TIMEOUTS_MS = [4_000, 10_000, 20_000] as const;
 
 export function getOfflineDatabaseApiBaseUrl(): string {
     return API_BASE_URL;
@@ -59,8 +60,30 @@ export async function primeOfflineShellCache(): Promise<void> {
 export async function fetchOfflineDatabaseAvailabilityMetadata(
     apiBaseUrl: string,
 ): Promise<OfflineDatabaseMetadata | null> {
+    let lastError: unknown = null;
+    for (const timeoutMs of OFFLINE_METADATA_TIMEOUTS_MS) {
+        try {
+            return await fetchOfflineDatabaseAvailabilityMetadataOnce(
+                apiBaseUrl,
+                timeoutMs,
+            );
+        } catch (err) {
+            lastError = err;
+            if (!isRetryableOfflineMetadataError(err)) break;
+        }
+    }
+
+    throw lastError instanceof Error
+        ? lastError
+        : new Error('Version check failed for an unknown reason');
+}
+
+async function fetchOfflineDatabaseAvailabilityMetadataOnce(
+    apiBaseUrl: string,
+    timeoutMs: number,
+): Promise<OfflineDatabaseMetadata | null> {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 4000);
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
         const response = await fetch(`${apiBaseUrl}/database/version`, {
@@ -77,4 +100,12 @@ export async function fetchOfflineDatabaseAvailabilityMetadata(
     } finally {
         clearTimeout(timer);
     }
+}
+
+function isRetryableOfflineMetadataError(err: unknown): boolean {
+    if (!err || typeof err !== 'object') return false;
+    const name = String((err as { name?: unknown }).name ?? '');
+    const message = String((err as { message?: unknown }).message ?? '');
+    if (name === 'AbortError' || name === 'TimeoutError') return true;
+    return message.includes('Failed to fetch') || message.includes('NetworkError');
 }

--- a/client/src/workers/dbWorker/messages.js
+++ b/client/src/workers/dbWorker/messages.js
@@ -132,6 +132,40 @@ async function fetchEncryptedDatabase(apiBase, token) {
   );
 }
 
+function waitBeforeOfflineDownloadRetry() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 1200);
+  });
+}
+
+function isRetryableOfflineDownloadError(error) {
+  if (!(error instanceof Error)) return false;
+  if (error.message.includes("(403)") || error.message.includes("(429)")) return false;
+  if (error.message.includes("integrity verification failed")) return false;
+  return true;
+}
+
+async function fetchEncryptedDatabaseBundle(apiBase, id) {
+  let lastError = null;
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const tokenData = await requestInstallToken(apiBase);
+      postWorkerProgress(id, 10, "fetching_database");
+      const dlResp = await fetchEncryptedDatabase(apiBase, tokenData.token);
+      const encryptedBlob = await readEncryptedDatabaseBlob(dlResp, id);
+      return { tokenData, encryptedBlob };
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableOfflineDownloadError(error) || attempt === 1) break;
+      postWorkerProgress(id, 10, "retrying_download");
+      await waitBeforeOfflineDownloadRetry();
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("Offline database download failed");
+}
+
 async function updateInstalledVersion(apiBase) {
   let nextVersion = null;
 
@@ -162,9 +196,8 @@ async function handleInstallMessage(id, payload) {
   let plaintext = null;
 
   try {
-    const tokenData = await requestInstallToken(apiBase);
+    const { tokenData, encryptedBlob } = await fetchEncryptedDatabaseBundle(apiBase, id);
     const {
-      token,
       app_seed: appSeed,
       encrypted_sha256: expectedEncryptedSha256,
       chunk_size: chunkSize = 65536,
@@ -174,11 +207,6 @@ async function handleInstallMessage(id, payload) {
       throw new Error("Offline database key was not provided by the server");
     }
     setAppSeed(appSeed);
-
-    postWorkerProgress(id, 10, "fetching_database");
-
-    const dlResp = await fetchEncryptedDatabase(apiBase, token);
-    const encryptedBlob = await readEncryptedDatabaseBlob(dlResp, id);
 
     if (expectedEncryptedSha256) {
       postWorkerProgress(id, 72, "verifying_integrity");

--- a/client/tests/unit/offlineDatabaseSync.test.ts
+++ b/client/tests/unit/offlineDatabaseSync.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchOfflineDatabaseAvailabilityMetadata } from '../../src/context/offlineDatabaseSync'
+
+function makeOfflineVersionResponse(version: string): Response {
+  return new Response(
+    JSON.stringify({
+      version,
+      size_bytes: 2048,
+      sha256: 'plain-sha',
+      encrypted_sha256: 'enc-sha',
+      chunk_size: 131072,
+      pbkdf2_iterations: 700000,
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  )
+}
+
+describe('offlineDatabaseSync', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('retries metadata checks after a transient abort', async () => {
+    const abortError = new DOMException(
+      'signal is aborted without reason',
+      'AbortError'
+    )
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(abortError)
+      .mockResolvedValueOnce(makeOfflineVersionResponse('2026.04.29'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      fetchOfflineDatabaseAvailabilityMetadata('https://api.example.test')
+    ).resolves.toEqual({
+      version: '2026.04.29',
+      size_bytes: 2048,
+      sha256: 'plain-sha',
+      encrypted_sha256: 'enc-sha',
+      built_at: null,
+      updated_at: null,
+      format_version: 1,
+      chunk_size: 131072,
+      pbkdf2_iterations: 700000,
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry non-recoverable HTTP failures', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('missing bundle', { status: 503 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      fetchOfflineDatabaseAvailabilityMetadata('https://api.example.test')
+    ).rejects.toThrow('Version check failed (503)')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -54,6 +54,7 @@
 
 ### Evidências usadas na classificação (amostra)
 - Offline contract backend: `tests/unit/test_database_download_route.py`
+- Offline metadata compatibility/retry: `client/tests/unit/offlineDatabaseSync.test.ts`
 - Auth e AI chat contracts: `tests/integration/test_auth_api_contract.py`
 - Webhooks contract: `tests/integration/test_webhooks_api_contract.py`
 - Search/services contracts: `tests/integration/test_search_route_contracts.py`, `tests/integration/test_services_route_contract.py`

--- a/tests/unit/test_database_download_route.py
+++ b/tests/unit/test_database_download_route.py
@@ -105,10 +105,10 @@ async def test_get_database_version_exposes_offline_contract(offline_bundle):
     assert payload["size_bytes"] == 128
     assert payload["built_at"] == "2026-04-15T12:00:00Z"
     assert payload["format_version"] == 1
-    assert "sha256" not in payload
-    assert "encrypted_sha256" not in payload
-    assert "chunk_size" not in payload
-    assert "pbkdf2_iterations" not in payload
+    assert payload["sha256"] == "plain-sha"
+    assert payload["encrypted_sha256"] == "enc-sha"
+    assert payload["chunk_size"] == 65536
+    assert payload["pbkdf2_iterations"] == 600000
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Retry offline metadata checks with progressive timeouts so slow PCs/connections do not fail on the first AbortError.
- Expose safe offline bundle metadata from /database/version, including hashes and crypto parameters, without exposing the app seed.
- Give the install worker more time and retry transient token/download failures while preserving one-time token, rate-limit, and integrity protections.

## Validation
- npm test -- tests/unit/offlineDatabaseSync.test.ts tests/unit/LocalDatabaseContext.autoinstall.test.tsx tests/unit/offlineDatabase.test.ts
- npm run type-check
- uv run pytest tests/unit/test_database_download_route.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Offline database synchronization now includes automatic retry logic with progressive timeouts for improved reliability.
  * Extended offline database installation timeout to better support larger downloads.
  * Database download operations now retry on transient network failures.
  * API endpoints expose additional cryptographic parameters for offline database verification.

* **Tests**
  * Added unit test coverage for offline database synchronization scenarios.

* **Documentation**
  * Updated testing documentation with offline database coverage references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->