### PR TITLE
[codex] Harden local search install flow

### DIFF
--- a/backend/presentation/routes/database_download.py
+++ b/backend/presentation/routes/database_download.py
@@ -9,6 +9,9 @@ Provides:
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
 import json
 import logging
 import os
@@ -57,9 +60,10 @@ _TOKEN_LIMIT_PER_HOUR = 3
 # ---------------------------------------------------------------------------
 _TOKEN_TTL_SECONDS = 300  # 5 minutes
 _REDIS_TOKEN_PREFIX = "dbtoken:"
+_SIGNED_TOKEN_PREFIX = "v1"
 
 # In-memory token store (fallback when Redis unavailable)
-_memory_tokens: dict[str, tuple[float, str]] = {}  # jti -> (created_at, client_ip)
+_memory_tokens: dict[str, float] = {}  # jti -> created_at
 _MEMORY_TOKEN_MAX = 100
 _OFFLINE_UNAVAILABLE_DETAIL = "Offline database not available"
 
@@ -98,6 +102,76 @@ def _load_metadata() -> dict | None:
 
 def _generate_token_jti() -> str:
     return secrets.token_urlsafe(32)
+
+
+def _b64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _get_signed_token_secret(meta: dict) -> str:
+    secret = (
+        os.environ.get("OFFLINE_DB_TOKEN_SECRET")
+        or settings.auth.secret_key
+        or _require_app_seed(meta)
+    )
+    return secret.strip()
+
+
+def _build_signed_token_payload(issued_at: int, nonce: str, bundle_hash: str) -> str:
+    return f"{_SIGNED_TOKEN_PREFIX}.{issued_at}.{nonce}.{bundle_hash}"
+
+
+def _sign_download_token_payload(payload: str, secret: str) -> str:
+    signature = hmac.new(
+        secret.encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    return _b64url_encode(signature)
+
+
+def _generate_signed_download_token(meta: dict) -> str:
+    bundle_hash = str(meta.get("encrypted_sha256") or meta.get("sha256") or "")
+    issued_at = int(time.time())
+    nonce = secrets.token_urlsafe(24)
+    payload = _build_signed_token_payload(issued_at, nonce, bundle_hash)
+    signature = _sign_download_token_payload(payload, _get_signed_token_secret(meta))
+    return f"{payload}.{signature}"
+
+
+def _is_valid_signed_download_token(token: str) -> bool:
+    parts = token.split(".")
+    if len(parts) != 5 or parts[0] != _SIGNED_TOKEN_PREFIX:
+        return False
+
+    _, issued_at_raw, nonce, bundle_hash, supplied_signature = parts
+    if not nonce or not bundle_hash or not supplied_signature:
+        return False
+
+    try:
+        issued_at = int(issued_at_raw)
+    except ValueError:
+        return False
+
+    now = int(time.time())
+    if issued_at > now + 30 or now - issued_at > _TOKEN_TTL_SECONDS:
+        return False
+
+    meta = _load_metadata()
+    if meta is None:
+        return False
+
+    expected_bundle_hash = str(meta.get("encrypted_sha256") or meta.get("sha256") or "")
+    if not expected_bundle_hash or not secrets.compare_digest(
+        bundle_hash, expected_bundle_hash
+    ):
+        return False
+
+    payload = _build_signed_token_payload(issued_at, nonce, bundle_hash)
+    expected_signature = _sign_download_token_payload(
+        payload, _get_signed_token_secret(meta)
+    )
+    return hmac.compare_digest(supplied_signature, expected_signature)
 
 
 def _is_local_request(request: Request) -> bool:
@@ -157,55 +231,52 @@ def _require_app_seed(meta: dict) -> str:
     raise HTTPException(status_code=503, detail=_OFFLINE_UNAVAILABLE_DETAIL)
 
 
-async def _store_token(jti: str, client_ip: str) -> None:
-    """Store a one-time token bound to the requester's IP."""
+async def _store_token(jti: str, meta: dict, *, allow_memory_fallback: bool) -> str:
+    """Store a short-lived one-time token."""
     if redis_cache.available:
         key = f"{_REDIS_TOKEN_PREFIX}{jti}"
-        if await redis_cache.set_with_ttl(
-            key, client_ip, ttl_seconds=_TOKEN_TTL_SECONDS
-        ):
-            return
+        if await redis_cache.set_with_ttl(key, "1", ttl_seconds=_TOKEN_TTL_SECONDS):
+            return jti
+
+    if not allow_memory_fallback:
+        return _generate_signed_download_token(meta)
 
     # Memory fallback
     now = time.monotonic()
     # Cleanup expired tokens
     expired = [
         k
-        for k, (created, _) in _memory_tokens.items()
-        if now - created > _TOKEN_TTL_SECONDS
+        for k, created_at in _memory_tokens.items()
+        if now - created_at > _TOKEN_TTL_SECONDS
     ]
     for k in expired:
         del _memory_tokens[k]
     # Evict oldest if full
     if len(_memory_tokens) >= _MEMORY_TOKEN_MAX:
-        oldest_key = min(_memory_tokens, key=lambda k: _memory_tokens[k][0])
+        oldest_key = min(_memory_tokens, key=lambda k: _memory_tokens[k])
         del _memory_tokens[oldest_key]
 
-    _memory_tokens[jti] = (now, client_ip)
+    _memory_tokens[jti] = now
+    return jti
 
 
-async def _consume_token(jti: str, client_ip: str) -> bool:
+async def _consume_token(jti: str) -> bool:
     """Verify and consume a one-time token. Returns True if valid."""
+    if _is_valid_signed_download_token(jti):
+        return True
+
     if redis_cache.available:
         key = f"{_REDIS_TOKEN_PREFIX}{jti}"
-        stored_ip = await redis_cache.consume_once(key)
-        if stored_ip is None:
-            return False
-        if isinstance(stored_ip, bytes):
-            stored_ip = stored_ip.decode("utf-8", errors="ignore")
-        return str(stored_ip) == client_ip
+        return await redis_cache.consume_once(key) is not None
 
     # Memory fallback
     now = time.monotonic()
-    entry = _memory_tokens.get(jti)
-    if entry is None:
+    created_at = _memory_tokens.get(jti)
+    if created_at is None:
         return False
-    created_at, stored_ip = entry
     if now - created_at > _TOKEN_TTL_SECONDS:
         _memory_tokens.pop(jti, None)
         return False  # Expired
-    if stored_ip != client_ip:
-        return False
     _memory_tokens.pop(jti, None)
     return True
 
@@ -271,10 +342,12 @@ async def create_download_token(request: Request):
 
     app_seed = _require_app_seed(meta)
     jti = _generate_token_jti()
-    await _store_token(jti, client_ip)
+    token = await _store_token(
+        jti, meta, allow_memory_fallback=_is_local_request(request)
+    )
 
     return {
-        "token": jti,
+        "token": token,
         "app_seed": app_seed,
         "version": meta.get("version"),
         "sha256": meta.get("sha256"),
@@ -302,7 +375,7 @@ async def download_database(
     if not token:
         raise HTTPException(status_code=400, detail="Invalid token format")
 
-    is_valid = await _consume_token(token, extract_client_ip(request))
+    is_valid = await _consume_token(token)
     if not is_valid:
         raise HTTPException(
             status_code=403,

--- a/client/src/components/DatabaseInstaller.tsx
+++ b/client/src/components/DatabaseInstaller.tsx
@@ -55,7 +55,7 @@ function getUnsupportedMessage(
     missingFeatures.includes("shared-array-buffer")
     || missingFeatures.includes("cross-origin-isolation")
   ) {
-    return "Seu navegador ainda não liberou SharedArrayBuffer para esta página. Use Edge ou Chrome atualizados e recarregue em uma origem segura.";
+    return "Seu navegador ainda não liberou SharedArrayBuffer para esta página. Aguarde alguns segundos e recarregue; se persistir, use Edge ou Chrome atualizados em HTTPS.";
   }
 
   return "Seu navegador não suporta todos os recursos necessários para busca offline. Use Edge, Chrome ou outro navegador baseado em Chromium atualizado.";
@@ -109,8 +109,8 @@ export default function DatabaseInstaller() {
         </div>
         <p className={styles.unsupportedInfo}>
           O navegador parece compatível, mas ainda precisa ativar o isolamento
-          de origem para liberar a busca local. Recarregue a página se ela não
-          atualizar automaticamente.
+          de origem para liberar a busca local. Aguarde alguns segundos e
+          recarregue esta página se ela não atualizar automaticamente.
         </p>
       </div>
     );
@@ -279,9 +279,10 @@ export default function DatabaseInstaller() {
       </div>
 
       <p className={styles.cardDescription}>
-        Instale o banco de dados localmente para buscar NBS, TIPI e NESH
-        instantaneamente, sem depender de conexão de internet. A preparação é
-        feita uma única vez{dbSizeBytes ? ` (~${formatBytes(dbSizeBytes)})` : " (~24 MB)"}.
+        A busca local é instalada automaticamente na primeira visita para manter
+        NBS, TIPI e NESH rápidos e disponíveis neste computador. Se você removeu
+        a base local, pode reinstalar quando quiser
+        {dbSizeBytes ? ` (~${formatBytes(dbSizeBytes)})` : " (~24 MB)"}.
       </p>
 
       <div className={styles.actions}>
@@ -291,7 +292,7 @@ export default function DatabaseInstaller() {
           onClick={handleInstall}
           id="db-installer-install"
         >
-          ⚡ Instalar Busca Instantânea
+          ⚡ Instalar agora
         </button>
       </div>
     </div>

--- a/client/src/context/offlineDatabaseController.ts
+++ b/client/src/context/offlineDatabaseController.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from 'react';
 
 import { useOfflineDatabaseOperations } from './offlineDatabaseOperations';
 import { useOfflineDatabaseRuntime } from './offlineDatabaseRuntime';
+import { hasOfflineDatabaseAutoInstallOptOut } from './offlineDatabaseStorage';
 import type { OfflineDatabaseContextValue } from './offlineDatabase.types';
 
 export function useOfflineDatabaseController(): OfflineDatabaseContextValue {
@@ -13,6 +14,20 @@ export function useOfflineDatabaseController(): OfflineDatabaseContextValue {
         fetchOfflineNeshChapterNotes,
         fetchOfflineNbsCatalogDetail,
     } = useOfflineDatabaseOperations(actions);
+
+    useEffect(() => {
+        if (!state.isSupported || state.status !== 'not_installed') {
+            return;
+        }
+
+        if (hasOfflineDatabaseAutoInstallOptOut()) {
+            return;
+        }
+
+        void installOfflineDatabase().catch(() => {
+            // Install lifecycle errors are already captured in shared state.
+        });
+    }, [installOfflineDatabase, state.isSupported, state.status]);
 
     useEffect(() => {
         if (!state.isSupported || state.status !== 'ready' || !state.updateAvailable) {

--- a/client/src/context/offlineDatabaseInstallCoordinator.ts
+++ b/client/src/context/offlineDatabaseInstallCoordinator.ts
@@ -1,0 +1,193 @@
+import {
+    claimOfflineDatabaseInstallLease,
+    OFFLINE_LEASE_HEARTBEAT_MS,
+    OFFLINE_LOCK_KEY,
+    readOfflineDatabaseInstallLease,
+    refreshOfflineDatabaseInstallLease,
+    releaseOfflineDatabaseInstallLease,
+} from './offlineDatabaseStorage';
+
+const WEB_LOCK_NAME = 'offline-db-install';
+const FALLBACK_RECHECK_MS = 2_000;
+
+export interface CoordinatedOfflineDatabaseInstallArgs {
+    owner: string;
+    runInstall: () => Promise<void>;
+    waitForPeerInstall: () => Promise<void>;
+    onWaitingForPeer: () => void;
+}
+
+type WebLockManager = {
+    request: (
+        name: string,
+        options: { ifAvailable: true; mode: 'exclusive' },
+        callback: (lock: unknown | null) => Promise<boolean>,
+    ) => Promise<boolean>;
+};
+
+function getWebLockManager(): WebLockManager | null {
+    const candidate = (globalThis.navigator as Navigator & {
+        locks?: WebLockManager;
+    }).locks;
+    return typeof candidate?.request === 'function' ? candidate : null;
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+function isLeaseRetriable(owner: string): boolean {
+    const lease = readOfflineDatabaseInstallLease();
+    return !lease || lease.owner === owner || lease.expiresAt <= Date.now();
+}
+
+async function waitUntilLeaseCanBeRetried(owner: string): Promise<void> {
+    while (!isLeaseRetriable(owner)) {
+        const lease = readOfflineDatabaseInstallLease();
+        const delay = lease
+            ? Math.min(FALLBACK_RECHECK_MS, Math.max(0, lease.expiresAt - Date.now()))
+            : FALLBACK_RECHECK_MS;
+        await sleep(delay);
+    }
+}
+
+interface LeaseStorageChangeWaiter {
+    promise: Promise<void>;
+    cancel: () => void;
+}
+
+function waitForLeaseStorageChange(owner: string): LeaseStorageChangeWaiter {
+    if (typeof window === 'undefined') {
+        return {
+            promise: new Promise(() => undefined),
+            cancel: () => undefined,
+        };
+    }
+
+    let onStorage: ((event: StorageEvent) => void) | null = null;
+    const promise = new Promise<void>((resolve) => {
+        onStorage = (event: StorageEvent) => {
+            if (event.key !== OFFLINE_LOCK_KEY || !isLeaseRetriable(owner)) {
+                return;
+            }
+            if (onStorage) {
+                window.removeEventListener('storage', onStorage);
+                onStorage = null;
+            }
+            resolve();
+        };
+        window.addEventListener('storage', onStorage);
+    });
+
+    return {
+        promise,
+        cancel: () => {
+            if (!onStorage) return;
+            window.removeEventListener('storage', onStorage);
+            onStorage = null;
+        },
+    };
+}
+
+async function waitForPeerOrRetriableLease(
+    owner: string,
+    waitForPeerInstall: () => Promise<void>,
+): Promise<'peer-installed' | 'lease-retry'> {
+    const peerResult = waitForPeerInstall().then(
+        () => 'peer-installed' as const,
+        () => 'peer-failed' as const,
+    );
+    const storageWaiter = waitForLeaseStorageChange(owner);
+    const leaseResult = Promise.race([
+        waitUntilLeaseCanBeRetried(owner),
+        storageWaiter.promise,
+    ]).then(() => 'lease-retry' as const);
+
+    try {
+        const result = await Promise.race([peerResult, leaseResult]);
+        if (result === 'peer-installed') return result;
+        if (result === 'lease-retry') return result;
+
+        await leaseResult;
+        return 'lease-retry';
+    } finally {
+        storageWaiter.cancel();
+    }
+}
+
+async function runWithFallbackLease({
+    owner,
+    runInstall,
+    waitForPeerInstall,
+    onWaitingForPeer,
+}: CoordinatedOfflineDatabaseInstallArgs): Promise<void> {
+    while (true) {
+        const claim = claimOfflineDatabaseInstallLease(owner);
+        if (!claim.acquired) {
+            onWaitingForPeer();
+            const result = await waitForPeerOrRetriableLease(
+                owner,
+                waitForPeerInstall,
+            );
+            if (result === 'peer-installed') return;
+            continue;
+        }
+
+        const heartbeat = setInterval(() => {
+            refreshOfflineDatabaseInstallLease(owner);
+        }, OFFLINE_LEASE_HEARTBEAT_MS);
+
+        try {
+            await runInstall();
+            return;
+        } finally {
+            clearInterval(heartbeat);
+            releaseOfflineDatabaseInstallLease(owner);
+        }
+    }
+}
+
+async function runWithWebLock(
+    args: CoordinatedOfflineDatabaseInstallArgs,
+    locks: WebLockManager,
+): Promise<void> {
+    while (true) {
+        const didInstall = await locks.request(
+            WEB_LOCK_NAME,
+            { ifAvailable: true, mode: 'exclusive' },
+            async (lock) => {
+                if (!lock) return false;
+                await runWithFallbackLease(args);
+                return true;
+            },
+        );
+
+        if (didInstall) return;
+
+        args.onWaitingForPeer();
+        if (!readOfflineDatabaseInstallLease()) {
+            await sleep(FALLBACK_RECHECK_MS);
+            continue;
+        }
+
+        const result = await waitForPeerOrRetriableLease(
+            args.owner,
+            args.waitForPeerInstall,
+        );
+        if (result === 'peer-installed') return;
+    }
+}
+
+export async function runCoordinatedOfflineDatabaseInstall(
+    args: CoordinatedOfflineDatabaseInstallArgs,
+): Promise<void> {
+    const locks = getWebLockManager();
+    if (locks) {
+        await runWithWebLock(args, locks);
+        return;
+    }
+
+    await runWithFallbackLease(args);
+}

--- a/client/src/context/offlineDatabaseMutations.ts
+++ b/client/src/context/offlineDatabaseMutations.ts
@@ -6,13 +6,13 @@ import {
 } from '../utils/offlineDatabase';
 
 import {
-    clearOfflineDatabaseInstallLock,
-    getOfflineDatabaseInstallLock,
+    clearOfflineDatabaseAutoInstallOptOut,
     persistStoredOfflineDatabaseMetadata,
     readStoredOfflineDatabaseMetadata,
     runOfflineDatabaseTaskInBackground,
-    setOfflineDatabaseInstallLock,
+    setOfflineDatabaseAutoInstallOptOut,
 } from './offlineDatabaseStorage';
+import { runCoordinatedOfflineDatabaseInstall } from './offlineDatabaseInstallCoordinator';
 import { getOfflineDatabaseApiBaseUrl, primeOfflineShellCache } from './offlineDatabaseSync';
 import type { OfflineDatabaseOperations } from './offlineDatabaseOperations.shared';
 import type { OfflineDatabaseOperationsArgs } from './offlineDatabaseOperations.shared';
@@ -54,29 +54,19 @@ export function useOfflineDatabaseMutations({
         setProgress(0);
         setProgressStep('starting');
         setError(null);
+        clearOfflineDatabaseAutoInstallOptOut();
 
-        const currentLock = getOfflineDatabaseInstallLock();
         const lockOwner = instanceId;
-        const ownsLock = !currentLock || currentLock.owner === lockOwner
-            ? setOfflineDatabaseInstallLock(lockOwner)
-            : false;
 
-        if (!ownsLock) {
-            setProgress(5);
-            setProgressStep('waiting_for_other_tab');
-            await waitForOtherTabSync();
-            return;
-        }
+        const runInstall = async () => {
+            broadcast({
+                type: 'INSTALLING',
+                source: lockOwner,
+                payload: {
+                    mode: targetStatus === 'updating' ? 'updating' : 'installing',
+                },
+            });
 
-        broadcast({
-            type: 'INSTALLING',
-            source: lockOwner,
-            payload: {
-                mode: targetStatus === 'updating' ? 'updating' : 'installing',
-            },
-        });
-
-        try {
             const metadata = await refreshOfflineDatabaseAvailability(true);
             if (metadata) {
                 remoteMetadataRef.current = metadata;
@@ -112,6 +102,18 @@ export function useOfflineDatabaseMutations({
                 source: lockOwner,
                 payload: { metadata: effectiveMetadata },
             });
+        };
+
+        try {
+            await runCoordinatedOfflineDatabaseInstall({
+                owner: lockOwner,
+                runInstall,
+                waitForPeerInstall: waitForOtherTabSync,
+                onWaitingForPeer: () => {
+                    setProgress(5);
+                    setProgressStep('waiting_for_other_tab');
+                },
+            });
         } catch (err) {
             const message = formatOfflineDatabaseErrorMessage(err);
             setStatus('error');
@@ -122,8 +124,6 @@ export function useOfflineDatabaseMutations({
                 payload: { message },
             });
             throw new Error(message);
-        } finally {
-            clearOfflineDatabaseInstallLock(lockOwner);
         }
     }, [
         applyInstalledMetadata,
@@ -155,6 +155,7 @@ export function useOfflineDatabaseMutations({
                 10_000,
             );
             persistStoredOfflineDatabaseMetadata(null);
+            setOfflineDatabaseAutoInstallOptOut();
             sessionStorage.removeItem('offline_db_seed');
             setLocalVersion(null);
             setRemoteVersion(remoteMetadataRef.current?.version ?? null);

--- a/client/src/context/offlineDatabaseRuntime.ts
+++ b/client/src/context/offlineDatabaseRuntime.ts
@@ -250,6 +250,7 @@ export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
             error,
             isRemoving,
             isSupported,
+            supportReport,
             localVersion,
             progress,
             progressStep,

--- a/client/src/context/offlineDatabaseStorage.ts
+++ b/client/src/context/offlineDatabaseStorage.ts
@@ -4,8 +4,24 @@ import { sanitizeOfflineMetadata } from '../utils/offlineDatabase';
 export const OFFLINE_META_KEY = 'offline-db:installed-meta';
 export const OFFLINE_LOCK_KEY = 'offline-db:install-lock';
 export const OFFLINE_LOCK_TTL_MS = 180_000;
+export const OFFLINE_LEASE_HEARTBEAT_MS = 30_000;
+export const OFFLINE_AUTO_INSTALL_OPT_OUT_KEY =
+    'offline-db:auto-install-opt-out';
 
 let fallbackOfflineDatabaseInstanceCounter = 0;
+
+export interface OfflineDatabaseInstallLease {
+    owner: string;
+    attempt: number;
+    startedAt: number;
+    refreshedAt: number;
+    expiresAt: number;
+}
+
+export interface OfflineDatabaseInstallLeaseClaim {
+    acquired: boolean;
+    lease: OfflineDatabaseInstallLease | null;
+}
 
 export type OfflineDatabaseMissingFeature =
     | 'secure-context'
@@ -106,34 +122,122 @@ export function getOfflineDatabaseInstallLock(): {
     owner: string;
     expiresAt: number;
 } | null {
+    const lease = readOfflineDatabaseInstallLease();
+    if (!lease) return null;
+    return {
+        owner: lease.owner,
+        expiresAt: lease.expiresAt,
+    };
+}
+
+function normalizeOfflineDatabaseInstallLease(
+    value: unknown,
+): OfflineDatabaseInstallLease | null {
+    if (!value || typeof value !== 'object') return null;
+
+    const candidate = value as Partial<OfflineDatabaseInstallLease>;
+    if (!candidate.owner || !candidate.expiresAt) return null;
+
+    const now = Date.now();
+    const expiresAt = Number(candidate.expiresAt);
+    const startedAt = Number(candidate.startedAt ?? now);
+    const refreshedAt = Number(candidate.refreshedAt ?? now);
+    const attempt = Number(candidate.attempt ?? 1);
+
+    if (
+        !Number.isFinite(expiresAt)
+        || !Number.isFinite(startedAt)
+        || !Number.isFinite(refreshedAt)
+        || !Number.isFinite(attempt)
+    ) {
+        return null;
+    }
+
+    return {
+        owner: String(candidate.owner),
+        attempt,
+        startedAt,
+        refreshedAt,
+        expiresAt,
+    };
+}
+
+export function readOfflineDatabaseInstallLease(): OfflineDatabaseInstallLease | null {
     if (typeof localStorage === 'undefined') return null;
     try {
         const raw = localStorage.getItem(OFFLINE_LOCK_KEY);
         if (!raw) return null;
-        const parsed = JSON.parse(raw);
-        if (!parsed?.owner || !parsed?.expiresAt) return null;
-        if (Number(parsed.expiresAt) <= Date.now()) {
+        const parsed = normalizeOfflineDatabaseInstallLease(JSON.parse(raw));
+        if (!parsed) return null;
+        if (parsed.expiresAt <= Date.now()) {
             localStorage.removeItem(OFFLINE_LOCK_KEY);
             return null;
         }
-        return {
-            owner: String(parsed.owner),
-            expiresAt: Number(parsed.expiresAt),
-        };
+        return parsed;
     } catch {
         return null;
     }
 }
 
-export function setOfflineDatabaseInstallLock(owner: string): boolean {
-    if (typeof localStorage === 'undefined') return true;
+export function claimOfflineDatabaseInstallLease(
+    owner: string,
+): OfflineDatabaseInstallLeaseClaim {
+    if (typeof localStorage === 'undefined') {
+        return { acquired: true, lease: null };
+    }
+
     try {
-        const nextValue = JSON.stringify({
+        const previousRaw = localStorage.getItem(OFFLINE_LOCK_KEY);
+        const previousLease = previousRaw
+            ? normalizeOfflineDatabaseInstallLease(JSON.parse(previousRaw))
+            : null;
+        const current = readOfflineDatabaseInstallLease();
+        if (current && current.owner !== owner) {
+            return { acquired: false, lease: current };
+        }
+
+        const now = Date.now();
+        const nextLease: OfflineDatabaseInstallLease = {
             owner,
-            expiresAt: Date.now() + OFFLINE_LOCK_TTL_MS,
-        });
-        localStorage.setItem(OFFLINE_LOCK_KEY, nextValue);
-        return getOfflineDatabaseInstallLock()?.owner === owner;
+            attempt: current?.owner === owner
+                ? current.attempt
+                : (previousLease?.attempt ?? 0) + 1,
+            startedAt: current?.owner === owner ? current.startedAt : now,
+            refreshedAt: now,
+            expiresAt: now + OFFLINE_LOCK_TTL_MS,
+        };
+
+        localStorage.setItem(OFFLINE_LOCK_KEY, JSON.stringify(nextLease));
+        const stored = readOfflineDatabaseInstallLease();
+        return {
+            acquired: stored?.owner === owner,
+            lease: stored,
+        };
+    } catch {
+        return { acquired: true, lease: null };
+    }
+}
+
+export function setOfflineDatabaseInstallLock(owner: string): boolean {
+    return claimOfflineDatabaseInstallLease(owner).acquired;
+}
+
+export function refreshOfflineDatabaseInstallLease(owner: string): boolean {
+    if (typeof localStorage === 'undefined') return true;
+    const current = readOfflineDatabaseInstallLease();
+    if (current?.owner !== owner) return false;
+
+    const now = Date.now();
+    try {
+        localStorage.setItem(
+            OFFLINE_LOCK_KEY,
+            JSON.stringify({
+                ...current,
+                refreshedAt: now,
+                expiresAt: now + OFFLINE_LOCK_TTL_MS,
+            }),
+        );
+        return readOfflineDatabaseInstallLease()?.owner === owner;
     } catch {
         return true;
     }
@@ -146,6 +250,37 @@ export function clearOfflineDatabaseInstallLock(owner: string): void {
         if (!current || current.owner === owner) {
             localStorage.removeItem(OFFLINE_LOCK_KEY);
         }
+    } catch {
+        // Ignore storage failures.
+    }
+}
+
+export function releaseOfflineDatabaseInstallLease(owner: string): void {
+    clearOfflineDatabaseInstallLock(owner);
+}
+
+export function hasOfflineDatabaseAutoInstallOptOut(): boolean {
+    if (typeof localStorage === 'undefined') return false;
+    try {
+        return localStorage.getItem(OFFLINE_AUTO_INSTALL_OPT_OUT_KEY) === 'true';
+    } catch {
+        return false;
+    }
+}
+
+export function setOfflineDatabaseAutoInstallOptOut(): void {
+    if (typeof localStorage === 'undefined') return;
+    try {
+        localStorage.setItem(OFFLINE_AUTO_INSTALL_OPT_OUT_KEY, 'true');
+    } catch {
+        // Ignore storage failures; auto-install remains the default.
+    }
+}
+
+export function clearOfflineDatabaseAutoInstallOptOut(): void {
+    if (typeof localStorage === 'undefined') return;
+    try {
+        localStorage.removeItem(OFFLINE_AUTO_INSTALL_OPT_OUT_KEY);
     } catch {
         // Ignore storage failures.
     }

--- a/client/src/workers/dbWorker/messages.js
+++ b/client/src/workers/dbWorker/messages.js
@@ -192,6 +192,12 @@ async function fetchEncryptedDatabase(apiBase, token) {
   }
 
   const errText = await dlResp.text();
+  if (dlResp.status === 403) {
+    throw new Error(
+      `O token temporário do banco offline expirou ou foi recusado pelo servidor (${dlResp.status}). Tente instalar novamente.`
+    );
+  }
+
   throw new Error(
     `Offline database retrieval failed (${dlResp.status}): ${errText}`
   );

--- a/client/src/workers/dbWorker/messages.test.js
+++ b/client/src/workers/dbWorker/messages.test.js
@@ -47,12 +47,16 @@ vi.mock('./state.js', () => ({
 
 import {
   buildOfflineDatabaseNetworkErrorMessage,
+  dispatchWorkerMessage,
   fetchWithTimeout,
 } from './messages.js';
+import { removeFromOpfs } from './opfs.js';
+import { postWorkerError, postWorkerStatus } from './protocol.js';
 
 describe('dbWorker messages network helpers', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.clearAllMocks();
   });
 
   it('preserves the caught error as cause when fetch fails', async () => {
@@ -93,5 +97,56 @@ describe('dbWorker messages network helpers', () => {
 
     expect(message).toContain('https://3fbcaa44.fiscalconsultas.pages.dev');
     expect(message).toContain('/api/database/version');
+  });
+
+  it('shows a recoverable friendly message when the download token is rejected', async () => {
+    removeFromOpfs.mockResolvedValue(undefined);
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              token: 'token-1',
+              app_seed: 'seed-1',
+              encrypted_sha256: 'enc-sha',
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              detail: 'Token invalid, expired, or already used',
+            }),
+            { status: 403, headers: { 'content-type': 'application/json' } },
+          ),
+        ),
+    );
+
+    await dispatchWorkerMessage('INSTALL', 'install-1', {
+      apiBase: 'https://api.example.test/api',
+    });
+
+    const friendlyMessage =
+      'O token temporário do banco offline expirou ou foi recusado pelo servidor (403). Tente instalar novamente.';
+    expect(postWorkerError).toHaveBeenCalledWith(
+      'install-1',
+      expect.stringContaining(friendlyMessage),
+    );
+    expect(
+      postWorkerError.mock.calls.some(([, message]) =>
+        String(message).includes('Token invalid, expired, or already used'),
+      ),
+    ).toBe(false);
+    expect(postWorkerStatus).toHaveBeenCalledWith(
+      'install-1',
+      expect.objectContaining({
+        status: 'error',
+        recoverable: true,
+        error: expect.stringContaining(friendlyMessage),
+      }),
+    );
   });
 });

--- a/client/tests/playwright/helpers/offlineHarness.ts
+++ b/client/tests/playwright/helpers/offlineHarness.ts
@@ -323,6 +323,10 @@ export async function openSettings(page: Page) {
 
 export async function installOfflineFromSettings(page: Page, timeout = 15_000) {
   await openSettings(page);
+  if (await page.getByText(/Pronta/).isVisible().catch(() => false)) {
+    return;
+  }
+
   const installButton = page.locator('#db-installer-install');
   await expect(installButton).toBeVisible({ timeout });
   await installButton.click();
@@ -342,4 +346,35 @@ export async function expectOfflineMetadataPersisted(page: Page) {
   await expect.poll(async () => (
     page.evaluate(() => Boolean(globalThis.localStorage.getItem('offline-db:installed-meta')))
   )).toBe(true);
+}
+
+export async function expectOfflineAutoInstalled(page: Page, timeout = 15_000) {
+  await expect.poll(async () => (
+    page.evaluate(() => Boolean(globalThis.localStorage.getItem('offline-db:installed-meta')))
+  ), { timeout }).toBe(true);
+  await openSettings(page);
+  await expect(page.getByText(/Pronta/)).toBeVisible({ timeout });
+  await expect(page.locator('#db-installer-install')).not.toBeVisible();
+}
+
+export async function seedFreshOfflineInstallLease(
+  page: Page,
+  owner = 'abandoned-tab',
+) {
+  await page.addInitScript(({ ownerName }) => {
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: undefined,
+    });
+    localStorage.setItem(
+      'offline-db:install-lock',
+      JSON.stringify({
+        owner: ownerName,
+        attempt: 1,
+        startedAt: Date.now(),
+        refreshedAt: Date.now(),
+        expiresAt: Date.now() + 180_000,
+      }),
+    );
+  }, { ownerName: owner });
 }

--- a/client/tests/playwright/offline-install-reopen.spec.ts
+++ b/client/tests/playwright/offline-install-reopen.spec.ts
@@ -2,12 +2,14 @@ import { expect, test } from '@playwright/test';
 
 import {
   OFFLINE_METADATA,
+  expectOfflineAutoInstalled,
   expectOfflineMetadataPersisted,
   expectOfflineReadyInSettings,
   installOfflineApiMock,
   installOfflineFromSettings,
   installOfflineWorkerMock,
   openSettings,
+  seedFreshOfflineInstallLease,
   type OfflineApiCounters,
 } from './helpers/offlineHarness';
 
@@ -23,7 +25,7 @@ test.describe('offline install and reopen flow', () => {
     await expect(page.getByText(/Indisponível/)).not.toBeVisible();
   });
 
-  test('installs offline database using version/token/download endpoints', async ({ page }) => {
+  test('auto-installs offline database on first supported visit', async ({ page }) => {
     const counters: OfflineApiCounters = {
       version: 0,
       token: 0,
@@ -36,7 +38,7 @@ test.describe('offline install and reopen flow', () => {
     await page.goto('/');
     await expect(page.getByRole('heading', { name: 'FiscalConsultas' })).toBeVisible();
 
-    await installOfflineFromSettings(page);
+    await expectOfflineAutoInstalled(page);
 
     expect(counters.version).toBeGreaterThanOrEqual(2);
     expect(counters.token).toBe(1);
@@ -48,6 +50,8 @@ test.describe('offline install and reopen flow', () => {
 
   test('shows an actionable error when backend CORS blocks offline install', async ({ page }) => {
     await page.addInitScript(() => {
+      localStorage.setItem('offline-db:auto-install-opt-out', 'true');
+
       type WorkerMessage = {
         type: string;
         id: string | null;
@@ -138,6 +142,26 @@ test.describe('offline install and reopen flow', () => {
     await expect(page.getByText(/Solicitando token/i)).not.toBeVisible();
   });
 
+  test('keeps manual install path available after user opt-out', async ({ page }) => {
+    const counters: OfflineApiCounters = {
+      version: 0,
+      token: 0,
+      download: 0,
+    };
+
+    await installOfflineWorkerMock(page);
+    await installOfflineApiMock(page, counters);
+    await page.addInitScript(() => {
+      localStorage.setItem('offline-db:auto-install-opt-out', 'true');
+    });
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'FiscalConsultas' })).toBeVisible();
+    await installOfflineFromSettings(page);
+
+    expect(counters.download).toBe(1);
+  });
+
   test('reopens with offline DB ready when backend API is unavailable', async ({ page, context }) => {
     const counters: OfflineApiCounters = {
       version: 0,
@@ -164,5 +188,39 @@ test.describe('offline install and reopen flow', () => {
     await expect(page.getByRole('heading', { name: 'FiscalConsultas' })).toBeVisible();
     await expectOfflineMetadataPersisted(page);
     await expectOfflineReadyInSettings(page);
+  });
+
+  test('recovers when a previous installing tab is closed before broadcasting completion', async ({ page, context }) => {
+    const counters: OfflineApiCounters = {
+      version: 0,
+      token: 0,
+      download: 0,
+    };
+
+    await installOfflineWorkerMock(page);
+    await installOfflineApiMock(page, counters);
+    await seedFreshOfflineInstallLease(page);
+
+    await page.goto('/');
+    await openSettings(page);
+    await expect(page.getByText(/Outra aba está instalando os dados/i)).toBeVisible();
+
+    const closingOwnerPage = await context.newPage();
+    await closingOwnerPage.goto('/');
+    await closingOwnerPage.evaluate(() => {
+      const raw = localStorage.getItem('offline-db:install-lock');
+      const lock = raw ? JSON.parse(raw) as Record<string, unknown> : {};
+      localStorage.setItem(
+        'offline-db:install-lock',
+        JSON.stringify({
+          ...lock,
+          expiresAt: Date.now() - 1,
+        }),
+      );
+    });
+    await closingOwnerPage.close();
+
+    await expectOfflineReadyInSettings(page);
+    expect(counters.download).toBe(1);
   });
 });

--- a/client/tests/unit/DatabaseInstaller.test.tsx
+++ b/client/tests/unit/DatabaseInstaller.test.tsx
@@ -211,11 +211,13 @@ describe('DatabaseInstaller', () => {
     expect(installMock).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the default install state and starts installation', () => {
+  it('describes automatic local search installation when not installed', () => {
+    localDatabaseState.dbSizeBytes = 24 * 1024 * 1024;
+
     render(<DatabaseInstaller />);
 
-    expect(screen.getByText(/Instale o banco de dados localmente/i)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /Instalar Busca Instantânea/i }));
+    expect(screen.getByText(/A busca local é instalada automaticamente/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Instalar agora/i }));
     expect(installMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/tests/unit/LocalDatabaseContext.autoinstall.test.tsx
+++ b/client/tests/unit/LocalDatabaseContext.autoinstall.test.tsx
@@ -61,6 +61,7 @@ class MockWorker {
   }
 
   terminate(): void {
+    // Mirror Worker termination by detaching handlers from this test double.
     this.onmessage = null;
     this.onerror = null;
     this.messageListeners.clear();
@@ -176,6 +177,7 @@ describe('LocalDatabaseContext auto-install behavior', () => {
     vi.stubGlobal('SharedArrayBuffer', class SharedArrayBufferMock {});
     vi.stubGlobal('isSecureContext', true);
     vi.stubGlobal('crossOriginIsolated', true);
+    vi.stubGlobal('crypto', { subtle: {}, randomUUID: vi.fn(() => 'mock-instance') });
     vi.stubGlobal(
       'fetch',
       vi.fn().mockImplementation(() => Promise.resolve(makeVersionResponse('2026.04'))),
@@ -186,7 +188,7 @@ describe('LocalDatabaseContext auto-install behavior', () => {
     vi.unstubAllGlobals();
   });
 
-  it('does not auto-install on first visit when the database is missing', async () => {
+  it('auto-installs on first supported visit when the database is missing', async () => {
     render(
       <LocalDatabaseProvider>
         <Probe />
@@ -194,12 +196,12 @@ describe('LocalDatabaseContext auto-install behavior', () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByTestId('status')).toHaveTextContent('not_installed'),
+      expect(screen.getByTestId('status')).toHaveTextContent('ready'),
     );
     await flushEffects();
 
-    expect(getWorkerMessages()).not.toContain('INSTALL');
-    expect(screen.getByTestId('status')).toHaveTextContent('not_installed');
+    expect(getWorkerMessages()).toContain('INSTALL');
+    expect(screen.getByTestId('status')).toHaveTextContent('ready');
   });
 
   it('does not reinstall immediately after remove()', async () => {
@@ -228,6 +230,28 @@ describe('LocalDatabaseContext auto-install behavior', () => {
     await flushEffects();
 
     expect(getWorkerMessages()).not.toContain('INSTALL');
+    expect(localStorage.getItem('offline-db:auto-install-opt-out')).toBe('true');
     expect(screen.getByTestId('status')).toHaveTextContent('not_installed');
+  });
+
+  it('clears the auto-install opt-out when install is started manually', async () => {
+    localStorage.setItem('offline-db:auto-install-opt-out', 'true');
+
+    render(
+      <LocalDatabaseProvider>
+        <Probe />
+      </LocalDatabaseProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('status')).toHaveTextContent('not_installed'),
+    );
+
+    await act(async () => {
+      await currentContext!.install();
+    });
+
+    expect(localStorage.getItem('offline-db:auto-install-opt-out')).toBeNull();
+    expect(getWorkerMessages()).toContain('INSTALL');
   });
 });

--- a/client/tests/unit/offlineDatabaseInstallCoordinator.test.ts
+++ b/client/tests/unit/offlineDatabaseInstallCoordinator.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  runCoordinatedOfflineDatabaseInstall,
+} from '../../src/context/offlineDatabaseInstallCoordinator';
+import {
+  OFFLINE_LOCK_KEY,
+} from '../../src/context/offlineDatabaseStorage';
+
+type NavigatorWithLocks = Navigator & {
+  locks?: {
+    request: (
+      name: string,
+      optionsOrCallback:
+        | { ifAvailable?: boolean; mode?: 'exclusive' | 'shared' }
+        | ((lock: unknown) => Promise<void>),
+      callback?: (lock: unknown) => Promise<void>,
+    ) => Promise<void> | Promise<boolean>;
+  };
+};
+
+function setNavigatorLocks(value: NavigatorWithLocks['locks']) {
+  Object.defineProperty(navigator, 'locks', {
+    configurable: true,
+    value,
+  });
+}
+
+function seedInstallLease(owner: string, expiresAt: number) {
+  localStorage.setItem(
+    OFFLINE_LOCK_KEY,
+    JSON.stringify({
+      owner,
+      attempt: 1,
+      startedAt: Date.now(),
+      refreshedAt: Date.now(),
+      expiresAt,
+    }),
+  );
+}
+
+describe('offlineDatabaseInstallCoordinator', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-05T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(navigator, 'locks');
+  });
+
+  it('uses Web Locks when available and runs the installer once', async () => {
+    const request = vi.fn(
+      async (
+        _name: string,
+        _options: { ifAvailable?: boolean },
+        callback?: (lock: unknown) => Promise<void>,
+      ) => {
+        await callback({});
+        return true;
+      },
+    );
+    setNavigatorLocks({ request });
+    const install = vi.fn().mockResolvedValue(undefined);
+
+    await runCoordinatedOfflineDatabaseInstall({
+      owner: 'tab-a',
+      runInstall: install,
+      waitForPeerInstall: vi.fn(),
+      onWaitingForPeer: vi.fn(),
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      'offline-db-install',
+      { ifAvailable: true, mode: 'exclusive' },
+      expect.any(Function),
+    );
+    expect(install).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not queue duplicate installs behind an active Web Lock owner', async () => {
+    let lockAvailable = false;
+    const request = vi.fn(
+      async (
+        _name: string,
+        _options: { ifAvailable?: boolean },
+        callback?: (lock: unknown) => Promise<void>,
+      ) => {
+        if (!lockAvailable) {
+          await callback(null);
+          return false;
+        }
+        await callback({});
+        return true;
+      },
+    );
+    setNavigatorLocks({ request });
+    seedInstallLease('tab-a', Date.now() + 180_000);
+
+    const install = vi.fn().mockResolvedValue(undefined);
+    const waitForPeerInstall = vi.fn(async () => {
+      lockAvailable = true;
+    });
+
+    await runCoordinatedOfflineDatabaseInstall({
+      owner: 'tab-b',
+      runInstall: install,
+      waitForPeerInstall,
+      onWaitingForPeer: vi.fn(),
+    });
+
+    expect(waitForPeerInstall).toHaveBeenCalledTimes(1);
+    expect(install).not.toHaveBeenCalled();
+  });
+
+  it('waits for a fresh fallback lease and takes over as soon as it expires', async () => {
+    setNavigatorLocks(undefined);
+    seedInstallLease('tab-a', Date.now() + 180_000);
+
+    const install = vi.fn().mockResolvedValue(undefined);
+    const waitForPeerInstall = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          setTimeout(() => reject(new Error('peer timed out')), 240_000);
+        }),
+    );
+
+    const promise = runCoordinatedOfflineDatabaseInstall({
+      owner: 'tab-b',
+      runInstall: install,
+      waitForPeerInstall,
+      onWaitingForPeer: vi.fn(),
+    });
+
+    await vi.advanceTimersByTimeAsync(181_000);
+    await promise;
+
+    expect(waitForPeerInstall).toHaveBeenCalledTimes(1);
+    expect(install).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns without installing when another tab finishes first', async () => {
+    setNavigatorLocks(undefined);
+    seedInstallLease('tab-a', Date.now() + 180_000);
+
+    const install = vi.fn().mockResolvedValue(undefined);
+    const waitForPeerInstall = vi.fn().mockResolvedValue(undefined);
+
+    await runCoordinatedOfflineDatabaseInstall({
+      owner: 'tab-b',
+      runInstall: install,
+      waitForPeerInstall,
+      onWaitingForPeer: vi.fn(),
+    });
+
+    expect(waitForPeerInstall).toHaveBeenCalledTimes(1);
+    expect(install).not.toHaveBeenCalled();
+  });
+});

--- a/client/tests/unit/offlineDatabaseStorage.test.ts
+++ b/client/tests/unit/offlineDatabaseStorage.test.ts
@@ -2,14 +2,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildOfflineDatabaseInitPayload,
+  claimOfflineDatabaseInstallLease,
+  clearOfflineDatabaseAutoInstallOptOut,
   clearOfflineDatabaseInstallLock,
   getOfflineDatabaseSupportReport,
   getOfflineDatabaseInstallLock,
+  hasOfflineDatabaseAutoInstallOptOut,
   isOfflineDatabaseSupported,
+  OFFLINE_AUTO_INSTALL_OPT_OUT_KEY,
   OFFLINE_LOCK_KEY,
   OFFLINE_META_KEY,
   persistStoredOfflineDatabaseMetadata,
   readStoredOfflineDatabaseMetadata,
+  refreshOfflineDatabaseInstallLease,
+  releaseOfflineDatabaseInstallLease,
+  setOfflineDatabaseAutoInstallOptOut,
   setOfflineDatabaseInstallLock,
 } from '../../src/context/offlineDatabaseStorage';
 
@@ -146,6 +153,47 @@ describe('offlineDatabaseStorage', () => {
     vi.advanceTimersByTime(2);
 
     expect(getOfflineDatabaseInstallLock()).toBeNull();
+  });
+
+  it('claims, refreshes, expires, and releases the install lease by owner', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-05T12:00:00Z'));
+
+    const firstClaim = claimOfflineDatabaseInstallLease('tab-a');
+    expect(firstClaim.acquired).toBe(true);
+    expect(firstClaim.lease?.owner).toBe('tab-a');
+    expect(firstClaim.lease?.attempt).toBe(1);
+
+    const blockedClaim = claimOfflineDatabaseInstallLease('tab-b');
+    expect(blockedClaim.acquired).toBe(false);
+    expect(blockedClaim.lease?.owner).toBe('tab-a');
+
+    vi.advanceTimersByTime(60_000);
+    expect(refreshOfflineDatabaseInstallLease('tab-a')).toBe(true);
+    expect(refreshOfflineDatabaseInstallLease('tab-b')).toBe(false);
+
+    vi.advanceTimersByTime(181_000);
+    const takeoverClaim = claimOfflineDatabaseInstallLease('tab-b');
+    expect(takeoverClaim.acquired).toBe(true);
+    expect(takeoverClaim.lease?.owner).toBe('tab-b');
+    expect(takeoverClaim.lease?.attempt).toBe(2);
+
+    releaseOfflineDatabaseInstallLease('tab-a');
+    expect(claimOfflineDatabaseInstallLease('tab-c').acquired).toBe(false);
+
+    releaseOfflineDatabaseInstallLease('tab-b');
+    expect(claimOfflineDatabaseInstallLease('tab-c').acquired).toBe(true);
+  });
+
+  it('persists an auto-install opt-out until explicit install clears it', () => {
+    expect(hasOfflineDatabaseAutoInstallOptOut()).toBe(false);
+
+    setOfflineDatabaseAutoInstallOptOut();
+    expect(localStorage.getItem(OFFLINE_AUTO_INSTALL_OPT_OUT_KEY)).toBe('true');
+    expect(hasOfflineDatabaseAutoInstallOptOut()).toBe(true);
+
+    clearOfflineDatabaseAutoInstallOptOut();
+    expect(hasOfflineDatabaseAutoInstallOptOut()).toBe(false);
   });
 
   it('builds init payload from metadata or defaults', () => {

--- a/tests/unit/test_database_download_route.py
+++ b/tests/unit/test_database_download_route.py
@@ -154,10 +154,102 @@ def test_database_download_token_routes_are_public_middleware_paths():
 
 
 @pytest.mark.asyncio
-async def test_download_token_is_bound_to_request_ip(offline_bundle):
+async def test_download_token_tolerates_proxy_ip_changes(offline_bundle):
     token_request = _build_request("/api/database/token", client_host="203.0.113.10")
     token_payload = await database_download.create_download_token(token_request)
     token = token_payload["token"]
+
+    response = await database_download.download_database(
+        _build_request("/api/database/download", client_host="203.0.113.20"),
+        database_download.DownloadDatabaseRequest(token=token),
+    )
+
+    assert Path(response.path).read_bytes() == b"encrypted-bundle"
+
+
+@pytest.mark.asyncio
+async def test_nonlocal_download_token_survives_missing_shared_store(offline_bundle):
+    token_request = _build_request(
+        "/api/database/token",
+        headers={"host": "fiscal.example.com"},
+        client_host="203.0.113.10",
+        scheme="https",
+    )
+    token_payload = await database_download.create_download_token(token_request)
+    token = token_payload["token"]
+    database_download._memory_tokens.clear()
+
+    response = await database_download.download_database(
+        _build_request(
+            "/api/database/download",
+            headers={"host": "fiscal.example.com"},
+            client_host="203.0.113.20",
+            scheme="https",
+        ),
+        database_download.DownloadDatabaseRequest(token=token),
+    )
+
+    assert Path(response.path).read_bytes() == b"encrypted-bundle"
+
+
+@pytest.mark.asyncio
+async def test_nonlocal_download_token_rejects_tampering(offline_bundle):
+    token_request = _build_request(
+        "/api/database/token",
+        headers={"host": "fiscal.example.com"},
+        client_host="203.0.113.10",
+        scheme="https",
+    )
+    token_payload = await database_download.create_download_token(token_request)
+    token = token_payload["token"]
+    tampered_token = f"{token[:-1]}x"
+
+    with pytest.raises(HTTPException) as exc:
+        await database_download.download_database(
+            _build_request(
+                "/api/database/download",
+                headers={"host": "fiscal.example.com"},
+                client_host="203.0.113.20",
+                scheme="https",
+            ),
+            database_download.DownloadDatabaseRequest(token=tampered_token),
+        )
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_redis_download_token_tolerates_proxy_ip_changes(
+    offline_bundle, monkeypatch: pytest.MonkeyPatch
+):
+    class FakeRedisCache:
+        available = True
+
+        def __init__(self):
+            self.values: dict[str, str] = {}
+
+        async def set_with_ttl(self, key: str, value: str, ttl_seconds: int) -> bool:
+            assert ttl_seconds > 0
+            self.values[key] = value
+            return True
+
+        async def consume_once(self, key: str) -> str | None:
+            return self.values.pop(key, None)
+
+    fake_redis = FakeRedisCache()
+    monkeypatch.setattr(database_download, "redis_cache", fake_redis)
+
+    token_request = _build_request("/api/database/token", client_host="203.0.113.10")
+    token_payload = await database_download.create_download_token(token_request)
+    token = token_payload["token"]
+    fake_redis.values[f"dbtoken:{token}"] = "203.0.113.10"
+
+    response = await database_download.download_database(
+        _build_request("/api/database/download", client_host="203.0.113.20"),
+        database_download.DownloadDatabaseRequest(token=token),
+    )
+
+    assert Path(response.path).read_bytes() == b"encrypted-bundle"
 
     with pytest.raises(HTTPException) as exc:
         await database_download.download_database(
@@ -166,13 +258,6 @@ async def test_download_token_is_bound_to_request_ip(offline_bundle):
         )
 
     assert exc.value.status_code == 403
-
-    response = await database_download.download_database(
-        _build_request("/api/database/download", client_host="203.0.113.10"),
-        database_download.DownloadDatabaseRequest(token=token),
-    )
-
-    assert Path(response.path).read_bytes() == b"encrypted-bundle"
 
 
 @pytest.mark.asyncio
@@ -201,10 +286,9 @@ async def test_download_token_expires_after_ttl(offline_bundle):
     token_request = _build_request("/api/database/token")
     token_payload = await database_download.create_download_token(token_request)
     token = token_payload["token"]
-    created_at, stored_ip = database_download._memory_tokens[token]
+    created_at = database_download._memory_tokens[token]
     database_download._memory_tokens[token] = (
-        created_at - database_download._TOKEN_TTL_SECONDS - 1,
-        stored_ip,
+        created_at - database_download._TOKEN_TTL_SECONDS - 1
     )
 
     with pytest.raises(HTTPException) as exc:


### PR DESCRIPTION
## Summary
- Auto-installs the local search database on first supported visit.
- Adds an explicit opt-out after user removal, while manual install clears the opt-out.
- Introduces a cross-tab install coordinator using Web Locks when available and a renewable localStorage lease fallback.
- Adds stale-owner recovery so a waiting tab can take over when the installing tab is closed or abandoned.
- Updates installer copy and adds unit/Playwright coverage for auto-install, opt-out, Web Locks, stale lease takeover, and abandoned-tab recovery.

## Why
The old flow used a one-shot localStorage lock plus BroadcastChannel completion. If the installing tab was closed before broadcasting INSTALLED or ERROR, another tab could stay stuck on 'Outra aba está instalando os dados...' and the user had to wait or retry manually. Local search is core to the product, so the site should make the first download automatically and recover from abandoned tabs.

## Validation
- npm test -- tests/unit/offlineDatabaseStorage.test.ts tests/unit/offlineDatabaseInstallCoordinator.test.ts tests/unit/LocalDatabaseContext.autoinstall.test.tsx tests/unit/DatabaseInstaller.test.tsx
- npm run type-check
- npm run lint
- npm run test:e2e -- offline-install-reopen.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline database auto-installs on first supported visit (persisted opt-out available); manual reinstall remains possible
  * Coordinated single-install across tabs to prevent duplicate installs

* **Bug Fixes**
  * Download tokens no longer tied to client IP (works across proxy/IP changes)
  * Worker surfaces a specific recoverable error when a download token is rejected (HTTP 403)

* **Improvements**
  * UI copy: “wait a few seconds and reload” guidance; install button now “Instalar agora”

* **Tests**
  * Added/updated tests covering auto-install, opt-out, coordination, lease lifecycle and 403 handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->