### PR TITLE
test: cover Portuguese stemmer cache

### DIFF
--- a/tests/performance/test_text_processor_cache_perf.py
+++ b/tests/performance/test_text_processor_cache_perf.py
@@ -1,0 +1,32 @@
+import pytest
+
+from backend.utils import text_processor
+from backend.utils.text_processor import NeshTextProcessor
+
+pytestmark = pytest.mark.perf
+
+
+def test_text_processor_cache_benchmark(benchmark):
+    text_processor._cached_stem.cache_clear()
+    processor = NeshTextProcessor(stopwords=["de", "com", "para"])
+    text = " ".join(
+        [
+            "motores",
+            "motores",
+            "máquinas",
+            "máquinas",
+            "luzes",
+            "papéis",
+            "trens",
+            "produtora",
+            "pequena",
+            "carros",
+        ]
+        * 200
+    )
+
+    result = benchmark(processor.process, text)
+
+    assert "motor" in result
+    assert "maquino" in result
+    assert text_processor._cached_stem.cache_info().hits > 0

--- a/tests/unit/test_text_processor.py
+++ b/tests/unit/test_text_processor.py
@@ -1,7 +1,15 @@
 import pytest
+from backend.utils import text_processor
 from backend.utils.text_processor import NeshTextProcessor, PortugueseStemmer
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def clear_stem_cache_between_tests():
+    text_processor._cached_stem.cache_clear()
+    yield
+    text_processor._cached_stem.cache_clear()
 
 
 def test_stemmer_plural_rules_cover_specific_suffixes():
@@ -38,6 +46,58 @@ def test_processor_normalize_and_process_with_stopwords():
     assert p.process(text) == "maquino lavar motor eletrico"
 
 
+@pytest.mark.parametrize(
+    (
+        "text",
+        "stopwords",
+        "expected_normalized",
+        "expected_process",
+        "expected_fts",
+        "expected_exact",
+    ),
+    [
+        (
+            "Máquinas de lavar, com motor elétrico!",
+            ["de", "com"],
+            "maquinas de lavar, com motor eletrico!",
+            "maquino lavar motor eletrico",
+            "maquino* lavar* motor* eletrico*",
+            "maquino lavar motor eletrico",
+        ),
+        (
+            "Motores, luzes e papéis para trens",
+            ["e", "para"],
+            "motores, luzes e papeis para trens",
+            "motor luz papel trem",
+            "motor* luz* papel* trem*",
+            "motor luz papel trem",
+        ),
+        (
+            "A produtora pequena vende carros nacionais",
+            ["a"],
+            "a produtora pequena vende carros nacionais",
+            "produtor pequeno vende carro nacional",
+            "produtor* pequeno* vende* carro* nacional*",
+            "produtor pequeno vende carro nacional",
+        ),
+    ],
+)
+def test_processor_outputs_stay_unchanged_with_stem_cache(
+    text,
+    stopwords,
+    expected_normalized,
+    expected_process,
+    expected_fts,
+    expected_exact,
+):
+    processor = NeshTextProcessor(stopwords=stopwords)
+
+    assert processor.normalize(text) == expected_normalized
+    assert processor.process(text) == expected_process
+    assert processor.process_query_for_fts(text) == expected_fts
+    assert processor.process_query_exact(text) == expected_exact
+
+
 def test_process_ignores_single_letters_and_stopwords():
     p = NeshTextProcessor(stopwords=["a"])
     assert p.process("a b c de") == "de"
@@ -51,6 +111,25 @@ def test_process_query_for_fts_appends_wildcards():
 def test_process_query_exact_without_wildcards():
     p = NeshTextProcessor(stopwords=["de"])
     assert p.process_query_exact("Motores de arranque") == "motor arranque"
+
+
+def test_processor_reuses_cached_stems_for_repeated_words(monkeypatch):
+    calls = []
+
+    def fake_stem(word):
+        calls.append(word)
+        return f"{word}-stemmed"
+
+    monkeypatch.setattr(text_processor._SHARED_STEMMER, "stem", fake_stem)
+
+    processor = NeshTextProcessor()
+
+    assert processor.process("motores motores luzes motores") == (
+        "motores-stemmed motores-stemmed luzes-stemmed motores-stemmed"
+    )
+    assert calls == ["motores", "luzes"]
+    assert text_processor._cached_stem.cache_info().hits == 2
+    assert text_processor._cached_stem.cache_info().misses == 2
 
 
 def test_step_augmentative_is_noop():


### PR DESCRIPTION
## Summary
- adds regression coverage for Portuguese text processing output
- verifies module-level LRU cache hits for repeated stems
- adds an optional perf-marked benchmark for repeated stemming workloads

## Tests
- pytest tests/unit/test_text_processor.py -v
- pytest tests/unit/test_text_processor.py tests/performance/test_text_processor_cache_perf.py -v
- pytest tests/performance/test_text_processor_cache_perf.py -m perf --benchmark-disable -v

## Scope checks
- frontend untouched in this branch
- pytest configuration unchanged
- AI context docs unchanged because this is local backend test/perf coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance benchmark for text processing cache behavior
  * Improved unit test robustness with automated cache reset and parametrized test coverage for text processing operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->