### PR TITLE
feat: define offline-first fiscal source contract

### DIFF
--- a/client/src/context/offlineDatabase.types.ts
+++ b/client/src/context/offlineDatabase.types.ts
@@ -1,6 +1,7 @@
 import type {
     NbsCatalogDetailApiResponse,
 } from '../types/api.types';
+import type { FiscalSourceId } from './offlineSources';
 import type { OfflineDatabaseMetadata } from '../utils/offlineDatabase';
 
 export type OfflineDatabaseStatus =
@@ -12,7 +13,12 @@ export type OfflineDatabaseStatus =
     | 'error'
     | 'unsupported';
 
-export type OfflineDocumentType = 'nbs' | 'tipi' | 'ncm' | 'nesh';
+export type OfflineFiscalSourceId = FiscalSourceId;
+export type OfflineLegacyDocumentType = 'ncm';
+export type OfflineSearchDocumentType =
+    | Exclude<OfflineFiscalSourceId, 'unspsc'>
+    | OfflineLegacyDocumentType;
+export type OfflineDocumentType = OfflineSearchDocumentType;
 
 export interface OfflineDatabaseState {
     status: OfflineDatabaseStatus;
@@ -203,21 +209,25 @@ export type OfflineDatabaseWorkerMessage =
 export type OfflineDatabaseChannelMessage =
     | {
         type: 'INSTALLING';
-        source: string;
+        source: OfflineFiscalSourceId;
+        senderId: string;
         payload: { mode: 'installing' | 'updating' };
     }
     | {
         type: 'INSTALLED';
-        source: string;
+        source: OfflineFiscalSourceId;
+        senderId: string;
         payload: { metadata: OfflineDatabaseMetadata | null };
     }
     | {
         type: 'REMOVED';
-        source: string;
+        source: OfflineFiscalSourceId;
+        senderId: string;
         payload: Record<string, never>;
     }
     | {
         type: 'ERROR';
-        source: string;
+        source: OfflineFiscalSourceId;
+        senderId: string;
         payload: { message: string };
     };

--- a/client/src/context/offlineDatabaseMutations.ts
+++ b/client/src/context/offlineDatabaseMutations.ts
@@ -17,6 +17,9 @@ import { getOfflineDatabaseApiBaseUrl, primeOfflineShellCache } from './offlineD
 import type { OfflineDatabaseOperations } from './offlineDatabaseOperations.shared';
 import type { OfflineDatabaseOperationsArgs } from './offlineDatabaseOperations.shared';
 
+// Current installs still use the legacy monolithic bundle until source-scoped installs land.
+const LEGACY_MONOLITHIC_BUNDLE_SOURCE = 'nesh';
+
 export function useOfflineDatabaseMutations({
     applyInstalledMetadata,
     broadcast,
@@ -70,7 +73,8 @@ export function useOfflineDatabaseMutations({
 
         broadcast({
             type: 'INSTALLING',
-            source: lockOwner,
+            source: LEGACY_MONOLITHIC_BUNDLE_SOURCE,
+            senderId: lockOwner,
             payload: {
                 mode: targetStatus === 'updating' ? 'updating' : 'installing',
             },
@@ -109,7 +113,8 @@ export function useOfflineDatabaseMutations({
 
             broadcast({
                 type: 'INSTALLED',
-                source: lockOwner,
+                source: LEGACY_MONOLITHIC_BUNDLE_SOURCE,
+                senderId: lockOwner,
                 payload: { metadata: effectiveMetadata },
             });
         } catch (err) {
@@ -118,7 +123,8 @@ export function useOfflineDatabaseMutations({
             setError(message);
             broadcast({
                 type: 'ERROR',
-                source: lockOwner,
+                source: LEGACY_MONOLITHIC_BUNDLE_SOURCE,
+                senderId: lockOwner,
                 payload: { message },
             });
             throw new Error(message);
@@ -164,7 +170,8 @@ export function useOfflineDatabaseMutations({
             setError(null);
             broadcast({
                 type: 'REMOVED',
-                source: instanceId,
+                source: LEGACY_MONOLITHIC_BUNDLE_SOURCE,
+                senderId: instanceId,
                 payload: {},
             });
         } catch (err) {

--- a/client/src/context/offlineDatabaseRuntime/useOfflineDatabaseBroadcastChannel.ts
+++ b/client/src/context/offlineDatabaseRuntime/useOfflineDatabaseBroadcastChannel.ts
@@ -81,7 +81,7 @@ export function useOfflineDatabaseBroadcastChannel({
 
         channel.onmessage = (event: MessageEvent<OfflineDatabaseChannelMessage>) => {
             const message = event.data;
-            if (!message || message.source === instanceId) return;
+            if (!message || message.senderId === instanceId) return;
 
             if (message.type === 'INSTALLING') {
                 const nextStatus =

--- a/client/src/context/offlineSources.ts
+++ b/client/src/context/offlineSources.ts
@@ -1,0 +1,33 @@
+export const FISCAL_OFFLINE_SOURCES = [
+  { id: 'nesh', label: 'NESH' },
+  { id: 'tipi', label: 'TIPI' },
+  { id: 'nbs', label: 'NBS' },
+  { id: 'unspsc', label: 'UNSPSC' },
+] as const;
+
+export type FiscalSourceId = (typeof FISCAL_OFFLINE_SOURCES)[number]['id'];
+
+export interface FiscalBundleUrls {
+  metadataUrl: string;
+  encryptedUrl: string;
+}
+
+const FISCAL_SOURCE_IDS = new Set<string>(
+  FISCAL_OFFLINE_SOURCES.map((source) => source.id),
+);
+
+export function isFiscalSourceId(value: unknown): value is FiscalSourceId {
+  return typeof value === 'string' && FISCAL_SOURCE_IDS.has(value);
+}
+
+export function buildFiscalBundleUrls(
+  baseUrl: string,
+  source: FiscalSourceId,
+): FiscalBundleUrls {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
+
+  return {
+    metadataUrl: `${normalizedBaseUrl}/${source}/${source}.meta.json`,
+    encryptedUrl: `${normalizedBaseUrl}/${source}/${source}.enc`,
+  };
+}

--- a/client/src/utils/offlineDatabase.ts
+++ b/client/src/utils/offlineDatabase.ts
@@ -1,3 +1,8 @@
+import {
+  isFiscalSourceId,
+  type FiscalSourceId,
+} from '../context/offlineSources';
+
 export interface OfflineDatabaseMetadata {
   version: string;
   size_bytes: number;
@@ -8,6 +13,11 @@ export interface OfflineDatabaseMetadata {
   format_version?: number;
   chunk_size?: number;
   pbkdf2_iterations?: number;
+}
+
+export interface OfflineSourceMetadata extends OfflineDatabaseMetadata {
+  source: FiscalSourceId;
+  encrypted_sha256: string;
 }
 
 export function compareOfflineVersions(
@@ -71,6 +81,24 @@ export function sanitizeOfflineMetadata(
     format_version: Number(metadata.format_version || 1),
     chunk_size: Number(metadata.chunk_size || 65536),
     pbkdf2_iterations: Number(metadata.pbkdf2_iterations || 600000),
+  };
+}
+
+export function sanitizeOfflineSourceMetadata(
+  source: unknown,
+  metadata: Partial<OfflineDatabaseMetadata> | null | undefined
+): OfflineSourceMetadata | null {
+  if (!isFiscalSourceId(source) || !metadata?.version || !metadata.encrypted_sha256) {
+    return null;
+  }
+
+  const sanitized = sanitizeOfflineMetadata(metadata);
+  if (!sanitized?.encrypted_sha256) return null;
+
+  return {
+    ...sanitized,
+    source,
+    encrypted_sha256: sanitized.encrypted_sha256,
   };
 }
 

--- a/client/tests/unit/offlineSources.test.ts
+++ b/client/tests/unit/offlineSources.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import {
+  FISCAL_OFFLINE_SOURCES,
+  buildFiscalBundleUrls,
+  isFiscalSourceId,
+} from '../../src/context/offlineSources';
+import type {
+  OfflineDocumentType,
+  OfflineFiscalSourceId,
+  OfflineSearchDocumentType,
+} from '../../src/context/offlineDatabase.types';
+import { sanitizeOfflineSourceMetadata } from '../../src/utils/offlineDatabase';
+
+describe('offline fiscal sources', () => {
+  it('declares the four independent fiscal sources', () => {
+    expect(FISCAL_OFFLINE_SOURCES.map((source) => source.id)).toEqual([
+      'nesh',
+      'tipi',
+      'nbs',
+      'unspsc',
+    ]);
+  });
+
+  it('builds source-scoped R2 URLs without using /api', () => {
+    expect(buildFiscalBundleUrls('https://r2.example.com/fiscal', 'tipi')).toEqual({
+      metadataUrl: 'https://r2.example.com/fiscal/tipi/tipi.meta.json',
+      encryptedUrl: 'https://r2.example.com/fiscal/tipi/tipi.enc',
+    });
+  });
+
+  it('normalizes trailing slashes in source-scoped R2 URLs', () => {
+    expect(buildFiscalBundleUrls('https://r2.example.com/fiscal/', 'nbs')).toEqual({
+      metadataUrl: 'https://r2.example.com/fiscal/nbs/nbs.meta.json',
+      encryptedUrl: 'https://r2.example.com/fiscal/nbs/nbs.enc',
+    });
+  });
+
+  it('sanitizes source metadata with encrypted bundle URL requirements', () => {
+    expect(
+      sanitizeOfflineSourceMetadata('nesh', {
+        version: '2026.05.06.120000',
+        size_bytes: 123,
+        sha256: 'plain',
+        encrypted_sha256: 'encrypted',
+        built_at: '2026-05-06T12:00:00Z',
+        format_version: 1,
+        chunk_size: 65536,
+        pbkdf2_iterations: 600000,
+      }),
+    ).toMatchObject({
+      source: 'nesh',
+      version: '2026.05.06.120000',
+      encrypted_sha256: 'encrypted',
+      size_bytes: 123,
+    });
+  });
+
+  it('rejects unknown source ids', () => {
+    expect(isFiscalSourceId('nesh')).toBe(true);
+    expect(isFiscalSourceId('render')).toBe(false);
+  });
+
+  it('rejects source metadata without encrypted hashes or known source ids', () => {
+    expect(
+      sanitizeOfflineSourceMetadata('tipi', {
+        version: '2026.05.06.120000',
+        size_bytes: 123,
+        sha256: 'plain',
+      }),
+    ).toBeNull();
+
+    expect(
+      sanitizeOfflineSourceMetadata('render', {
+        version: '2026.05.06.120000',
+        size_bytes: 123,
+        sha256: 'plain',
+        encrypted_sha256: 'encrypted',
+      }),
+    ).toBeNull();
+  });
+
+  it('keeps bundle source ids separate from currently searchable documents', () => {
+    expectTypeOf<'unspsc'>().toExtend<OfflineFiscalSourceId>();
+    expectTypeOf<'unspsc'>().not.toExtend<OfflineSearchDocumentType>();
+    expectTypeOf<OfflineDocumentType>().toEqualTypeOf<OfflineSearchDocumentType>();
+  });
+});

--- a/uv.lock
+++ b/uv.lock
@@ -867,14 +867,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Resumo
- Define contrato source-aware para bases fiscais offline
- Separa fontes fiscais baixáveis de fontes pesquisáveis
- Adiciona testes unitários do contrato de fontes

## Checks
- npm test -- tests/unit/offlineSources.test.ts
- npm run type-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple offline fiscal sources with stronger type checks.
  * Introduced source-aware metadata handling and deterministic bundle URL construction.
  * Broadcast messages now include sender identifiers and typed source fields for better delivery filtering.

* **Tests**
  * Added unit tests for fiscal sources, URL construction, metadata sanitization, and related type assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->