### PR TITLE
feat: install fiscal bundles from R2

### DIFF
--- a/client/src/context/offlineDatabase.types.ts
+++ b/client/src/context/offlineDatabase.types.ts
@@ -2,7 +2,10 @@ import type {
     NbsCatalogDetailApiResponse,
 } from '../types/api.types';
 import type { FiscalSourceId } from './offlineSources';
-import type { OfflineDatabaseMetadata } from '../utils/offlineDatabase';
+import type {
+    OfflineDatabaseMetadata,
+    OfflineSourceMetadata,
+} from '../utils/offlineDatabase';
 
 export type OfflineDatabaseStatus =
     | 'checking'
@@ -102,12 +105,26 @@ export type OfflineDatabaseWorkerRequest =
     | {
         type: 'INIT';
         id: string | null;
-        payload: { chunkSize: number; pbkdf2Iterations: number; seed?: string };
+        payload:
+            | { chunkSize: number; pbkdf2Iterations: number; seed?: string }
+            | {
+                chunkSize: number;
+                pbkdf2Iterations: number;
+                source: OfflineFiscalSourceId;
+                publicSeed: string;
+            };
     }
     | {
         type: 'INSTALL';
         id: string | null;
-        payload: { apiBase: string; clerkToken?: string | null };
+        payload:
+            | { apiBase: string; clerkToken?: string | null }
+            | {
+                source: OfflineFiscalSourceId;
+                r2BaseUrl: string;
+                publicSeed: string;
+                metadata: OfflineSourceMetadata;
+            };
     }
     | {
         type: 'TOKEN_RESPONSE';
@@ -123,7 +140,7 @@ export type OfflineDatabaseWorkerRequest =
     | {
         type: 'REMOVE';
         id: string | null;
-        payload: Record<string, never>;
+        payload: Record<string, never> | { source: OfflineFiscalSourceId };
     }
     | {
         type: 'SEARCH';

--- a/client/src/context/offlineDatabaseMutations.ts
+++ b/client/src/context/offlineDatabaseMutations.ts
@@ -3,22 +3,42 @@ import { useCallback } from 'react';
 import {
     compareOfflineVersions,
     formatOfflineDatabaseErrorMessage,
+    type OfflineSourceMetadata,
 } from '../utils/offlineDatabase';
 
 import {
     clearOfflineDatabaseInstallLock,
     getOfflineDatabaseInstallLock,
     persistStoredOfflineDatabaseMetadata,
+    persistStoredOfflineSourceMetadata,
     readStoredOfflineDatabaseMetadata,
     runOfflineDatabaseTaskInBackground,
     setOfflineDatabaseInstallLock,
 } from './offlineDatabaseStorage';
-import { getOfflineDatabaseApiBaseUrl, primeOfflineShellCache } from './offlineDatabaseSync';
+import {
+    getFiscalR2BaseUrl,
+    getOfflineDbPublicSeed,
+    getOfflineDatabaseApiBaseUrl,
+    primeOfflineShellCache,
+} from './offlineDatabaseSync';
+import { isFiscalSourceId } from './offlineSources';
 import type { OfflineDatabaseOperations } from './offlineDatabaseOperations.shared';
 import type { OfflineDatabaseOperationsArgs } from './offlineDatabaseOperations.shared';
 
 // Current installs still use the legacy monolithic bundle until source-scoped installs land.
 const LEGACY_MONOLITHIC_BUNDLE_SOURCE = 'nesh';
+
+function isOfflineSourceMetadata(
+    metadata: unknown,
+): metadata is OfflineSourceMetadata {
+    return Boolean(
+        metadata
+        && typeof metadata === 'object'
+        && 'source' in metadata
+        && isFiscalSourceId((metadata as { source?: unknown }).source)
+        && 'encrypted_sha256' in metadata,
+    );
+}
 
 export function useOfflineDatabaseMutations({
     applyInstalledMetadata,
@@ -89,14 +109,30 @@ export function useOfflineDatabaseMutations({
 
             runOfflineDatabaseTaskInBackground(primeOfflineShellCache());
 
+            const r2BaseUrl = getFiscalR2BaseUrl();
+            const publicSeed = getOfflineDbPublicSeed();
+            const installPayload =
+                r2BaseUrl && publicSeed
+                    ? isOfflineSourceMetadata(metadata)
+                        ? {
+                        source: metadata.source,
+                        r2BaseUrl,
+                        publicSeed,
+                        metadata,
+                    }
+                        : (() => {
+                            throw new Error('R2 source metadata unavailable');
+                        })()
+                    : {
+                        apiBase: getOfflineDatabaseApiBaseUrl(),
+                        clerkToken: '',
+                    };
+
             await sendToWorker(
                 {
                     type: 'INSTALL',
                     id: null,
-                    payload: {
-                        apiBase: getOfflineDatabaseApiBaseUrl(),
-                        clerkToken: '',
-                    },
+                    payload: installPayload,
                 },
                 600_000,
             );
@@ -156,11 +192,14 @@ export function useOfflineDatabaseMutations({
                 {
                     type: 'REMOVE',
                     id: null,
-                    payload: {},
+                    payload: getFiscalR2BaseUrl() && getOfflineDbPublicSeed()
+                        ? { source: LEGACY_MONOLITHIC_BUNDLE_SOURCE }
+                        : {},
                 },
                 10_000,
             );
             persistStoredOfflineDatabaseMetadata(null);
+            persistStoredOfflineSourceMetadata(LEGACY_MONOLITHIC_BUNDLE_SOURCE, null);
             sessionStorage.removeItem('offline_db_seed');
             setLocalVersion(null);
             setRemoteVersion(remoteMetadataRef.current?.version ?? null);

--- a/client/src/context/offlineDatabaseRuntime.ts
+++ b/client/src/context/offlineDatabaseRuntime.ts
@@ -10,20 +10,27 @@ import {
     compareOfflineVersions,
     formatOfflineDatabaseErrorMessage,
     type OfflineDatabaseMetadata,
+    type OfflineSourceMetadata,
 } from '../utils/offlineDatabase';
 import {
     buildOfflineDatabaseInitPayload,
     createOfflineDatabaseInstanceId,
     isOfflineDatabaseSupported,
     persistStoredOfflineDatabaseMetadata,
+    persistStoredOfflineSourceMetadata,
     readStoredOfflineDatabaseMetadata,
+    readStoredOfflineSourceMetadata,
     runOfflineDatabaseTaskInBackground,
 } from './offlineDatabaseStorage';
 import {
+    fetchOfflineSourceAvailabilityMetadata,
     fetchOfflineDatabaseAvailabilityMetadata,
+    getFiscalR2BaseUrl,
+    getOfflineDbPublicSeed,
     getOfflineDatabaseApiBaseUrl,
     primeOfflineShellCache,
 } from './offlineDatabaseSync';
+import { isFiscalSourceId } from './offlineSources';
 import type {
     OfflineDatabaseInitResult,
     OfflineDatabaseStatus,
@@ -32,6 +39,28 @@ import type { OfflineDatabaseOperationsArgs } from './offlineDatabaseOperations.
 import { useOfflineDatabaseBroadcastChannel } from './offlineDatabaseRuntime/useOfflineDatabaseBroadcastChannel';
 import { useOfflineDatabaseSyncWaiter } from './offlineDatabaseRuntime/useOfflineDatabaseSyncWaiter';
 import { useOfflineDatabaseWorkerBridge } from './offlineDatabaseRuntime/useOfflineDatabaseWorkerBridge';
+
+const LEGACY_MONOLITHIC_BUNDLE_SOURCE = 'nesh';
+
+function isOfflineSourceMetadata(
+    metadata: unknown,
+): metadata is OfflineSourceMetadata {
+    return Boolean(
+        metadata
+        && typeof metadata === 'object'
+        && 'source' in metadata
+        && isFiscalSourceId((metadata as { source?: unknown }).source)
+        && 'encrypted_sha256' in metadata,
+    );
+}
+
+function readInitialOfflineMetadata(): OfflineDatabaseMetadata | null {
+    if (getFiscalR2BaseUrl() && getOfflineDbPublicSeed()) {
+        return readStoredOfflineSourceMetadata(LEGACY_MONOLITHIC_BUNDLE_SOURCE);
+    }
+
+    return readStoredOfflineDatabaseMetadata();
+}
 
 export interface OfflineDatabaseRuntimeState {
     status: OfflineDatabaseStatus;
@@ -62,7 +91,7 @@ export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
     const instanceIdRef = useRef(createOfflineDatabaseInstanceId());
     const remoteCheckRef = useRef<Promise<OfflineDatabaseMetadata | null> | null>(null);
     const remoteMetaRef = useRef<OfflineDatabaseMetadata | null>(
-        readStoredOfflineDatabaseMetadata(),
+        readInitialOfflineMetadata(),
     );
 
     const [status, setStatus] = useState<OfflineDatabaseStatus>(
@@ -115,6 +144,12 @@ export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
             if (!metadata) return;
             remoteMetaRef.current = metadata;
             persistStoredOfflineDatabaseMetadata(metadata);
+            if ('source' in metadata && isFiscalSourceId(metadata.source)) {
+                persistStoredOfflineSourceMetadata(
+                    metadata.source,
+                    metadata as OfflineSourceMetadata,
+                );
+            }
             setLocalVersion(metadata.version);
             setRemoteVersion(metadata.version);
             setDbSizeBytes(metadata.size_bytes ?? null);
@@ -133,6 +168,14 @@ export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
                 metadata ?? remoteMetaRef.current ?? readStoredOfflineDatabaseMetadata();
             try {
                 const seed = sessionStorage.getItem('offline_db_seed');
+                const publicSeed = getOfflineDbPublicSeed();
+                const sourcePayload =
+                    publicSeed && isOfflineSourceMetadata(initMetadata)
+                        ? {
+                            source: initMetadata.source,
+                            publicSeed,
+                        }
+                        : {};
                 await sendToWorker(
                     {
                         type: 'INIT',
@@ -140,6 +183,7 @@ export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
                         payload: {
                             ...buildOfflineDatabaseInitPayload(initMetadata),
                             seed: seed || undefined,
+                            ...sourcePayload,
                         },
                     },
                     30_000,
@@ -167,10 +211,20 @@ export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
 
             const request = (async () => {
                 try {
-                    const metadata = await fetchOfflineDatabaseAvailabilityMetadata(
-                        getOfflineDatabaseApiBaseUrl(),
-                    );
+                    const r2BaseUrl = getFiscalR2BaseUrl();
+                    const publicSeed = getOfflineDbPublicSeed();
+                    const metadata = r2BaseUrl && publicSeed
+                        ? await fetchOfflineSourceAvailabilityMetadata(
+                            r2BaseUrl,
+                            LEGACY_MONOLITHIC_BUNDLE_SOURCE,
+                        )
+                        : await fetchOfflineDatabaseAvailabilityMetadata(
+                            getOfflineDatabaseApiBaseUrl(),
+                        );
                     remoteMetaRef.current = metadata;
+                    if (isOfflineSourceMetadata(metadata)) {
+                        persistStoredOfflineSourceMetadata(metadata.source, metadata);
+                    }
                     setRemoteVersion(metadata?.version ?? null);
                     setDbSizeBytes((current) => current ?? metadata?.size_bytes ?? null);
                     return metadata;

--- a/client/src/context/offlineDatabaseRuntime/useOfflineDatabaseBroadcastChannel.ts
+++ b/client/src/context/offlineDatabaseRuntime/useOfflineDatabaseBroadcastChannel.ts
@@ -125,7 +125,7 @@ export function useOfflineDatabaseBroadcastChannel({
                                 {
                                     type: 'REMOVE',
                                     id: null,
-                                    payload: {},
+                                    payload: { source: message.source },
                                 },
                                 10_000,
                             );

--- a/client/src/context/offlineDatabaseStorage.ts
+++ b/client/src/context/offlineDatabaseStorage.ts
@@ -1,7 +1,13 @@
+import type { FiscalSourceId } from './offlineSources';
 import type { OfflineDatabaseMetadata } from '../utils/offlineDatabase';
-import { sanitizeOfflineMetadata } from '../utils/offlineDatabase';
+import {
+    sanitizeOfflineMetadata,
+    sanitizeOfflineSourceMetadata,
+    type OfflineSourceMetadata,
+} from '../utils/offlineDatabase';
 
 export const OFFLINE_META_KEY = 'offline-db:installed-meta';
+export const OFFLINE_SOURCE_META_KEY_PREFIX = 'offline_fiscal_metadata:';
 export const OFFLINE_LOCK_KEY = 'offline-db:install-lock';
 export const OFFLINE_LOCK_TTL_MS = 180_000;
 
@@ -36,6 +42,48 @@ export function persistStoredOfflineDatabaseMetadata(
             return;
         }
         localStorage.setItem(OFFLINE_META_KEY, JSON.stringify(metadata));
+    } catch {
+        // Ignore storage failures. The worker state remains authoritative.
+    }
+}
+
+function getOfflineSourceMetadataKey(source: FiscalSourceId): string {
+    return `${OFFLINE_SOURCE_META_KEY_PREFIX}${source}`;
+}
+
+export function readStoredOfflineSourceMetadata(
+    source: FiscalSourceId,
+): OfflineSourceMetadata | null {
+    if (typeof localStorage === 'undefined') return null;
+    try {
+        return sanitizeOfflineSourceMetadata(
+            source,
+            JSON.parse(localStorage.getItem(getOfflineSourceMetadataKey(source)) || 'null'),
+        );
+    } catch {
+        return null;
+    }
+}
+
+export function persistStoredOfflineSourceMetadata(
+    source: FiscalSourceId,
+    metadata: OfflineSourceMetadata | null,
+): void {
+    if (typeof localStorage === 'undefined') return;
+    try {
+        if (!metadata) {
+            localStorage.removeItem(getOfflineSourceMetadataKey(source));
+            return;
+        }
+        const sanitized = sanitizeOfflineSourceMetadata(source, metadata);
+        if (!sanitized) {
+            localStorage.removeItem(getOfflineSourceMetadataKey(source));
+            return;
+        }
+        localStorage.setItem(
+            getOfflineSourceMetadataKey(source),
+            JSON.stringify(sanitized),
+        );
     } catch {
         // Ignore storage failures. The worker state remains authoritative.
     }

--- a/client/src/context/offlineDatabaseSync.ts
+++ b/client/src/context/offlineDatabaseSync.ts
@@ -1,5 +1,15 @@
 import { API_BASE_URL } from '../services/api';
-import { sanitizeOfflineMetadata, type OfflineDatabaseMetadata } from '../utils/offlineDatabase';
+import {
+    sanitizeOfflineMetadata,
+    sanitizeOfflineSourceMetadata,
+    type OfflineDatabaseMetadata,
+    type OfflineSourceMetadata,
+} from '../utils/offlineDatabase';
+import {
+    buildFiscalBundleUrls,
+    normalizeFiscalR2BaseUrl,
+    type FiscalSourceId,
+} from './offlineSources';
 
 export const OFFLINE_CHANNEL_NAME = 'offline-db-channel';
 export const OFFLINE_WAIT_TIMEOUT_MS = 240_000;
@@ -7,6 +17,53 @@ const OFFLINE_METADATA_TIMEOUTS_MS = [4_000, 10_000, 20_000] as const;
 
 export function getOfflineDatabaseApiBaseUrl(): string {
     return API_BASE_URL;
+}
+
+export function getFiscalR2BaseUrl(): string {
+    const env = import.meta.env as { VITE_FISCAL_R2_BASE_URL?: string | undefined };
+    const configuredBaseUrl = normalizeFiscalR2BaseUrl(env.VITE_FISCAL_R2_BASE_URL);
+
+    const { metadataUrl } = buildFiscalBundleUrls(configuredBaseUrl, 'nesh');
+    return metadataUrl.replace(/\/nesh\/nesh\.meta\.json$/, '');
+}
+
+export function getOfflineDbPublicSeed(): string {
+    const env = import.meta.env as { VITE_OFFLINE_DB_PUBLIC_SEED?: string | undefined };
+    return (env.VITE_OFFLINE_DB_PUBLIC_SEED || '').trim();
+}
+
+export async function fetchOfflineSourceAvailabilityMetadata(
+    r2BaseUrl: string,
+    source: FiscalSourceId,
+): Promise<OfflineSourceMetadata | null> {
+    const { metadataUrl } = buildFiscalBundleUrls(r2BaseUrl, source);
+    const response = await fetch(metadataUrl, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+        throw new Error(`Source metadata check failed (${response.status})`);
+    }
+
+    return sanitizeOfflineSourceMetadata(source, await response.json());
+}
+
+export async function fetchEncryptedFiscalBundle(
+    r2BaseUrl: string,
+    source: FiscalSourceId,
+): Promise<Response> {
+    const { encryptedUrl } = buildFiscalBundleUrls(r2BaseUrl, source);
+    const response = await fetch(encryptedUrl, {
+        method: 'GET',
+        headers: { Accept: 'application/octet-stream' },
+    });
+
+    if (!response.ok) {
+        throw new Error(`Source bundle download failed (${response.status})`);
+    }
+
+    return response;
 }
 
 export async function primeOfflineShellCache(): Promise<void> {

--- a/client/src/context/offlineSources.ts
+++ b/client/src/context/offlineSources.ts
@@ -20,11 +20,16 @@ export function isFiscalSourceId(value: unknown): value is FiscalSourceId {
   return typeof value === 'string' && FISCAL_SOURCE_IDS.has(value);
 }
 
+export function normalizeFiscalR2BaseUrl(value: string | undefined): string {
+  const normalizedValue = (value || '').trim().replace(/\/+$/, '');
+  return normalizedValue || '/fiscal-bases';
+}
+
 export function buildFiscalBundleUrls(
   baseUrl: string,
   source: FiscalSourceId,
 ): FiscalBundleUrls {
-  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
+  const normalizedBaseUrl = normalizeFiscalR2BaseUrl(baseUrl);
 
   return {
     metadataUrl: `${normalizedBaseUrl}/${source}/${source}.meta.json`,

--- a/client/src/workers/dbWorker/constants.js
+++ b/client/src/workers/dbWorker/constants.js
@@ -6,6 +6,8 @@ export const GCM_IV_SIZE = 12;
 export const GCM_TAG_SIZE = 16;
 export const DB_OPFS_FILENAME = "fiscal_offline.enc";
 export const DB_VERSION_KEY = "fiscal_offline_version";
+export const DB_SOURCE_OPFS_PREFIX = "fiscal-source-";
+export const DB_SOURCE_VERSION_PREFIX = "fiscal-source-version-";
 // TODO(security): saveSeed/readSeed persist plaintext seed under DB_SEED_KEY.
 // Replace with platform-backed or non-extractable key wrapping when available.
 export const DB_SEED_KEY = "fiscal_offline_seed";

--- a/client/src/workers/dbWorker/messages.js
+++ b/client/src/workers/dbWorker/messages.js
@@ -252,10 +252,18 @@ async function fetchEncryptedDatabaseBundle(apiBase, id) {
 }
 
 function buildFiscalBundleUrls(r2BaseUrl, source) {
-  const normalizedBaseUrl = String(r2BaseUrl || "").replace(/\/+$/, "");
+  const normalizedBaseUrl = trimTrailingSlashes(String(r2BaseUrl || ""));
   return {
     encryptedUrl: `${normalizedBaseUrl}/${source}/${source}.enc`,
   };
+}
+
+function trimTrailingSlashes(value) {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  return value.slice(0, end);
 }
 
 function getSourceAwareInstallPayloadIntent(payload) {

--- a/client/src/workers/dbWorker/messages.js
+++ b/client/src/workers/dbWorker/messages.js
@@ -3,9 +3,14 @@ import { getLocalNbsDetail } from "./catalogSearch.js";
 import {
   readFromOpfs,
   readSeed,
+  readSourceFromOpfs,
+  readSourceVersion,
   readVersion,
   removeFromOpfs,
+  removeSourceFromOpfs,
   saveSeed,
+  saveSourceToOpfs,
+  saveSourceVersion,
   saveToOpfs,
   saveVersion,
 } from "./opfs.js";
@@ -14,11 +19,18 @@ import { getStructuredSearchWithCache } from "./searchRuntime.js";
 import { loadDatabaseFromBytes } from "./sqlite.js";
 import { clearSearchCache, closeWorkerDb, getWorkerDb, getWorkerStatus, getWorkerVersion, setWorkerStatus, setWorkerVersion } from "./state.js";
 
+const FISCAL_SOURCE_IDS = new Set(["nesh", "tipi", "nbs", "unspsc"]);
+
+function isFiscalSourceId(value) {
+  return typeof value === "string" && FISCAL_SOURCE_IDS.has(value);
+}
+
 async function handleInitMessage(id, payload) {
-  const encData = await readFromOpfs();
-  const version = await readVersion();
-  const opfsSeed = await readSeed();
-  const seed = opfsSeed || payload?.seed;
+  const source = isFiscalSourceId(payload?.source) ? payload.source : null;
+  const encData = source ? await readSourceFromOpfs(source) : await readFromOpfs();
+  const version = source ? await readSourceVersion(source) : await readVersion();
+  const opfsSeed = source ? null : await readSeed();
+  const seed = source ? payload?.publicSeed : opfsSeed || payload?.seed;
   const usedPayloadSeedFallback = !opfsSeed && Boolean(payload?.seed);
 
   if (!encData || !version || !seed) {
@@ -46,7 +58,9 @@ async function handleInitMessage(id, payload) {
     closeWorkerDb();
     setWorkerVersion(null);
     setWorkerStatus("error");
-    if (usedPayloadSeedFallback) {
+    if (source) {
+      await removeSourceFromOpfs(source);
+    } else if (usedPayloadSeedFallback) {
       await removeFromOpfs();
     }
     const message = error instanceof Error ? error.message : "Unknown error";
@@ -166,6 +180,74 @@ async function fetchEncryptedDatabaseBundle(apiBase, id) {
   throw lastError instanceof Error ? lastError : new Error("Offline database download failed");
 }
 
+function buildFiscalBundleUrls(r2BaseUrl, source) {
+  const normalizedBaseUrl = String(r2BaseUrl || "").replace(/\/+$/, "");
+  return {
+    encryptedUrl: `${normalizedBaseUrl}/${source}/${source}.enc`,
+  };
+}
+
+function getSourceAwareInstallPayloadIntent(payload) {
+  return Boolean(
+    payload
+      && typeof payload === "object"
+      && (
+        "source" in payload
+        || "r2BaseUrl" in payload
+        || "publicSeed" in payload
+        || "metadata" in payload
+      )
+  );
+}
+
+export function validateSourceAwareInstallPayload(payload) {
+  if (!payload || typeof payload !== "object") {
+    return { ok: false, error: "Source-aware install payload is incomplete" };
+  }
+
+  if (!isFiscalSourceId(payload.source)) {
+    return { ok: false, error: "Invalid source-aware install source" };
+  }
+
+  if (
+    typeof payload.r2BaseUrl !== "string"
+      || !payload.r2BaseUrl.trim()
+      || typeof payload.publicSeed !== "string"
+      || !payload.publicSeed.trim()
+      || !payload.metadata
+      || typeof payload.metadata !== "object"
+      || typeof payload.metadata.version !== "string"
+      || !payload.metadata.version.trim()
+      || typeof payload.metadata.encrypted_sha256 !== "string"
+      || !payload.metadata.encrypted_sha256.trim()
+  ) {
+    return { ok: false, error: "Source-aware install payload is incomplete" };
+  }
+
+  if (payload.metadata.source !== payload.source) {
+    return { ok: false, error: "Source metadata does not match install source" };
+  }
+
+  return { ok: true };
+}
+
+async function fetchEncryptedSourceBundle(r2BaseUrl, source) {
+  const { encryptedUrl } = buildFiscalBundleUrls(r2BaseUrl, source);
+  const dlResp = await fetch(encryptedUrl, {
+    method: "GET",
+    headers: { Accept: "application/octet-stream" },
+  });
+
+  if (dlResp.ok) {
+    return dlResp;
+  }
+
+  const errText = await dlResp.text();
+  throw new Error(
+    `Offline source bundle retrieval failed (${dlResp.status}): ${errText}`
+  );
+}
+
 async function updateInstalledVersion(apiBase) {
   let nextVersion = null;
 
@@ -187,7 +269,82 @@ async function updateInstalledVersion(apiBase) {
   await saveVersion(nextVersion || "unknown");
 }
 
-async function handleInstallMessage(id, payload) {
+async function handleSourceAwareInstallMessage(id, payload) {
+  setWorkerStatus("installing");
+  postWorkerProgress(id, 0, "fetching_database");
+
+  const {
+    source,
+    r2BaseUrl,
+    publicSeed,
+    metadata,
+  } = payload;
+  /** @type {Uint8Array | null} */
+  let plaintext = null;
+
+  try {
+    const dlResp = await fetchEncryptedSourceBundle(r2BaseUrl, source);
+    const encryptedBlob = await readEncryptedDatabaseBlob(dlResp, id);
+    const {
+      encrypted_sha256: expectedEncryptedSha256,
+      chunk_size: chunkSize = 65536,
+      pbkdf2_iterations: iterations = 600000,
+    } = metadata;
+
+    postWorkerProgress(id, 72, "verifying_integrity");
+    const actualEncryptedSha256 = await sha256Hex(encryptedBlob);
+    if (actualEncryptedSha256 !== expectedEncryptedSha256) {
+      throw new Error("Offline database integrity verification failed");
+    }
+
+    setAppSeed(publicSeed);
+
+    postWorkerProgress(id, 75, "decrypting");
+    plaintext = await decryptDatabase(encryptedBlob, chunkSize, iterations);
+
+    postWorkerProgress(id, 85, "loading");
+    await loadDatabaseFromBytes(plaintext);
+
+    postWorkerProgress(id, 90, "saving");
+    await removeSourceFromOpfs(source);
+    try {
+      setAppSeed(publicSeed);
+      await saveSourceToOpfs(source, encryptedBlob);
+      await saveSourceVersion(source, metadata.version || "unknown");
+    } catch (error) {
+      await removeSourceFromOpfs(source);
+      throw error;
+    }
+
+    setWorkerVersion(metadata.version || "unknown");
+    setWorkerStatus("ready");
+    postWorkerProgress(id, 100, "done");
+    postWorkerStatus(id, {
+      status: "ready",
+      version: getWorkerVersion(),
+      sizeBytes: encryptedBlob.length,
+      seed: publicSeed,
+    });
+  } catch (error) {
+    setWorkerStatus("error");
+    const message = error instanceof Error ? error.message : "Unknown error";
+    const recoverableMessage = `${message}. Reinstale o banco offline para continuar.`;
+    postWorkerStatus(id, {
+      status: "error",
+      error: recoverableMessage,
+      recoverable: true,
+    });
+    postWorkerError(id, recoverableMessage);
+    await removeSourceFromOpfs(source).catch(() => undefined);
+    return;
+  } finally {
+    if (plaintext) {
+      plaintext.fill(0);
+    }
+  }
+}
+
+async function handleLegacyInstallMessage(id, payload) {
   setWorkerStatus("installing");
   postWorkerProgress(id, 0, "requesting_token");
 
@@ -261,6 +418,26 @@ async function handleInstallMessage(id, payload) {
   }
 }
 
+async function handleInstallMessage(id, payload) {
+  if (getSourceAwareInstallPayloadIntent(payload)) {
+    const validation = validateSourceAwareInstallPayload(payload);
+    if (!validation.ok) {
+      setWorkerStatus("error");
+      postWorkerStatus(id, {
+        status: "error",
+        error: validation.error,
+        recoverable: true,
+      });
+      postWorkerError(id, validation.error);
+      return;
+    }
+    await handleSourceAwareInstallMessage(id, payload);
+    return;
+  }
+
+  await handleLegacyInstallMessage(id, payload);
+}
+
 function handleSearchMessage(id, payload) {
   if (!getWorkerDb() || getWorkerStatus() !== "ready") {
     postWorkerResult(id, { results: null, source: "not_ready" });
@@ -325,13 +502,17 @@ function handleGetStatusMessage(id) {
   });
 }
 
-async function handleRemoveMessage(id) {
+async function handleRemoveMessage(id, payload) {
   closeWorkerDb();
   setWorkerVersion(null);
   setWorkerStatus("not_installed");
   clearSearchCache();
 
-  await removeFromOpfs();
+  if (isFiscalSourceId(payload?.source)) {
+    await removeSourceFromOpfs(payload.source);
+  } else {
+    await removeFromOpfs();
+  }
   postWorkerStatus(id, { status: "not_installed" });
 }
 
@@ -354,7 +535,7 @@ export async function dispatchWorkerMessage(type, id, payload) {
       handleGetStatusMessage(id);
       return;
     case "REMOVE":
-      await handleRemoveMessage(id);
+      await handleRemoveMessage(id, payload);
       return;
     default:
       postWorkerError(id, `Unknown message type: ${type}`);

--- a/client/src/workers/dbWorker/messages.test.js
+++ b/client/src/workers/dbWorker/messages.test.js
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
 
 vi.mock('./crypto.js', () => ({
   decryptDatabase: vi.fn(),
@@ -184,5 +185,11 @@ describe('dbWorker messages network helpers', () => {
         method: 'POST',
       }),
     );
+  });
+
+  it('does not trim fiscal R2 bundle URLs with a trailing-slash regex', () => {
+    const source = readFileSync('src/workers/dbWorker/messages.js', 'utf8');
+
+    expect(source).not.toContain('replace(/\\/+$/, "")');
   });
 });

--- a/client/src/workers/dbWorker/opfs.js
+++ b/client/src/workers/dbWorker/opfs.js
@@ -1,4 +1,10 @@
-import { DB_OPFS_FILENAME, DB_SEED_KEY, DB_VERSION_KEY } from "./constants.js";
+import {
+  DB_OPFS_FILENAME,
+  DB_SEED_KEY,
+  DB_SOURCE_OPFS_PREFIX,
+  DB_SOURCE_VERSION_PREFIX,
+  DB_VERSION_KEY,
+} from "./constants.js";
 
 /**
  * @returns {Promise<FileSystemDirectoryHandle>}
@@ -18,6 +24,44 @@ export async function saveToOpfs(data) {
   const writable = await fileHandle.createWritable();
   await writable.write(data);
   await writable.close();
+}
+
+function getSourceFilename(source) {
+  return `${DB_SOURCE_OPFS_PREFIX}${source}`;
+}
+
+function getSourceVersionFilename(source) {
+  return `${DB_SOURCE_VERSION_PREFIX}${source}`;
+}
+
+/**
+ * @param {string} source
+ * @param {Uint8Array} data
+ */
+export async function saveSourceToOpfs(source, data) {
+  const root = await getOpfsRoot();
+  const fileHandle = await root.getFileHandle(getSourceFilename(source), {
+    create: true,
+  });
+  const writable = await fileHandle.createWritable();
+  await writable.write(data);
+  await writable.close();
+}
+
+/**
+ * @param {string} source
+ * @returns {Promise<Uint8Array | null>}
+ */
+export async function readSourceFromOpfs(source) {
+  try {
+    const root = await getOpfsRoot();
+    const fileHandle = await root.getFileHandle(getSourceFilename(source));
+    const file = await fileHandle.getFile();
+    const buffer = await file.arrayBuffer();
+    return new Uint8Array(buffer);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -59,6 +103,25 @@ export async function removeFromOpfs() {
 }
 
 /**
+ * @param {string} source
+ */
+export async function removeSourceFromOpfs(source) {
+  try {
+    const root = await getOpfsRoot();
+    await root.removeEntry(getSourceFilename(source));
+  } catch {
+    // File already absent.
+  }
+
+  try {
+    const root = await getOpfsRoot();
+    await root.removeEntry(getSourceVersionFilename(source));
+  } catch {
+    // Version marker already absent.
+  }
+}
+
+/**
  * @param {string} version
  */
 export async function saveVersion(version) {
@@ -76,6 +139,35 @@ export async function readVersion() {
   try {
     const root = await getOpfsRoot();
     const fileHandle = await root.getFileHandle(DB_VERSION_KEY);
+    const file = await fileHandle.getFile();
+    return await file.text();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {string} source
+ * @param {string} version
+ */
+export async function saveSourceVersion(source, version) {
+  const root = await getOpfsRoot();
+  const fileHandle = await root.getFileHandle(getSourceVersionFilename(source), {
+    create: true,
+  });
+  const writable = await fileHandle.createWritable();
+  await writable.write(version);
+  await writable.close();
+}
+
+/**
+ * @param {string} source
+ * @returns {Promise<string | null>}
+ */
+export async function readSourceVersion(source) {
+  try {
+    const root = await getOpfsRoot();
+    const fileHandle = await root.getFileHandle(getSourceVersionFilename(source));
     const file = await fileHandle.getFile();
     return await file.text();
   } catch {

--- a/client/tests/unit/LocalDatabaseContext.autoinstall.test.tsx
+++ b/client/tests/unit/LocalDatabaseContext.autoinstall.test.tsx
@@ -139,8 +139,32 @@ function makeVersionResponse(version: string) {
   );
 }
 
+function makeSourceMetadataResponse(version: string) {
+  return new Response(
+    JSON.stringify({
+      source: 'nesh',
+      version,
+      size_bytes: 4096,
+      sha256: 'plain-sha',
+      encrypted_sha256: 'enc-sha',
+      chunk_size: 65536,
+      pbkdf2_iterations: 600000,
+    }),
+    {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+}
+
 function getWorkerMessages() {
   return MockWorker.instances[0]?.messages.map((message) => message.type) ?? [];
+}
+
+function getPostedWorkerMessages() {
+  return MockWorker.instances[0]?.messages ?? [];
 }
 
 async function flushEffects() {
@@ -178,6 +202,7 @@ describe('LocalDatabaseContext auto-install behavior', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it('does not auto-install on first visit when the database is missing', async () => {
@@ -223,5 +248,56 @@ describe('LocalDatabaseContext auto-install behavior', () => {
 
     expect(getWorkerMessages()).not.toContain('INSTALL');
     expect(screen.getByTestId('status')).toHaveTextContent('not_installed');
+  });
+
+  it('uses R2 metadata and public seed for first-time install when configured', async () => {
+    vi.stubEnv('VITE_FISCAL_R2_BASE_URL', 'https://r2.example.com/fiscal');
+    vi.stubEnv('VITE_OFFLINE_DB_PUBLIC_SEED', 'public-seed');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/database/version') || url.includes('/database/token')) {
+          return Promise.reject(new Error(`legacy endpoint called: ${url}`));
+        }
+        return Promise.resolve(makeSourceMetadataResponse('2026.05.01'));
+      }),
+    );
+
+    render(
+      <LocalDatabaseProvider>
+        <Probe />
+      </LocalDatabaseProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('status')).toHaveTextContent('not_installed'),
+    );
+    expect(currentContext).not.toBeNull();
+
+    await act(async () => {
+      await currentContext!.install();
+    });
+
+    const fetchUrls = (fetch as ReturnType<typeof vi.fn>).mock.calls.map((call) =>
+      String(call[0]),
+    );
+    expect(fetchUrls).toContain('https://r2.example.com/fiscal/nesh/nesh.meta.json');
+    expect(fetchUrls.join('\n')).not.toContain('/database/version');
+    expect(fetchUrls.join('\n')).not.toContain('/database/token');
+    expect(getPostedWorkerMessages()).toContainEqual(
+      expect.objectContaining({
+        type: 'INSTALL',
+        payload: {
+          source: 'nesh',
+          r2BaseUrl: 'https://r2.example.com/fiscal',
+          publicSeed: 'public-seed',
+          metadata: expect.objectContaining({
+            source: 'nesh',
+            version: '2026.05.01',
+            encrypted_sha256: 'enc-sha',
+          }),
+        },
+      }),
+    );
   });
 });

--- a/client/tests/unit/offlineDatabaseStorage.test.ts
+++ b/client/tests/unit/offlineDatabaseStorage.test.ts
@@ -6,7 +6,9 @@ import {
   getOfflineDatabaseInstallLock,
   OFFLINE_LOCK_KEY,
   OFFLINE_META_KEY,
+  persistStoredOfflineSourceMetadata,
   persistStoredOfflineDatabaseMetadata,
+  readStoredOfflineSourceMetadata,
   readStoredOfflineDatabaseMetadata,
   setOfflineDatabaseInstallLock,
 } from '../../src/context/offlineDatabaseStorage';
@@ -43,6 +45,52 @@ describe('offlineDatabaseStorage', () => {
 
     localStorage.setItem(OFFLINE_META_KEY, '{invalid json');
     expect(readStoredOfflineDatabaseMetadata()).toBeNull();
+  });
+
+  it('persists and reads sanitized source metadata without source collisions', () => {
+    persistStoredOfflineSourceMetadata('nesh', {
+      source: 'nesh',
+      version: '2026.05.01',
+      size_bytes: 2048,
+      sha256: 'nesh-plain',
+      encrypted_sha256: 'nesh-enc',
+      chunk_size: 8192,
+      pbkdf2_iterations: 900000,
+    });
+    persistStoredOfflineSourceMetadata('tipi', {
+      source: 'tipi',
+      version: '2026.05.02',
+      size_bytes: 4096,
+      sha256: 'tipi-plain',
+      encrypted_sha256: 'tipi-enc',
+      chunk_size: 16384,
+      pbkdf2_iterations: 700000,
+    });
+
+    expect(readStoredOfflineSourceMetadata('nesh')).toEqual({
+      source: 'nesh',
+      version: '2026.05.01',
+      size_bytes: 2048,
+      sha256: 'nesh-plain',
+      encrypted_sha256: 'nesh-enc',
+      built_at: null,
+      updated_at: null,
+      format_version: 1,
+      chunk_size: 8192,
+      pbkdf2_iterations: 900000,
+    });
+    expect(readStoredOfflineSourceMetadata('tipi')).toEqual({
+      source: 'tipi',
+      version: '2026.05.02',
+      size_bytes: 4096,
+      sha256: 'tipi-plain',
+      encrypted_sha256: 'tipi-enc',
+      built_at: null,
+      updated_at: null,
+      format_version: 1,
+      chunk_size: 16384,
+      pbkdf2_iterations: 700000,
+    });
   });
 
   it('stores, expires, and clears the install lock by owner', () => {

--- a/client/tests/unit/offlineDatabaseSync.test.ts
+++ b/client/tests/unit/offlineDatabaseSync.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { fetchOfflineDatabaseAvailabilityMetadata } from '../../src/context/offlineDatabaseSync'
+import {
+  fetchOfflineDatabaseAvailabilityMetadata,
+  fetchOfflineSourceAvailabilityMetadata,
+  getFiscalR2BaseUrl,
+  getOfflineDbPublicSeed,
+} from '../../src/context/offlineDatabaseSync'
 
 function makeOfflineVersionResponse(version: string): Response {
   return new Response(
@@ -22,6 +27,19 @@ function makeOfflineVersionResponse(version: string): Response {
 describe('offlineDatabaseSync', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+  })
+
+  it('reads R2 base URL and public seed from env config', () => {
+    vi.stubEnv('VITE_FISCAL_R2_BASE_URL', 'https://r2.example.com/fiscal/')
+    vi.stubEnv('VITE_OFFLINE_DB_PUBLIC_SEED', ' public-seed ')
+
+    expect(getFiscalR2BaseUrl()).toBe('https://r2.example.com/fiscal')
+    expect(getOfflineDbPublicSeed()).toBe('public-seed')
+  })
+
+  it('falls back to the static fiscal bundle base when R2 env is absent', () => {
+    expect(getFiscalR2BaseUrl()).toBe('/fiscal-bases')
   })
 
   it('retries metadata checks after a transient abort', async () => {
@@ -61,5 +79,69 @@ describe('offlineDatabaseSync', () => {
       fetchOfflineDatabaseAvailabilityMetadata('https://api.example.test')
     ).rejects.toThrow('Version check failed (503)')
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('fetches source metadata from the R2 manifest path', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          version: '2026.05.01',
+          size_bytes: 4096,
+          sha256: 'plain-sha',
+          encrypted_sha256: 'enc-sha',
+          chunk_size: 65536,
+          pbkdf2_iterations: 600000,
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      fetchOfflineSourceAvailabilityMetadata('https://r2.example.com/fiscal/', 'nbs')
+    ).resolves.toEqual({
+      source: 'nbs',
+      version: '2026.05.01',
+      size_bytes: 4096,
+      sha256: 'plain-sha',
+      encrypted_sha256: 'enc-sha',
+      built_at: null,
+      updated_at: null,
+      format_version: 1,
+      chunk_size: 65536,
+      pbkdf2_iterations: 600000,
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://r2.example.com/fiscal/nbs/nbs.meta.json',
+      expect.objectContaining({
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      })
+    )
+  })
+
+  it('does not call the legacy database version endpoint for source metadata', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          version: '2026.05.01',
+          size_bytes: 4096,
+          sha256: 'plain-sha',
+          encrypted_sha256: 'enc-sha',
+        }),
+        { status: 200 }
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchOfflineSourceAvailabilityMetadata('https://r2.example.com/fiscal', 'nbs')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain('/api/database/version')
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain('/database/version')
   })
 })

--- a/client/tests/unit/offlineDatabaseWorkerClient.test.ts
+++ b/client/tests/unit/offlineDatabaseWorkerClient.test.ts
@@ -6,6 +6,7 @@ import {
   isOfflineDatabaseWorkerReadyMessage,
   sendOfflineDatabaseWorkerRequest,
 } from '../../src/context/offlineDatabaseWorkerClient';
+import { validateSourceAwareInstallPayload } from '../../src/workers/dbWorker/messages.js';
 import type {
   OfflineDatabaseWorkerRequest,
   PendingOfflineDatabaseRequest,
@@ -68,6 +69,154 @@ describe('offlineDatabaseWorkerClient', () => {
       type: 'RESULT',
       id: message.id,
       payload: { detail: { codigo: '01.001' } },
+    });
+  });
+
+  it('accepts source-aware install payloads', async () => {
+    const postedMessages: OfflineDatabaseWorkerRequest[] = [];
+    const worker = {
+      postMessage: vi.fn((message: OfflineDatabaseWorkerRequest) => {
+        postedMessages.push(message);
+      }),
+    } as unknown as Worker;
+    const pending = new Map<string, PendingOfflineDatabaseRequest>();
+
+    const requestPromise = sendOfflineDatabaseWorkerRequest(
+      worker,
+      pending,
+      {
+        type: 'INSTALL',
+        id: null,
+        payload: {
+          source: 'nbs',
+          r2BaseUrl: 'https://r2.example.com/fiscal',
+          publicSeed: 'public-seed',
+          metadata: {
+            source: 'nbs',
+            version: '2026.05.01',
+            size_bytes: 4096,
+            sha256: 'plain-sha',
+            encrypted_sha256: 'enc-sha',
+            chunk_size: 65536,
+            pbkdf2_iterations: 600000,
+          },
+        },
+      },
+      1000,
+    );
+
+    const message = postedMessages[0] as OfflineDatabaseWorkerRequest & { id: string };
+    expect(message).toMatchObject({
+      type: 'INSTALL',
+      payload: {
+        source: 'nbs',
+        r2BaseUrl: 'https://r2.example.com/fiscal',
+        publicSeed: 'public-seed',
+        metadata: {
+          source: 'nbs',
+          version: '2026.05.01',
+          encrypted_sha256: 'enc-sha',
+        },
+      },
+    });
+
+    const pendingEntry = pending.get(message.id);
+    expect(pendingEntry).toBeDefined();
+    clearTimeout(pendingEntry!.timeout);
+    pending.delete(message.id);
+    pendingEntry!.resolve({
+      type: 'STATUS',
+      id: message.id,
+      payload: { status: 'ready', version: '2026.05.01' },
+    });
+
+    await expect(requestPromise).resolves.toMatchObject({
+      type: 'STATUS',
+      payload: { status: 'ready', version: '2026.05.01' },
+    });
+  });
+
+  it('accepts source-aware init and remove payloads', async () => {
+    const worker = {
+      postMessage: vi.fn(),
+    } as unknown as Worker;
+    const pending = new Map<string, PendingOfflineDatabaseRequest>();
+
+    sendOfflineDatabaseWorkerRequest(
+      worker,
+      pending,
+      {
+        type: 'INIT',
+        id: null,
+        payload: {
+          source: 'nesh',
+          publicSeed: 'public-seed',
+          chunkSize: 65536,
+          pbkdf2Iterations: 600000,
+        },
+      },
+      1000,
+    ).catch(() => undefined);
+
+    sendOfflineDatabaseWorkerRequest(
+      worker,
+      pending,
+      {
+        type: 'REMOVE',
+        id: null,
+        payload: { source: 'nesh' },
+      },
+      1000,
+    ).catch(() => undefined);
+
+    expect(worker.postMessage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        type: 'INIT',
+        payload: expect.objectContaining({
+          source: 'nesh',
+          publicSeed: 'public-seed',
+        }),
+      }),
+    );
+    expect(worker.postMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        type: 'REMOVE',
+        payload: { source: 'nesh' },
+      }),
+    );
+
+    for (const pendingEntry of pending.values()) {
+      clearTimeout(pendingEntry.timeout);
+    }
+  });
+
+  it('rejects malformed source-aware install payloads before legacy fallback', () => {
+    expect(
+      validateSourceAwareInstallPayload({
+        source: 'nbs',
+        r2BaseUrl: 'https://r2.example.com/fiscal',
+        publicSeed: 'public-seed',
+        metadata: {
+          source: 'tipi',
+          version: '2026.05.01',
+          encrypted_sha256: 'enc-sha',
+        },
+      }),
+    ).toEqual({
+      ok: false,
+      error: 'Source metadata does not match install source',
+    });
+
+    expect(
+      validateSourceAwareInstallPayload({
+        source: 'nbs',
+        r2BaseUrl: 'https://r2.example.com/fiscal',
+      }),
+    ).toEqual({
+      ok: false,
+      error: 'Source-aware install payload is incomplete',
     });
   });
 


### PR DESCRIPTION
## Resumo
- Instala bundles fiscais source-aware a partir do R2
- Valida metadata/hash e persiste bases por fonte no navegador
- Preserva compatibilidade de inicialização local/offline

## Checks
- npm test -- tests/unit/offlineSources.test.ts tests/unit/offlineDatabaseSync.test.ts tests/unit/offlineDatabaseStorage.test.ts tests/unit/offlineDatabaseWorkerClient.test.ts tests/unit/LocalDatabaseContext.autoinstall.test.tsx
- npm run type-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for per-fiscal-source offline database installation and management, enabling users to install and access offline data for individual fiscal sources rather than a single monolithic bundle.
  * Implemented encrypted offline bundle delivery from remote storage with integrity verification.

* **Improvements**
  * Enhanced offline database initialization to support source-specific metadata tracking and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->