### PR TITLE
feat: build fiscal R2 bundles by source

### DIFF
--- a/scripts/build_offline_db.py
+++ b/scripts/build_offline_db.py
@@ -57,6 +57,8 @@ CHUNK_SIZE = 65536  # 64 KB per encrypted chunk
 PBKDF2_ITERATIONS = 600_000
 MAGIC = b"FCDB"  # File magic bytes
 FORMAT_VERSION = 1
+VERSION_TIMESTAMP_FORMAT = "%Y.%m.%d.%H%M%S"
+BUILT_AT_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 # The app seed is delivered by the authenticated token endpoint and is not
 # embedded in the frontend bundle.
 
@@ -198,8 +200,8 @@ def _initialize_output_db(output_path: Path) -> sqlite3.Connection:
 
 
 def _create_db_metadata(cursor: sqlite3.Cursor, source: str) -> tuple[str, str]:
-    version = time.strftime("%Y.%m.%d.%H%M%S", time.gmtime())
-    built_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    version = time.strftime(VERSION_TIMESTAMP_FORMAT, time.gmtime())
+    built_at = time.strftime(BUILT_AT_TIMESTAMP_FORMAT, time.gmtime())
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS db_metadata (
             key TEXT PRIMARY KEY,
@@ -250,12 +252,12 @@ def _read_output_metadata(output_path: Path) -> tuple[str, str]:
     version = (
         version_row[0]
         if version_row
-        else time.strftime("%Y.%m.%d.%H%M%S", time.gmtime())
+        else time.strftime(VERSION_TIMESTAMP_FORMAT, time.gmtime())
     )
     built_at = (
         built_row[0]
         if built_row
-        else time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        else time.strftime(BUILT_AT_TIMESTAMP_FORMAT, time.gmtime())
     )
     return version, built_at
 
@@ -557,12 +559,12 @@ def _consolidate_databases(output_path: Path) -> None:
     conn.commit()
 
     # === Insert metadata ===
-    version = time.strftime("%Y.%m.%d.%H%M%S", time.gmtime())
+    version = time.strftime(VERSION_TIMESTAMP_FORMAT, time.gmtime())
     cursor.executemany(
         "INSERT INTO db_metadata (key, value) VALUES (?, ?)",
         [
             ("version", version),
-            ("built_at", time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())),
+            ("built_at", time.strftime(BUILT_AT_TIMESTAMP_FORMAT, time.gmtime())),
         ],
     )
     conn.commit()
@@ -1118,7 +1120,7 @@ def main() -> int:
     version = (
         version_row[0]
         if version_row
-        else time.strftime("%Y.%m.%d.%H%M%S", time.gmtime())
+        else time.strftime(VERSION_TIMESTAMP_FORMAT, time.gmtime())
     )
 
     cursor.execute("SELECT value FROM db_metadata WHERE key = 'built_at'")
@@ -1126,7 +1128,7 @@ def main() -> int:
     built_at = (
         built_row[0]
         if built_row
-        else time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        else time.strftime(BUILT_AT_TIMESTAMP_FORMAT, time.gmtime())
     )
     conn.close()
 

--- a/scripts/build_offline_db.py
+++ b/scripts/build_offline_db.py
@@ -609,7 +609,9 @@ def _consolidate_databases(output_path: Path) -> None:
 
 def _require_source_db(source: str, db_path: Path) -> None:
     if not db_path.exists():
-        raise RuntimeError(f"Missing required {source.upper()} DB input: {db_path.name}")
+        raise RuntimeError(
+            f"Missing required {source.upper()} DB input: {db_path.name}"
+        )
 
 
 def _consolidate_nbs_database(output_path: Path) -> None:
@@ -1072,7 +1074,9 @@ def build_source_bundle(
     consolidator = SOURCE_CONSOLIDATORS.get(source_id)
     if consolidator is None:
         supported = ", ".join(sorted(SOURCE_CONSOLIDATORS))
-        raise ValueError(f"Unsupported fiscal source '{source}'. Expected one of: {supported}")
+        raise ValueError(
+            f"Unsupported fiscal source '{source}'. Expected one of: {supported}"
+        )
 
     encrypted_path.parent.mkdir(parents=True, exist_ok=True)
     metadata_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/build_offline_db.py
+++ b/scripts/build_offline_db.py
@@ -23,6 +23,7 @@ import sqlite3
 import struct
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 try:
@@ -43,6 +44,7 @@ DB_DIR = PROJECT_ROOT / "database"
 NESH_DB = DB_DIR / "nesh.db"
 TIPI_DB = DB_DIR / "tipi.db"
 SERVICES_DB = DB_DIR / "services.db"
+UNSPSC_DB = DB_DIR / "unspsc.db"
 
 OUTPUT_DB = DB_DIR / "fiscal_offline.db"
 OUTPUT_ENCRYPTED = DB_DIR / "fiscal_offline.enc"
@@ -57,6 +59,16 @@ MAGIC = b"FCDB"  # File magic bytes
 FORMAT_VERSION = 1
 # The app seed is delivered by the authenticated token endpoint and is not
 # embedded in the frontend bundle.
+
+
+@dataclass(frozen=True)
+class OfflineBundleOutput:
+    source: str
+    encrypted_path: Path
+    metadata_path: Path
+    version: str
+    built_at: str
+    size_bytes: int
 
 
 def _log(msg: str) -> None:
@@ -162,6 +174,83 @@ def _render_nesh_chapter_html(
         "secoes": _build_nesh_sections(notes_row),
     }
     return html_renderer.render_chapter(chapter_payload)
+
+
+def _initialize_output_db(output_path: Path) -> sqlite3.Connection:
+    if output_path.exists():
+        output_path.unlink()
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(output_path))
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+    cursor.execute("PRAGMA journal_mode=WAL")
+    cursor.execute("PRAGMA synchronous=OFF")
+    cursor.execute("PRAGMA page_size=4096")
+    return conn
+
+
+def _create_db_metadata(cursor: sqlite3.Cursor, source: str) -> tuple[str, str]:
+    version = time.strftime("%Y.%m.%d.%H%M%S", time.gmtime())
+    built_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS db_metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+    """)
+    cursor.executemany(
+        "INSERT OR REPLACE INTO db_metadata (key, value) VALUES (?, ?)",
+        [
+            ("source", source),
+            ("version", version),
+            ("built_at", built_at),
+        ],
+    )
+    return version, built_at
+
+
+def _finalize_output_db(conn: sqlite3.Connection, output_path: Path) -> None:
+    cursor = conn.cursor()
+    _log("Running VACUUM...")
+    cursor.execute("PRAGMA journal_mode=DELETE")
+    cursor.execute("PRAGMA synchronous=FULL")
+    conn.commit()
+    cursor.execute("VACUUM")
+    conn.commit()
+
+    _log("Running integrity_check post-VACUUM...")
+    cursor.execute("PRAGMA integrity_check")
+    integrity_result = cursor.fetchone()
+    if integrity_result and integrity_result[0] != "ok":
+        raise RuntimeError(f"Integrity check failed: {integrity_result[0]}")
+    _log("  Integrity: OK")
+
+    conn.close()
+    size_kb = output_path.stat().st_size / 1024
+    _log(f"Consolidated DB: {size_kb:.1f} KB")
+
+
+def _read_output_metadata(output_path: Path) -> tuple[str, str]:
+    conn = sqlite3.connect(str(output_path))
+    cursor = conn.cursor()
+    cursor.execute("SELECT value FROM db_metadata WHERE key = 'version'")
+    version_row = cursor.fetchone()
+    cursor.execute("SELECT value FROM db_metadata WHERE key = 'built_at'")
+    built_row = cursor.fetchone()
+    conn.close()
+
+    version = (
+        version_row[0]
+        if version_row
+        else time.strftime("%Y.%m.%d.%H%M%S", time.gmtime())
+    )
+    built_at = (
+        built_row[0]
+        if built_row
+        else time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    )
+    return version, built_at
 
 
 # ---------------------------------------------------------------------------
@@ -518,6 +607,367 @@ def _consolidate_databases(output_path: Path) -> None:
     _log(f"Consolidated DB: {size_kb:.1f} KB")
 
 
+def _require_source_db(source: str, db_path: Path) -> None:
+    if not db_path.exists():
+        raise RuntimeError(f"Missing required {source.upper()} DB input: {db_path.name}")
+
+
+def _consolidate_nbs_database(output_path: Path) -> None:
+    _require_source_db("nbs", SERVICES_DB)
+    conn = _initialize_output_db(output_path)
+    cursor = conn.cursor()
+
+    cursor.execute("""
+        CREATE TABLE nbs_items (
+            code TEXT PRIMARY KEY,
+            code_clean TEXT NOT NULL,
+            description TEXT NOT NULL,
+            parent_code TEXT,
+            level INTEGER NOT NULL DEFAULT 0,
+            has_nebs INTEGER NOT NULL DEFAULT 0,
+            source_order INTEGER
+        )
+    """)
+    cursor.execute("CREATE INDEX idx_nbs_code_clean ON nbs_items(code_clean)")
+    cursor.execute("CREATE INDEX idx_nbs_parent ON nbs_items(parent_code)")
+    cursor.execute("""
+        CREATE TABLE nebs_entries (
+            code TEXT PRIMARY KEY,
+            code_clean TEXT NOT NULL,
+            title TEXT NOT NULL,
+            body_text TEXT,
+            body_markdown TEXT,
+            title_normalized TEXT,
+            body_normalized TEXT,
+            section_title TEXT,
+            page_start INTEGER,
+            page_end INTEGER
+        )
+    """)
+    cursor.execute("CREATE INDEX idx_nebs_code_clean ON nebs_entries(code_clean)")
+    _create_db_metadata(cursor, "nbs")
+    conn.commit()
+
+    cursor.execute("ATTACH DATABASE ? AS svc", (str(SERVICES_DB),))  # nosec B608
+    cursor.execute("""
+        INSERT OR IGNORE INTO nbs_items
+            (code, code_clean, description, parent_code, level, has_nebs, source_order)
+        SELECT code, code_clean, description, parent_code, level,
+               has_nebs, source_order
+        FROM svc.nbs_items
+    """)
+    cursor.execute(
+        "SELECT 1 FROM svc.sqlite_master WHERE type='table' AND name='nebs_entries' LIMIT 1"
+    )
+    if cursor.fetchone():
+        cursor.execute("""
+            INSERT OR IGNORE INTO nebs_entries
+                (
+                    code,
+                    code_clean,
+                    title,
+                    body_text,
+                    body_markdown,
+                    title_normalized,
+                    body_normalized,
+                    section_title,
+                    page_start,
+                    page_end
+                )
+            SELECT
+                code,
+                code_clean,
+                title,
+                body_text,
+                body_markdown,
+                title_normalized,
+                body_normalized,
+                section_title,
+                page_start,
+                page_end
+            FROM svc.nebs_entries
+        """)
+    conn.commit()
+    cursor.execute("DETACH DATABASE svc")
+
+    cursor.execute("""
+        CREATE VIRTUAL TABLE nbs_fts USING fts5(
+            code, code_clean, description,
+            content='nbs_items',
+            content_rowid='rowid'
+        )
+    """)
+    cursor.execute("INSERT INTO nbs_fts(nbs_fts) VALUES('rebuild')")
+    cursor.execute("""
+        CREATE VIRTUAL TABLE nebs_fts USING fts5(
+            code, code_clean, title, body_text,
+            content='nebs_entries',
+            content_rowid='rowid'
+        )
+    """)
+    cursor.execute("INSERT INTO nebs_fts(nebs_fts) VALUES('rebuild')")
+    conn.commit()
+    _finalize_output_db(conn, output_path)
+
+
+def _consolidate_tipi_database(output_path: Path) -> None:
+    _require_source_db("tipi", TIPI_DB)
+    conn = _initialize_output_db(output_path)
+    cursor = conn.cursor()
+
+    cursor.execute("""
+        CREATE TABLE tipi_positions (
+            ncm TEXT PRIMARY KEY,
+            capitulo TEXT NOT NULL,
+            descricao TEXT NOT NULL,
+            aliquota TEXT,
+            nivel INTEGER DEFAULT 0,
+            ncm_sort TEXT
+        )
+    """)
+    cursor.execute("CREATE INDEX idx_tipi_cap ON tipi_positions(capitulo)")
+    _create_db_metadata(cursor, "tipi")
+    conn.commit()
+
+    cursor.execute("ATTACH DATABASE ? AS tipi", (str(TIPI_DB),))  # nosec B608
+    cursor.execute("""
+        INSERT OR IGNORE INTO tipi_positions
+            (ncm, capitulo, descricao, aliquota, nivel, ncm_sort)
+        SELECT ncm, capitulo, descricao, aliquota, nivel, ncm_sort
+        FROM tipi.tipi_positions
+    """)
+    conn.commit()
+    cursor.execute("DETACH DATABASE tipi")
+
+    cursor.execute("""
+        CREATE VIRTUAL TABLE tipi_fts USING fts5(
+            ncm, descricao, aliquota,
+            content='tipi_positions',
+            content_rowid='rowid'
+        )
+    """)
+    cursor.execute("INSERT INTO tipi_fts(tipi_fts) VALUES('rebuild')")
+    conn.commit()
+    _finalize_output_db(conn, output_path)
+
+
+def _consolidate_nesh_database(output_path: Path) -> None:
+    _require_source_db("nesh", NESH_DB)
+    conn = _initialize_output_db(output_path)
+    cursor = conn.cursor()
+
+    cursor.execute("""
+        CREATE TABLE nesh_positions (
+            codigo TEXT PRIMARY KEY,
+            descricao TEXT NOT NULL,
+            chapter_num TEXT NOT NULL
+        )
+    """)
+    cursor.execute("CREATE INDEX idx_nesh_chapter ON nesh_positions(chapter_num)")
+    cursor.execute("""
+        CREATE TABLE nesh_chapters (
+            chapter_num TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            rendered_html TEXT
+        )
+    """)
+    cursor.execute("""
+        CREATE TABLE nesh_chapter_notes (
+            chapter_num TEXT PRIMARY KEY,
+            notes_content TEXT,
+            titulo TEXT,
+            notas TEXT,
+            consideracoes TEXT,
+            definicoes TEXT,
+            parsed_notes_json TEXT
+        )
+    """)
+    _create_db_metadata(cursor, "nesh")
+    conn.commit()
+
+    cursor.execute("ATTACH DATABASE ? AS nesh", (str(NESH_DB),))  # nosec B608
+    cursor.execute("""
+        INSERT OR IGNORE INTO nesh_positions (codigo, descricao, chapter_num)
+        SELECT codigo, descricao, chapter_num
+        FROM nesh.positions
+    """)
+
+    cursor.execute("""
+        SELECT 1 FROM nesh.sqlite_master
+        WHERE type='table' AND name='chapter_notes' LIMIT 1
+    """)
+    has_notes_table = cursor.fetchone() is not None
+
+    notes_by_chapter: dict[str, sqlite3.Row] = {}
+    if has_notes_table:
+        for row in conn.execute(
+            """
+            SELECT chapter_num, notes_content, titulo, notas,
+                   consideracoes, definicoes, parsed_notes_json
+            FROM nesh.chapter_notes
+            """
+        ):
+            notes_by_chapter[str(row["chapter_num"])] = row
+
+    positions_by_chapter: dict[str, list[sqlite3.Row]] = {}
+    for row in conn.execute(
+        """
+        SELECT chapter_num, codigo, descricao
+        FROM nesh.positions
+        ORDER BY chapter_num, codigo
+        """
+    ):
+        positions_by_chapter.setdefault(str(row["chapter_num"]), []).append(row)
+
+    chapter_rows = conn.execute(
+        """
+        SELECT chapter_num, content
+        FROM nesh.chapters
+        ORDER BY chapter_num
+        """
+    ).fetchall()
+    cursor.executemany(
+        """
+        INSERT OR IGNORE INTO nesh_chapters (chapter_num, content, rendered_html)
+        VALUES (?, ?, ?)
+        """,
+        [
+            (
+                str(row["chapter_num"]),
+                row["content"],
+                _render_nesh_chapter_html(
+                    row,
+                    notes_by_chapter.get(str(row["chapter_num"])),
+                    positions_by_chapter.get(str(row["chapter_num"]), []),
+                ),
+            )
+            for row in chapter_rows
+        ],
+    )
+    if has_notes_table:
+        cursor.execute("""
+            INSERT OR IGNORE INTO nesh_chapter_notes
+                (chapter_num, notes_content, titulo, notas,
+                 consideracoes, definicoes, parsed_notes_json)
+            SELECT chapter_num, notes_content, titulo, notas,
+                   consideracoes, definicoes, parsed_notes_json
+            FROM nesh.chapter_notes
+        """)
+    conn.commit()
+    cursor.execute("DETACH DATABASE nesh")
+
+    cursor.execute("""
+        CREATE VIRTUAL TABLE nesh_fts USING fts5(
+            codigo, descricao,
+            content='nesh_positions',
+            content_rowid='rowid'
+        )
+    """)
+    cursor.execute("INSERT INTO nesh_fts(nesh_fts) VALUES('rebuild')")
+    conn.commit()
+    _finalize_output_db(conn, output_path)
+
+
+def _source_columns(cursor: sqlite3.Cursor, attached_db: str, table: str) -> set[str]:
+    return {
+        str(row[1])
+        for row in cursor.execute(f"PRAGMA {attached_db}.table_info({table})")
+    }
+
+
+def _source_text_expr(columns: set[str], column: str, fallback: str = "NULL") -> str:
+    if column in columns:
+        return column
+    return fallback
+
+
+def _consolidate_unspsc_database(output_path: Path) -> None:
+    conn = _initialize_output_db(output_path)
+    cursor = conn.cursor()
+
+    cursor.execute("""
+        CREATE TABLE unspsc_items (
+            code TEXT PRIMARY KEY,
+            code_clean TEXT NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT,
+            segment TEXT,
+            family TEXT,
+            class TEXT,
+            commodity TEXT
+        )
+    """)
+    cursor.execute("CREATE INDEX idx_unspsc_code_clean ON unspsc_items(code_clean)")
+    _create_db_metadata(cursor, "unspsc")
+    conn.commit()
+
+    if UNSPSC_DB.exists():
+        cursor.execute("ATTACH DATABASE ? AS unspsc", (str(UNSPSC_DB),))  # nosec B608
+        cursor.execute("""
+            SELECT 1 FROM unspsc.sqlite_master
+            WHERE type='table' AND name='unspsc_items' LIMIT 1
+        """)
+        if cursor.fetchone():
+            columns = _source_columns(cursor, "unspsc", "unspsc_items")
+            code_clean_fallback = "code" if "code" in columns else "''"
+            title_fallback = "description" if "description" in columns else "NULL"
+            code_clean_expr = _source_text_expr(
+                columns,
+                "code_clean",
+                code_clean_fallback,
+            )
+            title_expr = _source_text_expr(columns, "title", title_fallback)
+            description_expr = _source_text_expr(columns, "description")
+            segment_expr = _source_text_expr(columns, "segment")
+            family_expr = _source_text_expr(columns, "family")
+            class_expr = _source_text_expr(columns, "class")
+            commodity_expr = _source_text_expr(columns, "commodity")
+            cursor.execute(f"""
+                INSERT OR IGNORE INTO unspsc_items
+                    (
+                        code,
+                        code_clean,
+                        title,
+                        description,
+                        segment,
+                        family,
+                        class,
+                        commodity
+                    )
+                SELECT
+                    code,
+                    COALESCE({code_clean_expr}, code),
+                    COALESCE({title_expr}, ''),
+                    {description_expr},
+                    {segment_expr},
+                    {family_expr},
+                    {class_expr},
+                    {commodity_expr}
+                FROM unspsc.unspsc_items
+            """)  # nosec B608
+        conn.commit()
+        cursor.execute("DETACH DATABASE unspsc")
+
+    cursor.execute("""
+        CREATE VIRTUAL TABLE unspsc_fts USING fts5(
+            code, code_clean, title, description,
+            content='unspsc_items',
+            content_rowid='rowid'
+        )
+    """)
+    cursor.execute("INSERT INTO unspsc_fts(unspsc_fts) VALUES('rebuild')")
+    conn.commit()
+    _finalize_output_db(conn, output_path)
+
+
+SOURCE_CONSOLIDATORS = {
+    "nbs": _consolidate_nbs_database,
+    "nesh": _consolidate_nesh_database,
+    "tipi": _consolidate_tipi_database,
+    "unspsc": _consolidate_unspsc_database,
+}
+
+
 # ---------------------------------------------------------------------------
 # Step 2: Encrypt the database file with AES-256-GCM
 # ---------------------------------------------------------------------------
@@ -588,6 +1038,69 @@ def _encrypt_database(plaintext_path: Path, encrypted_path: Path) -> dict:
     }
 
 
+def _write_bundle_metadata(
+    source: str,
+    plaintext_path: Path,
+    metadata_path: Path,
+    crypto_info: dict,
+) -> tuple[str, str]:
+    version, built_at = _read_output_metadata(plaintext_path)
+    meta = {
+        "source": source,
+        "version": version,
+        "sha256": crypto_info["sha256"],
+        "encrypted_sha256": crypto_info["encrypted_sha256"],
+        "salt": crypto_info["salt"],
+        "size_bytes": crypto_info["size_bytes"],
+        "chunks": crypto_info["chunks"],
+        "built_at": built_at,
+        "format_version": FORMAT_VERSION,
+        "chunk_size": CHUNK_SIZE,
+        "pbkdf2_iterations": PBKDF2_ITERATIONS,
+    }
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    return version, built_at
+
+
+def build_source_bundle(
+    source: str,
+    encrypted_path: Path,
+    metadata_path: Path,
+) -> OfflineBundleOutput:
+    source_id = source.strip().lower()
+    consolidator = SOURCE_CONSOLIDATORS.get(source_id)
+    if consolidator is None:
+        supported = ", ".join(sorted(SOURCE_CONSOLIDATORS))
+        raise ValueError(f"Unsupported fiscal source '{source}'. Expected one of: {supported}")
+
+    encrypted_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    plaintext_path = encrypted_path.with_suffix(".db")
+
+    _log(f"Building {source_id.upper()} source bundle...")
+    consolidator(plaintext_path)
+    try:
+        crypto_info = _encrypt_database(plaintext_path, encrypted_path)
+        version, built_at = _write_bundle_metadata(
+            source_id,
+            plaintext_path,
+            metadata_path,
+            crypto_info,
+        )
+    finally:
+        plaintext_path.unlink(missing_ok=True)
+
+    return OfflineBundleOutput(
+        source=source_id,
+        encrypted_path=encrypted_path,
+        metadata_path=metadata_path,
+        version=version,
+        built_at=built_at,
+        size_bytes=int(crypto_info["size_bytes"]),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -641,7 +1154,6 @@ def main() -> int:
         "format_version": FORMAT_VERSION,
         "chunk_size": CHUNK_SIZE,
         "pbkdf2_iterations": PBKDF2_ITERATIONS,
-        "app_seed": APP_SEED,
     }
     OUTPUT_META.write_text(json.dumps(meta, indent=2), encoding="utf-8")
     _log(f"Metadata written to {OUTPUT_META}")

--- a/scripts/build_offline_db.py
+++ b/scripts/build_offline_db.py
@@ -90,7 +90,14 @@ def _resolve_app_seed() -> str:
     return generated
 
 
-APP_SEED = _resolve_app_seed()
+_APP_SEED: str | None = None
+
+
+def _get_app_seed() -> str:
+    global _APP_SEED
+    if _APP_SEED is None:
+        _APP_SEED = _resolve_app_seed()
+    return _APP_SEED
 
 
 def _get_html_renderer():
@@ -460,32 +467,26 @@ def _consolidate_databases(output_path: Path) -> None:
 
     notes_by_chapter: dict[str, sqlite3.Row] = {}
     if has_notes_table:
-        for row in conn.execute(
-            """
+        for row in conn.execute("""
             SELECT chapter_num, notes_content, titulo, notas,
                    consideracoes, definicoes, parsed_notes_json
             FROM nesh.chapter_notes
-            """
-        ):
+            """):
             notes_by_chapter[str(row["chapter_num"])] = row
 
     positions_by_chapter: dict[str, list[sqlite3.Row]] = {}
-    for row in conn.execute(
-        """
+    for row in conn.execute("""
         SELECT chapter_num, codigo, descricao
         FROM nesh.positions
         ORDER BY chapter_num, codigo
-        """
-    ):
+        """):
         positions_by_chapter.setdefault(str(row["chapter_num"]), []).append(row)
 
-    chapter_rows = conn.execute(
-        """
+    chapter_rows = conn.execute("""
         SELECT chapter_num, content
         FROM nesh.chapters
         ORDER BY chapter_num
-        """
-    ).fetchall()
+        """).fetchall()
     cursor.executemany(
         """
         INSERT OR IGNORE INTO nesh_chapters (chapter_num, content, rendered_html)
@@ -802,32 +803,26 @@ def _consolidate_nesh_database(output_path: Path) -> None:
 
     notes_by_chapter: dict[str, sqlite3.Row] = {}
     if has_notes_table:
-        for row in conn.execute(
-            """
+        for row in conn.execute("""
             SELECT chapter_num, notes_content, titulo, notas,
                    consideracoes, definicoes, parsed_notes_json
             FROM nesh.chapter_notes
-            """
-        ):
+            """):
             notes_by_chapter[str(row["chapter_num"])] = row
 
     positions_by_chapter: dict[str, list[sqlite3.Row]] = {}
-    for row in conn.execute(
-        """
+    for row in conn.execute("""
         SELECT chapter_num, codigo, descricao
         FROM nesh.positions
         ORDER BY chapter_num, codigo
-        """
-    ):
+        """):
         positions_by_chapter.setdefault(str(row["chapter_num"]), []).append(row)
 
-    chapter_rows = conn.execute(
-        """
+    chapter_rows = conn.execute("""
         SELECT chapter_num, content
         FROM nesh.chapters
         ORDER BY chapter_num
-        """
-    ).fetchall()
+        """).fetchall()
     cursor.executemany(
         """
         INSERT OR IGNORE INTO nesh_chapters (chapter_num, content, rendered_html)
@@ -981,7 +976,7 @@ def _derive_key(salt: bytes) -> bytes:
         salt=salt,
         iterations=PBKDF2_ITERATIONS,
     )
-    return kdf.derive(APP_SEED.encode("utf-8"))
+    return kdf.derive(_get_app_seed().encode("utf-8"))
 
 
 def _compute_hmac(data: bytes, key: bytes) -> bytes:

--- a/scripts/build_offline_db.py
+++ b/scripts/build_offline_db.py
@@ -465,28 +465,9 @@ def _consolidate_databases(output_path: Path) -> None:
     """)
     has_notes_table = cursor.fetchone() is not None
 
-    notes_by_chapter: dict[str, sqlite3.Row] = {}
-    if has_notes_table:
-        for row in conn.execute("""
-            SELECT chapter_num, notes_content, titulo, notas,
-                   consideracoes, definicoes, parsed_notes_json
-            FROM nesh.chapter_notes
-            """):
-            notes_by_chapter[str(row["chapter_num"])] = row
-
-    positions_by_chapter: dict[str, list[sqlite3.Row]] = {}
-    for row in conn.execute("""
-        SELECT chapter_num, codigo, descricao
-        FROM nesh.positions
-        ORDER BY chapter_num, codigo
-        """):
-        positions_by_chapter.setdefault(str(row["chapter_num"]), []).append(row)
-
-    chapter_rows = conn.execute("""
-        SELECT chapter_num, content
-        FROM nesh.chapters
-        ORDER BY chapter_num
-        """).fetchall()
+    notes_by_chapter, positions_by_chapter, chapter_rows = _load_nesh_render_context(
+        conn, has_notes_table
+    )
     cursor.executemany(
         """
         INSERT OR IGNORE INTO nesh_chapters (chapter_num, content, rendered_html)
@@ -606,6 +587,35 @@ def _consolidate_databases(output_path: Path) -> None:
 
     size_kb = output_path.stat().st_size / 1024
     _log(f"Consolidated DB: {size_kb:.1f} KB")
+
+
+def _load_nesh_render_context(
+    conn: sqlite3.Connection,
+    has_notes_table: bool,
+) -> tuple[dict[str, sqlite3.Row], dict[str, list[sqlite3.Row]], list[sqlite3.Row]]:
+    notes_by_chapter: dict[str, sqlite3.Row] = {}
+    if has_notes_table:
+        for row in conn.execute("""
+            SELECT chapter_num, notes_content, titulo, notas,
+                   consideracoes, definicoes, parsed_notes_json
+            FROM nesh.chapter_notes
+            """):
+            notes_by_chapter[str(row["chapter_num"])] = row
+
+    positions_by_chapter: dict[str, list[sqlite3.Row]] = {}
+    for row in conn.execute("""
+        SELECT chapter_num, codigo, descricao
+        FROM nesh.positions
+        ORDER BY chapter_num, codigo
+        """):
+        positions_by_chapter.setdefault(str(row["chapter_num"]), []).append(row)
+
+    chapter_rows = conn.execute("""
+        SELECT chapter_num, content
+        FROM nesh.chapters
+        ORDER BY chapter_num
+        """).fetchall()
+    return notes_by_chapter, positions_by_chapter, chapter_rows
 
 
 def _require_source_db(source: str, db_path: Path) -> None:
@@ -801,28 +811,9 @@ def _consolidate_nesh_database(output_path: Path) -> None:
     """)
     has_notes_table = cursor.fetchone() is not None
 
-    notes_by_chapter: dict[str, sqlite3.Row] = {}
-    if has_notes_table:
-        for row in conn.execute("""
-            SELECT chapter_num, notes_content, titulo, notas,
-                   consideracoes, definicoes, parsed_notes_json
-            FROM nesh.chapter_notes
-            """):
-            notes_by_chapter[str(row["chapter_num"])] = row
-
-    positions_by_chapter: dict[str, list[sqlite3.Row]] = {}
-    for row in conn.execute("""
-        SELECT chapter_num, codigo, descricao
-        FROM nesh.positions
-        ORDER BY chapter_num, codigo
-        """):
-        positions_by_chapter.setdefault(str(row["chapter_num"]), []).append(row)
-
-    chapter_rows = conn.execute("""
-        SELECT chapter_num, content
-        FROM nesh.chapters
-        ORDER BY chapter_num
-        """).fetchall()
+    notes_by_chapter, positions_by_chapter, chapter_rows = _load_nesh_render_context(
+        conn, has_notes_table
+    )
     cursor.executemany(
         """
         INSERT OR IGNORE INTO nesh_chapters (chapter_num, content, rendered_html)

--- a/scripts/build_r2_fiscal_bundles.py
+++ b/scripts/build_r2_fiscal_bundles.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 from scripts.build_offline_db import DB_DIR, OfflineBundleOutput, build_source_bundle
 
-
 DEFAULT_OUTPUT_ROOT = DB_DIR / "r2"
 
 

--- a/scripts/build_r2_fiscal_bundles.py
+++ b/scripts/build_r2_fiscal_bundles.py
@@ -1,0 +1,72 @@
+"""
+Build R2-ready per-source fiscal bundles.
+
+Each fiscal source is written to its own directory:
+    database/r2/<source>/<source>.enc
+    database/r2/<source>/<source>.meta.json
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from scripts.build_offline_db import DB_DIR, OfflineBundleOutput, build_source_bundle
+
+
+DEFAULT_OUTPUT_ROOT = DB_DIR / "r2"
+
+
+@dataclass(frozen=True)
+class FiscalSource:
+    id: str
+
+
+@dataclass(frozen=True)
+class BundlePaths:
+    output_dir: Path
+    encrypted: Path
+    metadata: Path
+
+
+FISCAL_SOURCES = [
+    FiscalSource("nesh"),
+    FiscalSource("tipi"),
+    FiscalSource("nbs"),
+    FiscalSource("unspsc"),
+]
+
+
+def resolve_bundle_paths(output_root: Path, source: str) -> BundlePaths:
+    source_id = source.strip().lower()
+    output_dir = output_root / source_id
+    return BundlePaths(
+        output_dir=output_dir,
+        encrypted=output_dir / f"{source_id}.enc",
+        metadata=output_dir / f"{source_id}.meta.json",
+    )
+
+
+def build_all(output_root: Path = DEFAULT_OUTPUT_ROOT) -> list[OfflineBundleOutput]:
+    outputs: list[OfflineBundleOutput] = []
+    for source in FISCAL_SOURCES:
+        paths = resolve_bundle_paths(output_root, source.id)
+        outputs.append(
+            build_source_bundle(
+                source.id,
+                paths.encrypted,
+                paths.metadata,
+            )
+        )
+    return outputs
+
+
+def main() -> int:
+    outputs = build_all()
+    for output in outputs:
+        print(f"{output.source}: {output.encrypted_path} ({output.size_bytes} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_build_r2_fiscal_bundles.py
+++ b/tests/unit/test_build_r2_fiscal_bundles.py
@@ -2,8 +2,7 @@ import json
 import sqlite3
 from pathlib import Path
 
-from scripts import build_r2_fiscal_bundles
-from scripts import build_offline_db
+from scripts import build_offline_db, build_r2_fiscal_bundles
 from scripts.build_r2_fiscal_bundles import (
     DEFAULT_OUTPUT_ROOT,
     FISCAL_SOURCES,

--- a/tests/unit/test_build_r2_fiscal_bundles.py
+++ b/tests/unit/test_build_r2_fiscal_bundles.py
@@ -45,14 +45,20 @@ def test_build_source_bundle_metadata_excludes_app_seed(
 
 def test_legacy_main_metadata_excludes_app_seed(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(build_offline_db, "OUTPUT_DB", tmp_path / "fiscal_offline.db")
-    monkeypatch.setattr(build_offline_db, "OUTPUT_ENCRYPTED", tmp_path / "fiscal_offline.enc")
-    monkeypatch.setattr(build_offline_db, "OUTPUT_META", tmp_path / "fiscal_offline.meta")
+    monkeypatch.setattr(
+        build_offline_db, "OUTPUT_ENCRYPTED", tmp_path / "fiscal_offline.enc"
+    )
+    monkeypatch.setattr(
+        build_offline_db, "OUTPUT_META", tmp_path / "fiscal_offline.meta"
+    )
     monkeypatch.setattr(build_offline_db, "_consolidate_databases", _create_metadata_db)
     monkeypatch.setattr(build_offline_db, "_encrypt_database", _copy_plaintext)
 
     assert build_offline_db.main() == 0
 
-    metadata = json.loads((tmp_path / "fiscal_offline.meta").read_text(encoding="utf-8"))
+    metadata = json.loads(
+        (tmp_path / "fiscal_offline.meta").read_text(encoding="utf-8")
+    )
     assert "app_seed" not in metadata
 
 
@@ -195,7 +201,9 @@ def test_populated_unspsc_uses_safe_fallbacks_for_missing_optional_columns(
 def test_build_all_builds_each_source_with_resolved_paths(tmp_path: Path, monkeypatch):
     calls = []
 
-    def fake_build_source_bundle(source: str, encrypted_path: Path, metadata_path: Path):
+    def fake_build_source_bundle(
+        source: str, encrypted_path: Path, metadata_path: Path
+    ):
         calls.append((source, encrypted_path, metadata_path))
         return build_offline_db.OfflineBundleOutput(
             source=source,

--- a/tests/unit/test_build_r2_fiscal_bundles.py
+++ b/tests/unit/test_build_r2_fiscal_bundles.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 import sqlite3
 from pathlib import Path
 
@@ -272,13 +273,12 @@ def _copy_plaintext(plaintext_path: Path, encrypted_path: Path) -> dict:
     safe_plaintext_path = _resolve_test_bundle_path(plaintext_path, bundle_dir)
     safe_encrypted_path = _resolve_test_bundle_path(encrypted_path, bundle_dir)
 
-    safe_encrypted_path.write_bytes(safe_plaintext_path.read_bytes())
-    payload = safe_encrypted_path.read_bytes()
+    shutil.copyfile(safe_plaintext_path, safe_encrypted_path)  # NOSONAR
     return {
         "sha256": "plain-sha",
         "encrypted_sha256": "encrypted-sha",
         "salt": "salt",
-        "size_bytes": len(payload),
+        "size_bytes": safe_encrypted_path.stat().st_size,
         "chunks": 1,
     }
 

--- a/tests/unit/test_build_r2_fiscal_bundles.py
+++ b/tests/unit/test_build_r2_fiscal_bundles.py
@@ -234,6 +234,18 @@ def test_build_all_builds_each_source_with_resolved_paths(tmp_path: Path, monkey
     ]
 
 
+def test_copy_plaintext_rejects_output_outside_test_bundle_dir(tmp_path: Path):
+    plaintext_path = tmp_path / "unspsc.db"
+    plaintext_path.write_bytes(b"bundle")
+
+    try:
+        _copy_plaintext(plaintext_path, tmp_path.parent / "unspsc.enc")
+    except ValueError as exc:
+        assert str(exc) == "Test bundle paths must stay in the same directory"
+    else:
+        raise AssertionError("Expected path validation failure")
+
+
 def _create_metadata_db(output_path: Path) -> None:
     conn = sqlite3.connect(output_path)
     try:
@@ -256,8 +268,12 @@ def _create_metadata_db(output_path: Path) -> None:
 
 
 def _copy_plaintext(plaintext_path: Path, encrypted_path: Path) -> dict:
-    encrypted_path.write_bytes(plaintext_path.read_bytes())
-    payload = encrypted_path.read_bytes()
+    bundle_dir = plaintext_path.parent.resolve()
+    safe_plaintext_path = _resolve_test_bundle_path(plaintext_path, bundle_dir)
+    safe_encrypted_path = _resolve_test_bundle_path(encrypted_path, bundle_dir)
+
+    safe_encrypted_path.write_bytes(safe_plaintext_path.read_bytes())
+    payload = safe_encrypted_path.read_bytes()
     return {
         "sha256": "plain-sha",
         "encrypted_sha256": "encrypted-sha",
@@ -265,6 +281,13 @@ def _copy_plaintext(plaintext_path: Path, encrypted_path: Path) -> dict:
         "size_bytes": len(payload),
         "chunks": 1,
     }
+
+
+def _resolve_test_bundle_path(path: Path, bundle_dir: Path) -> Path:
+    resolved_path = path.resolve(strict=False)
+    if not resolved_path.is_relative_to(bundle_dir):
+        raise ValueError("Test bundle paths must stay in the same directory")
+    return resolved_path
 
 
 def _fail_encryption(plaintext_path: Path, encrypted_path: Path) -> dict:

--- a/tests/unit/test_build_r2_fiscal_bundles.py
+++ b/tests/unit/test_build_r2_fiscal_bundles.py
@@ -1,0 +1,265 @@
+import json
+import sqlite3
+from pathlib import Path
+
+from scripts import build_r2_fiscal_bundles
+from scripts import build_offline_db
+from scripts.build_r2_fiscal_bundles import (
+    DEFAULT_OUTPUT_ROOT,
+    FISCAL_SOURCES,
+    resolve_bundle_paths,
+)
+
+
+def test_fiscal_sources_are_split_for_r2():
+    assert [source.id for source in FISCAL_SOURCES] == ["nesh", "tipi", "nbs", "unspsc"]
+
+
+def test_resolve_bundle_paths_uses_r2_shape(tmp_path: Path):
+    paths = resolve_bundle_paths(tmp_path, "nesh")
+    assert paths.output_dir == tmp_path / "nesh"
+    assert paths.encrypted == tmp_path / "nesh" / "nesh.enc"
+    assert paths.metadata == tmp_path / "nesh" / "nesh.meta.json"
+
+
+def test_default_output_root_is_database_r2():
+    assert DEFAULT_OUTPUT_ROOT == build_offline_db.DB_DIR / "r2"
+
+
+def test_build_source_bundle_metadata_excludes_app_seed(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.setattr(build_offline_db, "UNSPSC_DB", tmp_path / "missing.db")
+    monkeypatch.setattr(build_offline_db, "_encrypt_database", _copy_plaintext)
+
+    build_offline_db.build_source_bundle(
+        "unspsc",
+        tmp_path / "unspsc.enc",
+        tmp_path / "unspsc.meta.json",
+    )
+
+    metadata = json.loads((tmp_path / "unspsc.meta.json").read_text(encoding="utf-8"))
+    assert "app_seed" not in metadata
+
+
+def test_legacy_main_metadata_excludes_app_seed(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(build_offline_db, "OUTPUT_DB", tmp_path / "fiscal_offline.db")
+    monkeypatch.setattr(build_offline_db, "OUTPUT_ENCRYPTED", tmp_path / "fiscal_offline.enc")
+    monkeypatch.setattr(build_offline_db, "OUTPUT_META", tmp_path / "fiscal_offline.meta")
+    monkeypatch.setattr(build_offline_db, "_consolidate_databases", _create_metadata_db)
+    monkeypatch.setattr(build_offline_db, "_encrypt_database", _copy_plaintext)
+
+    assert build_offline_db.main() == 0
+
+    metadata = json.loads((tmp_path / "fiscal_offline.meta").read_text(encoding="utf-8"))
+    assert "app_seed" not in metadata
+
+
+def test_build_source_bundle_removes_plaintext_when_encryption_fails(
+    tmp_path: Path,
+    monkeypatch,
+):
+    encrypted_path = tmp_path / "unspsc.enc"
+    plaintext_path = tmp_path / "unspsc.db"
+
+    monkeypatch.setattr(build_offline_db, "UNSPSC_DB", tmp_path / "missing.db")
+    monkeypatch.setattr(build_offline_db, "_encrypt_database", _fail_encryption)
+
+    try:
+        build_offline_db.build_source_bundle(
+            "unspsc",
+            encrypted_path,
+            tmp_path / "unspsc.meta.json",
+        )
+    except RuntimeError as exc:
+        assert str(exc) == "encryption failed"
+    else:
+        raise AssertionError("Expected encryption failure")
+
+    assert not plaintext_path.exists()
+
+
+def test_build_source_bundle_creates_empty_unspsc_schema_when_source_missing(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.setattr(build_offline_db, "UNSPSC_DB", tmp_path / "missing.db")
+    monkeypatch.setattr(build_offline_db, "_encrypt_database", _copy_plaintext)
+
+    build_offline_db.build_source_bundle(
+        "unspsc",
+        tmp_path / "unspsc.enc",
+        tmp_path / "unspsc.meta.json",
+    )
+
+    conn = sqlite3.connect(tmp_path / "unspsc.enc")
+    try:
+        table_names = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type IN ('table', 'virtual')"
+            )
+        }
+        metadata_rows = dict(conn.execute("SELECT key, value FROM db_metadata"))
+    finally:
+        conn.close()
+
+    assert {"unspsc_items", "unspsc_fts", "db_metadata"} <= table_names
+    assert metadata_rows["source"] == "unspsc"
+
+
+def test_empty_unspsc_schema_uses_planned_columns(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(build_offline_db, "UNSPSC_DB", tmp_path / "missing.db")
+    monkeypatch.setattr(build_offline_db, "_encrypt_database", _copy_plaintext)
+
+    build_offline_db.build_source_bundle(
+        "unspsc",
+        tmp_path / "unspsc.enc",
+        tmp_path / "unspsc.meta.json",
+    )
+
+    conn = sqlite3.connect(tmp_path / "unspsc.enc")
+    try:
+        columns = [
+            (row[1], row[2], bool(row[3]), bool(row[5]))
+            for row in conn.execute("PRAGMA table_info(unspsc_items)")
+        ]
+    finally:
+        conn.close()
+
+    assert columns == [
+        ("code", "TEXT", False, True),
+        ("code_clean", "TEXT", True, False),
+        ("title", "TEXT", True, False),
+        ("description", "TEXT", False, False),
+        ("segment", "TEXT", False, False),
+        ("family", "TEXT", False, False),
+        ("class", "TEXT", False, False),
+        ("commodity", "TEXT", False, False),
+    ]
+
+
+def test_populated_unspsc_uses_safe_fallbacks_for_missing_optional_columns(
+    tmp_path: Path,
+    monkeypatch,
+):
+    source_db = tmp_path / "unspsc-source.db"
+    conn = sqlite3.connect(source_db)
+    try:
+        conn.execute("""
+            CREATE TABLE unspsc_items (
+                code TEXT PRIMARY KEY,
+                description TEXT
+            )
+        """)
+        conn.execute(
+            "INSERT INTO unspsc_items (code, description) VALUES (?, ?)",
+            ("10101501", "Live bovine cattle"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(build_offline_db, "UNSPSC_DB", source_db)
+    monkeypatch.setattr(build_offline_db, "_encrypt_database", _copy_plaintext)
+
+    build_offline_db.build_source_bundle(
+        "unspsc",
+        tmp_path / "unspsc.enc",
+        tmp_path / "unspsc.meta.json",
+    )
+
+    conn = sqlite3.connect(tmp_path / "unspsc.enc")
+    try:
+        row = conn.execute("""
+            SELECT code, code_clean, title, description,
+                   segment, family, class, commodity
+            FROM unspsc_items
+        """).fetchone()
+    finally:
+        conn.close()
+
+    assert row == (
+        "10101501",
+        "10101501",
+        "Live bovine cattle",
+        "Live bovine cattle",
+        None,
+        None,
+        None,
+        None,
+    )
+
+
+def test_build_all_builds_each_source_with_resolved_paths(tmp_path: Path, monkeypatch):
+    calls = []
+
+    def fake_build_source_bundle(source: str, encrypted_path: Path, metadata_path: Path):
+        calls.append((source, encrypted_path, metadata_path))
+        return build_offline_db.OfflineBundleOutput(
+            source=source,
+            encrypted_path=encrypted_path,
+            metadata_path=metadata_path,
+            version="v",
+            built_at="now",
+            size_bytes=1,
+        )
+
+    monkeypatch.setattr(
+        build_r2_fiscal_bundles,
+        "build_source_bundle",
+        fake_build_source_bundle,
+    )
+
+    outputs = build_r2_fiscal_bundles.build_all(tmp_path)
+
+    assert calls == [
+        (
+            source.id,
+            tmp_path / source.id / f"{source.id}.enc",
+            tmp_path / source.id / f"{source.id}.meta.json",
+        )
+        for source in FISCAL_SOURCES
+    ]
+    assert [output.source for output in outputs] == [
+        source.id for source in FISCAL_SOURCES
+    ]
+
+
+def _create_metadata_db(output_path: Path) -> None:
+    conn = sqlite3.connect(output_path)
+    try:
+        conn.execute("""
+            CREATE TABLE db_metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            )
+        """)
+        conn.executemany(
+            "INSERT INTO db_metadata (key, value) VALUES (?, ?)",
+            [
+                ("version", "test-version"),
+                ("built_at", "2026-05-06T00:00:00Z"),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _copy_plaintext(plaintext_path: Path, encrypted_path: Path) -> dict:
+    encrypted_path.write_bytes(plaintext_path.read_bytes())
+    payload = encrypted_path.read_bytes()
+    return {
+        "sha256": "plain-sha",
+        "encrypted_sha256": "encrypted-sha",
+        "salt": "salt",
+        "size_bytes": len(payload),
+        "chunks": 1,
+    }
+
+
+def _fail_encryption(plaintext_path: Path, encrypted_path: Path) -> dict:
+    assert plaintext_path.exists()
+    raise RuntimeError("encryption failed")


### PR DESCRIPTION
## Resumo
- Gera bundles R2 separados por NESH, TIPI, NBS e UNSPSC
- Mantém metadata por fonte e saída compatível com R2
- Adiciona testes do builder de bundles fiscais

## Checks
- python -m pytest tests/unit/test_build_r2_fiscal_bundles.py --basetemp C:\tmp\pytest-r2-bundles
- python -m py_compile scripts/build_r2_fiscal_bundles.py scripts/build_offline_db.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-source offline bundles for NBS, NESH, TIPI, UNSPSC with individual encrypted files and metadata.
  * New standalone R2-ready build that produces deterministic per-source output paths and reports bundle sizes.

* **Bug Fixes / Reliability**
  * Plaintext intermediates are removed on failure; encryption failures surface and clean up artifacts.
  * Bundling tolerates missing or minimal source DBs, producing valid empty bundles and required tables.
  * Metadata now records build/version/encryption parameters (no app_seed).

* **Tests**
  * Unit tests for bundle paths, metadata, edge cases, encryption failure, and orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->