### PR TITLE
[codex] Fix smart-link browser tab opening

### DIFF
--- a/client/src/useAppInteractions.ts
+++ b/client/src/useAppInteractions.ts
@@ -317,6 +317,8 @@ if (!content) {
     }, [updateTab]);
 
     useEffect(() => {
+        const middleMouseDownHandledLinks = new WeakSet<Element>();
+
         const handleDelegatedMiddleMouseDown = (event: MouseEvent) => {
             if (event.button !== 1) {
                 return;
@@ -324,6 +326,55 @@ if (!content) {
 
             const target = event.target;
             if (!(target instanceof Element)) {
+                return;
+            }
+
+            if (handleDelegatedSearchNavigation(
+                target,
+                'a.smart-link',
+                'ncm',
+                true,
+                event,
+                handleSearchRef.current,
+                openTextResultInNewTabRef.current,
+            )) {
+                const link = target.closest('a.smart-link');
+                if (link) {
+                    middleMouseDownHandledLinks.add(link);
+                }
+                return;
+            }
+
+            if (handleDelegatedSearchNavigation(
+                target,
+                '.service-smart-link, .service-code-target',
+                'serviceCode',
+                true,
+                event,
+                handleSearchRef.current,
+                openServiceResultInNewTabRef.current,
+            )) {
+                const link = target.closest('.service-smart-link, .service-code-target');
+                if (link) {
+                    middleMouseDownHandledLinks.add(link);
+                }
+            }
+        };
+
+        const handleDelegatedAuxClick = (event: MouseEvent) => {
+            if (event.button !== 1) {
+                return;
+            }
+
+            const target = event.target;
+            if (!(target instanceof Element)) {
+                return;
+            }
+
+            const handledMiddleLink = target.closest('a.smart-link, .service-smart-link, .service-code-target');
+            if (handledMiddleLink && middleMouseDownHandledLinks.has(handledMiddleLink)) {
+                middleMouseDownHandledLinks.delete(handledMiddleLink);
+                event.preventDefault();
                 return;
             }
 
@@ -390,9 +441,11 @@ if (!content) {
         };
 
         document.addEventListener('mousedown', handleDelegatedMiddleMouseDown);
+        document.addEventListener('auxclick', handleDelegatedAuxClick);
         document.addEventListener('click', handleDelegatedClick);
         return () => {
             document.removeEventListener('mousedown', handleDelegatedMiddleMouseDown);
+            document.removeEventListener('auxclick', handleDelegatedAuxClick);
             document.removeEventListener('click', handleDelegatedClick);
         };
     }, []);

--- a/client/tests/unit/App.behavior.test.tsx
+++ b/client/tests/unit/App.behavior.test.tsx
@@ -1198,6 +1198,24 @@ describe('App behavior', () => {
     });
   });
 
+  it('prevents browser tab navigation after middle-clicking a smart link', async () => {
+    render(<App />);
+
+    const smartLink = appendSmartLink('841320');
+    fireEvent.mouseDown(smartLink, { bubbles: true, button: 1 });
+
+    await waitFor(() => {
+      expect(mocks.createTabMock).toHaveBeenCalledTimes(1);
+      expect(mocks.executeSearchForTabMock).toHaveBeenCalledWith('new-nesh-1', 'nesh', '841320', false);
+    });
+
+    const auxClickEvent = new MouseEvent('auxclick', { bubbles: true, button: 1, cancelable: true });
+    smartLink.dispatchEvent(auxClickEvent);
+
+    expect(auxClickEvent.defaultPrevented).toBe(true);
+    expect(mocks.createTabMock).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps note navigation working when a smart-link anchor has no NCM data', async () => {
     setTabsState([
       buildTab({


### PR DESCRIPTION
## O que mudou
- Cancela o auxclick depois que o clique do meio em smart-link cria a aba interna.
- Evita que o navegador abra uma aba externa alem da aba do site.
- Adiciona teste unitario para o caso 841320.

## Causa raiz
O mousedown do botao do meio abria a aba interna, mas o auxclick posterior do anchor ainda podia acionar a navegacao padrao do navegador.

## Testes
- npm test -- tests/unit/App.behavior.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced middle-click navigation handling for search and service links to reliably create background tabs while preventing duplicate activation and unwanted default browser behavior.

* **Tests**
  * Added test coverage for smart-link middle-click interactions, verifying correct tab creation and default behavior suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->