### PR TITLE
[codex] fix local search support detection

### DIFF
--- a/client/public/_headers
+++ b/client/public/_headers
@@ -1,0 +1,3 @@
+/*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: credentialless

--- a/client/public/coi-serviceworker.js
+++ b/client/public/coi-serviceworker.js
@@ -117,9 +117,11 @@ if (typeof window === "undefined") {
   });
 
   self.addEventListener("message", (event) => {
+    if (event.origin && event.origin !== self.location.origin) return;
+    if (!isTrustedMessageOrigin(event)) return;
+
     const message = event.data;
     if (!message) return;
-    if (!isTrustedMessageOrigin(event)) return;
 
     if (message.type === "deregister") {
       self.registration
@@ -228,7 +230,7 @@ if (typeof window === "undefined") {
     event.respondWith(
       networkWithOptionalCredentials(request).catch(async () => {
         if (!sameOrigin) {
-          throw new Error("Cross-origin request unavailable offline");
+          return Response.error();
         }
         const cache = await caches.open(RUNTIME_CACHE);
         const cachedResponse = await cache.match(request.url);
@@ -282,7 +284,12 @@ if (typeof window === "undefined") {
       const isViteDevClientPresent = Boolean(
         document.querySelector('script[src*="/@vite/client"]')
       );
-      if (isLocalhost && isViteDevClientPresent) {
+      if (
+        isLocalhost &&
+        isViteDevClientPresent &&
+        window.crossOriginIsolated === true &&
+        typeof window.SharedArrayBuffer !== "undefined"
+      ) {
         console.info("[coi] Local dev detected. Bypassing SW to prevent Vite conflicts.");
         navigator.serviceWorker.getRegistrations().then((registrations) => {
           for (const reg of registrations) {
@@ -315,8 +322,7 @@ if (typeof window === "undefined") {
                 if (
                   newSW.state === "activated" &&
                   !window.SharedArrayBuffer &&
-                  !alreadyRetried &&
-                  !navigator.serviceWorker.controller
+                  !alreadyRetried
                 ) {
                   window.sessionStorage.setItem("coiReloadedBySelf", "reload");
                   window.location.reload();
@@ -336,8 +342,7 @@ if (typeof window === "undefined") {
             if (
               registration.active &&
               !window.SharedArrayBuffer &&
-              !alreadyRetried &&
-              !navigator.serviceWorker.controller
+              !alreadyRetried
             ) {
               window.sessionStorage.setItem("coiReloadedBySelf", "reload");
               window.location.reload();

--- a/client/src/components/DatabaseInstaller.tsx
+++ b/client/src/components/DatabaseInstaller.tsx
@@ -6,6 +6,7 @@
  */
 import { useCallback } from "react";
 import { useLocalDatabase } from "../context/LocalDatabaseContext";
+import type { OfflineDatabaseMissingFeature } from "../context/offlineDatabaseStorage";
 import styles from "./DatabaseInstaller.module.css";
 
 const STEP_LABELS: Record<string, string> = {
@@ -39,6 +40,27 @@ function formatDatabaseVersion(version: string): string {
   return `${day}/${month}/${year}`;
 }
 
+function getUnsupportedMessage(
+  missingFeatures: OfflineDatabaseMissingFeature[],
+): string {
+  if (missingFeatures.includes("secure-context")) {
+    return "A busca local precisa de uma origem segura. Abra o app em http://127.0.0.1:5173/, localhost ou HTTPS para usar esta funcionalidade.";
+  }
+
+  if (missingFeatures.includes("opfs")) {
+    return "Seu navegador não liberou OPFS, o armazenamento local necessário para a busca offline. Use uma versão atual do Edge, Chrome ou outro navegador baseado em Chromium.";
+  }
+
+  if (
+    missingFeatures.includes("shared-array-buffer")
+    || missingFeatures.includes("cross-origin-isolation")
+  ) {
+    return "Seu navegador ainda não liberou SharedArrayBuffer para esta página. Use Edge ou Chrome atualizados e recarregue em uma origem segura.";
+  }
+
+  return "Seu navegador não suporta todos os recursos necessários para busca offline. Use Edge, Chrome ou outro navegador baseado em Chromium atualizado.";
+}
+
 /**
  * Displays the status and management interface for the offline search database.
  *
@@ -57,10 +79,14 @@ export default function DatabaseInstaller() {
     error,
     dbSizeBytes,
     isSupported,
+    supportReport,
     install,
   } = useLocalDatabase();
 
   const progressWidth = progress > 0 ? Math.max(progress, 2) : 0;
+  const missingFeatures = supportReport?.missingFeatures ?? [];
+  const canRecoverWithIsolationReload =
+    supportReport?.canRecoverWithIsolationReload === true;
 
   const handleInstall = useCallback(async () => {
     try {
@@ -70,8 +96,30 @@ export default function DatabaseInstaller() {
     }
   }, [install]);
 
+  // ---------- Recoverable isolation setup ----------
+  if (!isSupported && canRecoverWithIsolationReload) {
+    return (
+      <div className={styles.installerCard}>
+        <div className={styles.cardHeader}>
+          <span className={styles.cardIcon}>⚡</span>
+          <span className={styles.cardTitle}>Busca local</span>
+          <span className={`${styles.statusBadge} ${styles.statusInstalling}`}>
+            🔄 Preparando…
+          </span>
+        </div>
+        <p className={styles.unsupportedInfo}>
+          O navegador parece compatível, mas ainda precisa ativar o isolamento
+          de origem para liberar a busca local. Recarregue a página se ela não
+          atualizar automaticamente.
+        </p>
+      </div>
+    );
+  }
+
   // ---------- Unsupported browser ----------
   if (!isSupported) {
+    const unsupportedMessage = getUnsupportedMessage(missingFeatures);
+
     return (
       <div className={styles.installerCard}>
         <div className={styles.cardHeader}>
@@ -82,9 +130,7 @@ export default function DatabaseInstaller() {
           </span>
         </div>
         <p className={styles.unsupportedInfo}>
-          Seu navegador não suporta os recursos necessários para busca offline
-          (SharedArrayBuffer, OPFS). Use Chrome, Edge, ou outro navegador
-          baseado em Chromium para esta funcionalidade.
+          {unsupportedMessage}
         </p>
       </div>
     );

--- a/client/src/context/LocalDatabaseContext.tsx
+++ b/client/src/context/LocalDatabaseContext.tsx
@@ -22,6 +22,20 @@ const DEFAULT_LOCAL_DATABASE_CONTEXT: OfflineDatabaseContextValue = {
     error: null,
     dbSizeBytes: null,
     isSupported: false,
+    supportReport: {
+        supported: false,
+        missingFeatures: [
+            'secure-context',
+            'cross-origin-isolation',
+            'shared-array-buffer',
+            'worker',
+            'web-crypto',
+            'opfs',
+        ],
+        canRecoverWithIsolationReload: false,
+        isSecureContext: false,
+        crossOriginIsolated: false,
+    },
     isRemoving: false,
     installOfflineDatabase: async () => {
         throw new Error('Offline DB not supported in this browser');

--- a/client/src/context/offlineDatabase.types.ts
+++ b/client/src/context/offlineDatabase.types.ts
@@ -2,6 +2,7 @@ import type {
     NbsCatalogDetailApiResponse,
 } from '../types/api.types';
 import type { OfflineDatabaseMetadata } from '../utils/offlineDatabase';
+import type { OfflineDatabaseSupportReport } from './offlineDatabaseStorage';
 
 export type OfflineDatabaseStatus =
     | 'checking'
@@ -24,6 +25,7 @@ export interface OfflineDatabaseState {
     error: string | null;
     dbSizeBytes: number | null;
     isSupported: boolean;
+    supportReport: OfflineDatabaseSupportReport;
     isRemoving: boolean;
 }
 

--- a/client/src/context/offlineDatabaseRuntime.ts
+++ b/client/src/context/offlineDatabaseRuntime.ts
@@ -14,10 +14,11 @@ import {
 import {
     buildOfflineDatabaseInitPayload,
     createOfflineDatabaseInstanceId,
-    isOfflineDatabaseSupported,
+    getOfflineDatabaseSupportReport,
     persistStoredOfflineDatabaseMetadata,
     readStoredOfflineDatabaseMetadata,
     runOfflineDatabaseTaskInBackground,
+    type OfflineDatabaseSupportReport,
 } from './offlineDatabaseStorage';
 import {
     fetchOfflineDatabaseAvailabilityMetadata,
@@ -43,6 +44,7 @@ export interface OfflineDatabaseRuntimeState {
     error: string | null;
     dbSizeBytes: number | null;
     isSupported: boolean;
+    supportReport: OfflineDatabaseSupportReport;
     isRemoving: boolean;
 }
 
@@ -58,7 +60,8 @@ export interface OfflineDatabaseRuntimeValue {
 }
 
 export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
-    const isSupported = useMemo(() => isOfflineDatabaseSupported(), []);
+    const supportReport = useMemo(() => getOfflineDatabaseSupportReport(), []);
+    const isSupported = supportReport.supported;
     const instanceIdRef = useRef(createOfflineDatabaseInstanceId());
     const remoteCheckRef = useRef<Promise<OfflineDatabaseMetadata | null> | null>(null);
     const remoteMetaRef = useRef<OfflineDatabaseMetadata | null>(
@@ -66,7 +69,9 @@ export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
     );
 
     const [status, setStatus] = useState<OfflineDatabaseStatus>(
-        isSupported ? 'checking' : 'unsupported',
+        isSupported || supportReport.canRecoverWithIsolationReload
+            ? 'checking'
+            : 'unsupported',
     );
     const [progress, setProgress] = useState(0);
     const [progressStep, setProgressStep] = useState('');
@@ -237,6 +242,7 @@ export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
             error,
             dbSizeBytes,
             isSupported,
+            supportReport,
             isRemoving,
         }),
         [
@@ -249,6 +255,7 @@ export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
             progressStep,
             remoteVersion,
             status,
+            supportReport,
             updateAvailable,
         ],
     );

--- a/client/src/context/offlineDatabaseStorage.ts
+++ b/client/src/context/offlineDatabaseStorage.ts
@@ -7,12 +7,73 @@ export const OFFLINE_LOCK_TTL_MS = 180_000;
 
 let fallbackOfflineDatabaseInstanceCounter = 0;
 
+export type OfflineDatabaseMissingFeature =
+    | 'secure-context'
+    | 'cross-origin-isolation'
+    | 'shared-array-buffer'
+    | 'worker'
+    | 'web-crypto'
+    | 'opfs';
+
+export interface OfflineDatabaseSupportReport {
+    supported: boolean;
+    missingFeatures: OfflineDatabaseMissingFeature[];
+    canRecoverWithIsolationReload: boolean;
+    isSecureContext: boolean;
+    crossOriginIsolated: boolean;
+}
+
+function isLocalhostLikeOrigin(): boolean {
+    const hostname = globalThis.location?.hostname;
+    return hostname === 'localhost'
+        || hostname === '127.0.0.1'
+        || hostname === '[::1]';
+}
+
+export function getOfflineDatabaseSupportReport(): OfflineDatabaseSupportReport {
+    const isSecureContext =
+        globalThis.isSecureContext === true
+        || (
+            typeof globalThis.isSecureContext === 'undefined'
+            && (
+                globalThis.location?.protocol === 'https:'
+                || isLocalhostLikeOrigin()
+            )
+        );
+    const crossOriginIsolated = globalThis.crossOriginIsolated === true;
+    const hasSharedArrayBuffer = typeof globalThis.SharedArrayBuffer !== 'undefined';
+    const hasWorker = typeof globalThis.Worker !== 'undefined';
+    const hasWebCrypto = typeof globalThis.crypto?.subtle !== 'undefined';
+    const hasOpfs = typeof globalThis.navigator?.storage?.getDirectory === 'function';
+
+    const missingFeatures: OfflineDatabaseMissingFeature[] = [];
+    if (!isSecureContext) missingFeatures.push('secure-context');
+    if (!crossOriginIsolated) missingFeatures.push('cross-origin-isolation');
+    if (!hasSharedArrayBuffer) missingFeatures.push('shared-array-buffer');
+    if (!hasWorker) missingFeatures.push('worker');
+    if (!hasWebCrypto) missingFeatures.push('web-crypto');
+    if (!hasOpfs) missingFeatures.push('opfs');
+
+    const canRecoverWithIsolationReload =
+        isSecureContext
+        && !crossOriginIsolated
+        && !hasSharedArrayBuffer
+        && hasWorker
+        && hasWebCrypto
+        && hasOpfs
+        && typeof globalThis.navigator?.serviceWorker !== 'undefined';
+
+    return {
+        supported: missingFeatures.length === 0,
+        missingFeatures,
+        canRecoverWithIsolationReload,
+        isSecureContext,
+        crossOriginIsolated,
+    };
+}
+
 export function isOfflineDatabaseSupported(): boolean {
-    if (typeof SharedArrayBuffer === 'undefined') return false;
-    if (typeof Worker === 'undefined') return false;
-    if (typeof crypto?.subtle === 'undefined') return false;
-    if (typeof navigator?.storage?.getDirectory !== 'function') return false;
-    return true;
+    return getOfflineDatabaseSupportReport().supported;
 }
 
 export function readStoredOfflineDatabaseMetadata(): OfflineDatabaseMetadata | null {

--- a/client/src/services/api/httpClient.ts
+++ b/client/src/services/api/httpClient.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { configureApiAuthTransport } from './authTransport';
 
 const explicitBaseUrl = import.meta.env.VITE_API_FILTER_URL || import.meta.env.VITE_API_URL;
+const DEFAULT_PAGES_API_URL = 'https://fiscal-api-5eok.onrender.com';
 
 const isLocalHost = (host: string) => host === 'localhost' || host === '127.0.0.1';
 
@@ -12,11 +13,16 @@ const isExplicitLocalApi =
 
 const shouldUseDevProxyApi = import.meta.env.DEV;
 const hasGlobalLocation = typeof globalThis.location !== 'undefined';
+const isCloudflarePagesHost =
+    hasGlobalLocation && /\.pages\.dev$/i.test(globalThis.location.hostname);
 const shouldUseProxyApi =
     shouldUseDevProxyApi
     || (hasGlobalLocation && isExplicitLocalApi && !isLocalHost(globalThis.location.hostname));
 
-const rawBaseUrl = shouldUseProxyApi ? '/api' : (explicitBaseUrl || '/api');
+const fallbackBaseUrl = isCloudflarePagesHost ? DEFAULT_PAGES_API_URL : '/api';
+const rawBaseUrl = shouldUseProxyApi && !isCloudflarePagesHost
+    ? '/api'
+    : (explicitBaseUrl || fallbackBaseUrl);
 
 function normalizeApiUrl(base: string): string {
     const trimmed = base.replace(/\/$/, '');

--- a/client/src/utils/offlineDatabase.ts
+++ b/client/src/utils/offlineDatabase.ts
@@ -54,6 +54,31 @@ export function formatOfflineDatabaseErrorMessage(
   return fallbackMessage;
 }
 
+export function buildOfflineDatabaseNetworkErrorMessage(
+  url: string,
+  action: "version" | "token" | "download" | "request" = "request"
+): string {
+  let targetOrigin = url;
+  try {
+    targetOrigin = new URL(url, globalThis.location?.href).origin;
+  } catch {
+    // Keep the original value when it is not URL-like.
+  }
+
+  const currentOrigin =
+    typeof globalThis.location !== "undefined"
+      ? globalThis.location.origin
+      : "esta origem";
+  const actionLabel = {
+    version: "consultar a versão do banco offline",
+    token: "solicitar o token do banco offline",
+    download: "baixar o banco offline",
+    request: "acessar o banco offline",
+  }[action];
+
+  return `Não foi possível ${actionLabel} em ${targetOrigin}. Verifique se o backend permite esta origem: ${currentOrigin}.`;
+}
+
 export function sanitizeOfflineMetadata(
   metadata: Partial<OfflineDatabaseMetadata> | null | undefined
 ): OfflineDatabaseMetadata | null {

--- a/client/src/workers/dbWorker/messages.js
+++ b/client/src/workers/dbWorker/messages.js
@@ -14,6 +14,71 @@ import { getStructuredSearchWithCache } from "./searchRuntime.js";
 import { loadDatabaseFromBytes } from "./sqlite.js";
 import { clearSearchCache, closeWorkerDb, getWorkerDb, getWorkerStatus, getWorkerVersion, setWorkerStatus, setWorkerVersion } from "./state.js";
 
+const OFFLINE_FETCH_TIMEOUT_MS = 60_000;
+
+function getCurrentOrigin() {
+  return globalThis.self?.location?.origin || globalThis.location?.origin || "";
+}
+
+function resolveNetworkTarget(url) {
+  try {
+    const resolvedUrl = new URL(url, getCurrentOrigin() || undefined);
+    return {
+      origin: resolvedUrl.origin,
+      path: `${resolvedUrl.pathname}${resolvedUrl.search}`,
+    };
+  } catch {
+    return {
+      origin: String(url),
+      path: "",
+    };
+  }
+}
+
+export function buildOfflineDatabaseNetworkErrorMessage(url, action = "request") {
+  const target = resolveNetworkTarget(url);
+  const targetLabel = `${target.origin}${target.path}`;
+
+  const currentOrigin = getCurrentOrigin() || "esta origem";
+  const actionLabels = {
+    version: "consultar a versão do banco offline",
+    token: "solicitar o token do banco offline",
+    download: "baixar o banco offline",
+    request: "acessar o banco offline",
+  };
+  const actionLabel = actionLabels[action] || actionLabels.request;
+
+  return `Não foi possível ${actionLabel} em ${targetLabel}. Verifique se o backend permite esta origem: ${currentOrigin}.`;
+}
+
+export async function fetchWithTimeout(
+  url,
+  options = {},
+  timeoutMs = OFFLINE_FETCH_TIMEOUT_MS,
+  action = "request"
+) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new Error(buildOfflineDatabaseNetworkErrorMessage(url, action), {
+        cause: error,
+      });
+    }
+    throw new Error(buildOfflineDatabaseNetworkErrorMessage(url, action), {
+      cause: error,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 async function handleInitMessage(id, payload) {
   const encData = await readFromOpfs();
   const version = await readVersion();
@@ -102,10 +167,10 @@ async function readEncryptedDatabaseBlob(dlResp, id) {
 }
 
 async function requestInstallToken(apiBase) {
-  const tokenResp = await fetch(`${apiBase}/database/token`, {
+  const tokenResp = await fetchWithTimeout(`${apiBase}/database/token`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-  });
+  }, OFFLINE_FETCH_TIMEOUT_MS, "token");
 
   if (tokenResp.ok) {
     return tokenResp.json();
@@ -116,11 +181,11 @@ async function requestInstallToken(apiBase) {
 }
 
 async function fetchEncryptedDatabase(apiBase, token) {
-  const dlResp = await fetch(`${apiBase}/database/download`, {
+  const dlResp = await fetchWithTimeout(`${apiBase}/database/download`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ token }),
-  });
+  }, OFFLINE_FETCH_TIMEOUT_MS, "download");
 
   if (dlResp.ok) {
     return dlResp;
@@ -170,7 +235,12 @@ async function updateInstalledVersion(apiBase) {
   let nextVersion = null;
 
   try {
-    const versionResp = await fetch(`${apiBase}/database/version`);
+    const versionResp = await fetchWithTimeout(
+      `${apiBase}/database/version`,
+      {},
+      OFFLINE_FETCH_TIMEOUT_MS,
+      "version"
+    );
     if (versionResp.ok) {
       const versionData = await versionResp.json();
       nextVersion = versionData.version;

--- a/client/src/workers/dbWorker/messages.test.js
+++ b/client/src/workers/dbWorker/messages.test.js
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./crypto.js', () => ({
+  decryptDatabase: vi.fn(),
+  setAppSeed: vi.fn(),
+  sha256Hex: vi.fn(),
+}));
+
+vi.mock('./catalogSearch.js', () => ({
+  getLocalNbsDetail: vi.fn(),
+}));
+
+vi.mock('./opfs.js', () => ({
+  readFromOpfs: vi.fn(),
+  readSeed: vi.fn(),
+  readVersion: vi.fn(),
+  removeFromOpfs: vi.fn(),
+  saveSeed: vi.fn(),
+  saveToOpfs: vi.fn(),
+  saveVersion: vi.fn(),
+}));
+
+vi.mock('./protocol.js', () => ({
+  postWorkerError: vi.fn(),
+  postWorkerProgress: vi.fn(),
+  postWorkerResult: vi.fn(),
+  postWorkerStatus: vi.fn(),
+}));
+
+vi.mock('./searchRuntime.js', () => ({
+  getStructuredSearchWithCache: vi.fn(),
+}));
+
+vi.mock('./sqlite.js', () => ({
+  loadDatabaseFromBytes: vi.fn(),
+}));
+
+vi.mock('./state.js', () => ({
+  clearSearchCache: vi.fn(),
+  closeWorkerDb: vi.fn(),
+  getWorkerDb: vi.fn(),
+  getWorkerStatus: vi.fn(),
+  getWorkerVersion: vi.fn(),
+  setWorkerStatus: vi.fn(),
+  setWorkerVersion: vi.fn(),
+}));
+
+import {
+  buildOfflineDatabaseNetworkErrorMessage,
+  fetchWithTimeout,
+} from './messages.js';
+
+describe('dbWorker messages network helpers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('preserves the caught error as cause when fetch fails', async () => {
+    const originalError = new TypeError('Failed to fetch');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(originalError));
+
+    await expect(
+      fetchWithTimeout(
+        'https://fiscal-api-5eok.onrender.com/api/database/token',
+        {},
+        1000,
+        'token',
+      ),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('Verifique se o backend permite esta origem'),
+      cause: originalError,
+    });
+  });
+
+  it('describes the backend origin and current origin in network messages', () => {
+    expect(
+      buildOfflineDatabaseNetworkErrorMessage(
+        'https://fiscal-api-5eok.onrender.com/api/database/version',
+        'version',
+      ),
+    ).toContain('https://fiscal-api-5eok.onrender.com');
+  });
+
+  it('resolves relative backend URLs against the current origin', () => {
+    vi.stubGlobal('location', {
+      origin: 'https://3fbcaa44.fiscalconsultas.pages.dev',
+    });
+
+    const message = buildOfflineDatabaseNetworkErrorMessage(
+      '/api/database/version',
+      'version',
+    );
+
+    expect(message).toContain('https://3fbcaa44.fiscalconsultas.pages.dev');
+    expect(message).toContain('/api/database/version');
+  });
+});

--- a/client/tests/playwright/offline-install-reopen.spec.ts
+++ b/client/tests/playwright/offline-install-reopen.spec.ts
@@ -1,15 +1,28 @@
 import { expect, test } from '@playwright/test';
 
 import {
+  OFFLINE_METADATA,
   expectOfflineMetadataPersisted,
   expectOfflineReadyInSettings,
   installOfflineApiMock,
   installOfflineFromSettings,
   installOfflineWorkerMock,
+  openSettings,
   type OfflineApiCounters,
 } from './helpers/offlineHarness';
 
 test.describe('offline install and reopen flow', () => {
+  test('serves the preview app with cross-origin isolation for local search', async ({ page }) => {
+    await installOfflineWorkerMock(page);
+
+    await page.goto('/');
+
+    await expect(page.getByRole('heading', { name: 'FiscalConsultas' })).toBeVisible();
+    await expect.poll(() => page.evaluate(() => globalThis.crossOriginIsolated)).toBe(true);
+    await openSettings(page);
+    await expect(page.getByText(/Indisponível/)).not.toBeVisible();
+  });
+
   test('installs offline database using version/token/download endpoints', async ({ page }) => {
     const counters: OfflineApiCounters = {
       version: 0,
@@ -31,6 +44,98 @@ test.describe('offline install and reopen flow', () => {
 
     await page.keyboard.press('Escape');
     await expectOfflineMetadataPersisted(page);
+  });
+
+  test('shows an actionable error when backend CORS blocks offline install', async ({ page }) => {
+    await page.addInitScript(() => {
+      type WorkerMessage = {
+        type: string;
+        id: string | null;
+        payload: Record<string, unknown>;
+      };
+
+      function emitToWorker(
+        worker: {
+          onmessage: ((event: MessageEvent<WorkerMessage>) => void) | null;
+          listeners: Set<(event: MessageEvent<WorkerMessage>) => void>;
+        },
+        message: WorkerMessage,
+      ) {
+        const event = { data: message } as MessageEvent<WorkerMessage>;
+        worker.onmessage?.(event);
+        worker.listeners.forEach((listener) => listener(event));
+      }
+
+      class FailingOfflineWorker {
+        public onmessage: ((event: MessageEvent<WorkerMessage>) => void) | null = null;
+
+        public listeners = new Set<(event: MessageEvent<WorkerMessage>) => void>();
+
+        constructor() {
+          queueMicrotask(() => {
+            emitToWorker(this, { type: 'READY', id: null, payload: {} });
+          });
+        }
+
+        addEventListener(type: string, listener: (event: MessageEvent<WorkerMessage>) => void) {
+          if (type === 'message') this.listeners.add(listener);
+        }
+
+        removeEventListener(type: string, listener: (event: MessageEvent<WorkerMessage>) => void) {
+          if (type === 'message') this.listeners.delete(listener);
+        }
+
+        terminate() {
+          this.listeners.clear();
+        }
+
+        postMessage(message: WorkerMessage) {
+          if (message.type === 'INIT') {
+            emitToWorker(this, {
+              type: 'STATUS',
+              id: message.id,
+              payload: { status: 'not_installed' },
+            });
+            return;
+          }
+
+          if (message.type === 'INSTALL') {
+            const error = 'Não foi possível solicitar o token do banco offline em https://fiscal-api-5eok.onrender.com. Verifique se o backend permite esta origem: https://3fbcaa44.fiscalconsultas.pages.dev. Reinstale o banco offline para continuar.';
+            emitToWorker(this, {
+              type: 'STATUS',
+              id: message.id,
+              payload: { status: 'error', error },
+            });
+            emitToWorker(this, {
+              type: 'ERROR',
+              id: message.id,
+              payload: { error },
+            });
+          }
+        }
+      }
+
+      Object.defineProperty(globalThis, 'Worker', {
+        configurable: true,
+        writable: true,
+        value: FailingOfflineWorker,
+      });
+    });
+
+    await page.context().route('**/api/database/version', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(OFFLINE_METADATA),
+      });
+    });
+
+    await page.goto('/');
+    await openSettings(page);
+    await page.locator('#db-installer-install').click();
+
+    await expect(page.getByText(/Verifique se o backend permite esta origem/i)).toBeVisible();
+    await expect(page.getByText(/Solicitando token/i)).not.toBeVisible();
   });
 
   test('reopens with offline DB ready when backend API is unavailable', async ({ page, context }) => {

--- a/client/tests/unit/DatabaseInstaller.test.tsx
+++ b/client/tests/unit/DatabaseInstaller.test.tsx
@@ -16,6 +16,13 @@ const localDatabaseState = {
   error: null,
   dbSizeBytes: null,
   isSupported: true,
+  supportReport: {
+    supported: true,
+    missingFeatures: [],
+    canRecoverWithIsolationReload: false,
+    isSecureContext: true,
+    crossOriginIsolated: true,
+  },
   isRemoving: false,
   install: installMock,
   remove: removeMock,
@@ -41,18 +48,80 @@ describe('DatabaseInstaller', () => {
       error: null,
       dbSizeBytes: null,
       isSupported: true,
+      supportReport: {
+        supported: true,
+        missingFeatures: [],
+        canRecoverWithIsolationReload: false,
+        isSecureContext: true,
+        crossOriginIsolated: true,
+      },
       isRemoving: false,
     });
   });
 
   it('renders the unsupported browser message', () => {
     localDatabaseState.isSupported = false;
+    localDatabaseState.supportReport = {
+      supported: false,
+      missingFeatures: ['worker'],
+      canRecoverWithIsolationReload: false,
+      isSecureContext: true,
+      crossOriginIsolated: true,
+    };
 
     render(<DatabaseInstaller />);
 
     expect(screen.getByText('Busca local')).toBeInTheDocument();
-    expect(screen.getByText(/Seu navegador não suporta os recursos necessários/i)).toBeInTheDocument();
+    expect(screen.getByText(/Seu navegador não suporta todos os recursos/i)).toBeInTheDocument();
     expect(screen.getByText(/Indisponível/)).toBeInTheDocument();
+  });
+
+  it('renders a recoverable isolation message before marking Edge as incompatible', () => {
+    localDatabaseState.isSupported = false;
+    localDatabaseState.supportReport = {
+      supported: false,
+      missingFeatures: ['cross-origin-isolation', 'shared-array-buffer'],
+      canRecoverWithIsolationReload: true,
+      isSecureContext: true,
+      crossOriginIsolated: false,
+    };
+
+    render(<DatabaseInstaller />);
+
+    expect(screen.getByText(/Preparando/)).toBeInTheDocument();
+    expect(screen.getByText(/precisa ativar o isolamento de origem/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Indisponível/)).not.toBeInTheDocument();
+  });
+
+  it('renders an insecure-origin message when the page is not in a secure context', () => {
+    localDatabaseState.isSupported = false;
+    localDatabaseState.supportReport = {
+      supported: false,
+      missingFeatures: ['secure-context', 'shared-array-buffer'],
+      canRecoverWithIsolationReload: false,
+      isSecureContext: false,
+      crossOriginIsolated: false,
+    };
+
+    render(<DatabaseInstaller />);
+
+    expect(screen.getByText(/precisa de uma origem segura/i)).toBeInTheDocument();
+    expect(screen.getByText(/127\.0\.0\.1:5173/i)).toBeInTheDocument();
+  });
+
+  it('renders an OPFS-specific message when browser storage is unavailable', () => {
+    localDatabaseState.isSupported = false;
+    localDatabaseState.supportReport = {
+      supported: false,
+      missingFeatures: ['opfs'],
+      canRecoverWithIsolationReload: false,
+      isSecureContext: true,
+      crossOriginIsolated: true,
+    };
+
+    render(<DatabaseInstaller />);
+
+    expect(screen.getByText(/não liberou OPFS/i)).toBeInTheDocument();
   });
 
   it('renders the checking state', () => {

--- a/client/tests/unit/LocalDatabaseContext.autoinstall.test.tsx
+++ b/client/tests/unit/LocalDatabaseContext.autoinstall.test.tsx
@@ -60,7 +60,11 @@ class MockWorker {
     });
   }
 
-  terminate(): void {}
+  terminate(): void {
+    this.onmessage = null;
+    this.onerror = null;
+    this.messageListeners.clear();
+  }
 
   private respond(message: WorkerPayload): void {
     if (message.type === 'INIT') {
@@ -170,6 +174,8 @@ describe('LocalDatabaseContext auto-install behavior', () => {
     vi.stubGlobal('Worker', MockWorker as unknown as typeof Worker);
     vi.stubGlobal('BroadcastChannel', undefined);
     vi.stubGlobal('SharedArrayBuffer', class SharedArrayBufferMock {});
+    vi.stubGlobal('isSecureContext', true);
+    vi.stubGlobal('crossOriginIsolated', true);
     vi.stubGlobal(
       'fetch',
       vi.fn().mockImplementation(() => Promise.resolve(makeVersionResponse('2026.04'))),

--- a/client/tests/unit/api.service.test.ts
+++ b/client/tests/unit/api.service.test.ts
@@ -175,6 +175,22 @@ describe('api service', () => {
     }
   });
 
+  it('falls back to the public backend on Cloudflare Pages when API env is missing', async () => {
+    const restoreLocation = swapLocation('https://1d6c99f0.fiscalconsultas.pages.dev/');
+
+    try {
+      await loadApiModule();
+
+      expect(mockAxios.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://fiscal-api-5eok.onrender.com/api',
+        }),
+      );
+    } finally {
+      restoreLocation();
+    }
+  });
+
   it('injects auth token for protected routes and skips public routes', async () => {
     const apiModule = await loadApiModule();
     const getter = vi.fn().mockResolvedValue('jwt-token');

--- a/client/tests/unit/offlineDatabase.test.ts
+++ b/client/tests/unit/offlineDatabase.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildOfflineDatabaseNetworkErrorMessage,
   compareOfflineVersions,
   formatOfflineDatabaseErrorMessage,
   sanitizeOfflineMetadata,
@@ -69,5 +70,20 @@ describe('offlineDatabase utils', () => {
     expect(formatOfflineDatabaseErrorMessage(new Error('  boom  '))).toBe('boom');
     expect(formatOfflineDatabaseErrorMessage({ message: '  boom  ' })).toBe('boom');
     expect(formatOfflineDatabaseErrorMessage({ message: '   ' })).toBe('Unknown error');
+  });
+
+  it('builds actionable network messages for Cloudflare Pages backend failures', () => {
+    expect(
+      buildOfflineDatabaseNetworkErrorMessage(
+        'https://fiscal-api-5eok.onrender.com/api/database/token',
+        'token',
+      ),
+    ).toContain('Verifique se o backend permite esta origem:');
+    expect(
+      buildOfflineDatabaseNetworkErrorMessage(
+        'https://fiscal-api-5eok.onrender.com/api/database/token',
+        'token',
+      ),
+    ).toContain('https://fiscal-api-5eok.onrender.com');
   });
 });

--- a/client/tests/unit/offlineDatabaseStorage.test.ts
+++ b/client/tests/unit/offlineDatabaseStorage.test.ts
@@ -3,13 +3,82 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildOfflineDatabaseInitPayload,
   clearOfflineDatabaseInstallLock,
+  getOfflineDatabaseSupportReport,
   getOfflineDatabaseInstallLock,
+  isOfflineDatabaseSupported,
   OFFLINE_LOCK_KEY,
   OFFLINE_META_KEY,
   persistStoredOfflineDatabaseMetadata,
   readStoredOfflineDatabaseMetadata,
   setOfflineDatabaseInstallLock,
 } from '../../src/context/offlineDatabaseStorage';
+
+const originalNavigatorStorageDescriptor = Object.getOwnPropertyDescriptor(
+  navigator,
+  'storage',
+);
+const originalNavigatorServiceWorkerDescriptor = Object.getOwnPropertyDescriptor(
+  navigator,
+  'serviceWorker',
+);
+
+type OfflineSupportStubOptions = {
+  sharedArrayBuffer?: boolean;
+  worker?: boolean;
+  webCrypto?: boolean;
+  opfs?: boolean;
+  serviceWorker?: boolean;
+  secureContext?: boolean;
+  isolated?: boolean;
+};
+
+function restoreNavigatorProperty(
+  property: 'storage' | 'serviceWorker',
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(navigator, property, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(navigator, property);
+}
+
+function stubOfflineSupport({
+  sharedArrayBuffer = true,
+  worker = true,
+  webCrypto = true,
+  opfs = true,
+  serviceWorker = true,
+  secureContext = true,
+  isolated = true,
+}: OfflineSupportStubOptions = {}) {
+  vi.stubGlobal('isSecureContext', secureContext);
+  vi.stubGlobal('crossOriginIsolated', isolated);
+
+  if (sharedArrayBuffer) {
+    vi.stubGlobal('SharedArrayBuffer', class SharedArrayBufferMock {});
+  } else {
+    vi.stubGlobal('SharedArrayBuffer', undefined);
+  }
+
+  if (worker) {
+    vi.stubGlobal('Worker', class WorkerMock {});
+  } else {
+    vi.stubGlobal('Worker', undefined);
+  }
+
+  vi.stubGlobal('crypto', webCrypto ? { subtle: {} } : {});
+
+  Object.defineProperty(navigator, 'storage', {
+    configurable: true,
+    value: opfs ? { getDirectory: vi.fn() } : {},
+  });
+  Object.defineProperty(navigator, 'serviceWorker', {
+    configurable: true,
+    value: serviceWorker ? {} : undefined,
+  });
+}
 
 describe('offlineDatabaseStorage', () => {
   beforeEach(() => {
@@ -18,6 +87,12 @@ describe('offlineDatabaseStorage', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
+    restoreNavigatorProperty('storage', originalNavigatorStorageDescriptor);
+    restoreNavigatorProperty(
+      'serviceWorker',
+      originalNavigatorServiceWorkerDescriptor,
+    );
   });
 
   it('persists and reads sanitized offline metadata', () => {
@@ -91,5 +166,73 @@ describe('offlineDatabaseStorage', () => {
       chunkSize: 4096,
       pbkdf2Iterations: 750000,
     });
+  });
+
+  it('reports Edge or Chromium with required browser primitives as supported', () => {
+    stubOfflineSupport();
+
+    expect(isOfflineDatabaseSupported()).toBe(true);
+    expect(getOfflineDatabaseSupportReport()).toEqual({
+      supported: true,
+      missingFeatures: [],
+      canRecoverWithIsolationReload: false,
+      isSecureContext: true,
+      crossOriginIsolated: true,
+    });
+  });
+
+  it('treats missing SharedArrayBuffer in a secure service-worker origin as recoverable', () => {
+    stubOfflineSupport({
+      sharedArrayBuffer: false,
+      isolated: false,
+    });
+
+    expect(isOfflineDatabaseSupported()).toBe(false);
+    expect(getOfflineDatabaseSupportReport()).toEqual({
+      supported: false,
+      missingFeatures: ['cross-origin-isolation', 'shared-array-buffer'],
+      canRecoverWithIsolationReload: true,
+      isSecureContext: true,
+      crossOriginIsolated: false,
+    });
+  });
+
+  it('does not treat a SharedArrayBuffer failure as recoverable when already isolated', () => {
+    stubOfflineSupport({
+      sharedArrayBuffer: false,
+      isolated: true,
+    });
+
+    expect(getOfflineDatabaseSupportReport()).toMatchObject({
+      supported: false,
+      canRecoverWithIsolationReload: false,
+      crossOriginIsolated: true,
+    });
+  });
+
+  it('reports insecure origins as a non-recoverable missing feature', () => {
+    stubOfflineSupport({
+      sharedArrayBuffer: false,
+      secureContext: false,
+      isolated: false,
+    });
+
+    expect(getOfflineDatabaseSupportReport()).toMatchObject({
+      supported: false,
+      canRecoverWithIsolationReload: false,
+      isSecureContext: false,
+      crossOriginIsolated: false,
+    });
+    expect(getOfflineDatabaseSupportReport().missingFeatures).toContain('secure-context');
+  });
+
+  it('reports missing OPFS as a non-recoverable missing feature', () => {
+    stubOfflineSupport({ opfs: false });
+
+    expect(getOfflineDatabaseSupportReport()).toMatchObject({
+      supported: false,
+      canRecoverWithIsolationReload: false,
+    });
+    expect(getOfflineDatabaseSupportReport().missingFeatures).toContain('opfs');
   });
 });

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -6,6 +6,11 @@ const clerkMockPath = fileURLToPath(
   new URL('./tests/playwright/mocks/clerk.tsx', import.meta.url)
 );
 
+const crossOriginIsolationHeaders = {
+  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Embedder-Policy': 'require-corp',
+};
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
@@ -33,10 +38,7 @@ export default defineConfig(({ mode }) => {
         : {},
     },
     server: {
-      headers: {
-        'Cross-Origin-Opener-Policy': 'same-origin',
-        'Cross-Origin-Embedder-Policy': 'require-corp',
-      },
+      headers: crossOriginIsolationHeaders,
       proxy: {
         '/api': {
           target: proxyTarget, // NOSONAR: dev proxy target comes from local env or local backend
@@ -46,6 +48,7 @@ export default defineConfig(({ mode }) => {
     },
     preview: {
       allowedHosts: ['offline-e2e.local'],
+      headers: crossOriginIsolationHeaders,
     },
     optimizeDeps: {
       exclude: ['@sqlite.org/sqlite-wasm'],

--- a/tests/unit/test_app_lifespan_additional.py
+++ b/tests/unit/test_app_lifespan_additional.py
@@ -1,5 +1,6 @@
 import asyncio
 import builtins
+import re
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import cast
@@ -566,6 +567,30 @@ def test_build_cors_configuration_fails_closed_in_production(monkeypatch):
 
     assert origins == []
     assert cors_regex is None
+
+
+def test_build_cors_configuration_accepts_cloudflare_pages_previews(monkeypatch):
+    monkeypatch.setattr(app_module.settings.server, "env", "production", raising=False)
+    monkeypatch.setattr(
+        app_module.settings.server,
+        "cors_allowed_origins",
+        ["https://fiscalconsultas.pages.dev"],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        app_module.settings.server,
+        "cors_allowed_origin_regex",
+        r"^https://[a-z0-9-]+\.fiscalconsultas\.pages\.dev$",
+        raising=False,
+    )
+
+    origins, cors_regex = app_module._build_cors_configuration()
+
+    assert origins == ["https://fiscalconsultas.pages.dev"]
+    assert cors_regex is not None
+    compiled = re.compile(cors_regex)
+    assert compiled.fullmatch("https://3fbcaa44.fiscalconsultas.pages.dev")
+    assert not compiled.fullmatch("https://attacker.example.com")
 
 
 def test_log_runtime_security_warnings_for_production_misconfiguration(monkeypatch):


### PR DESCRIPTION
## Summary
- Adds structured browser support diagnostics for the offline local search database.
- Avoids marking Edge/Chromium as unsupported while origin isolation can still recover SharedArrayBuffer.
- Adds COOP/COEP headers to Vite preview and improves installer messages for isolation, insecure origin, OPFS, and true unsupported cases.

## Root Cause
The local search installer treated the absence of `SharedArrayBuffer` as a permanent browser incompatibility. In Edge/Chromium this can happen while the page is not yet cross-origin isolated, especially around the COI service worker and local dev/preview headers.

## Validation
- `npm test -- offlineDatabaseStorage.test.ts DatabaseInstaller.test.tsx LocalDatabaseContext.autoinstall.test.tsx`
- `npm run type-check`
- `npm run test:e2e -- offline-install-reopen.spec.ts`
- `npm run test:e2e:live -- offline-reopen.sw.live.spec.ts`

Note: running the mocked and live Playwright commands simultaneously caused a temporary port `4173` conflict; rerunning the mocked E2E alone passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detailed offline-support diagnostics and user-facing messages for missing features
  * Automated recovery flow for cross-origin isolation with inline “Preparando…” guidance
  * Better network error messages and timeouts for offline installation failures
  * Cloudflare Pages fallback for API base URL

* **Bug Fixes**
  * Improved offline/service-worker behavior for cross-origin fetch failure cases

* **Tests**
  * Expanded unit and end-to-end tests covering offline support, network failures, and Cloudflare Pages scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->