### PR TITLE
Add static R2 offline fiscal bundle flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,13 @@ BILLING__ASAAS_WEBHOOK_TOKEN=change_me
 VITE_API_URL=https://seu-backend.onrender.com
 # Opcional: sobrepõe VITE_API_URL quando necessário
 VITE_API_FILTER_URL=
+# Base pública do bucket R2. Publique os arquivos gerados por
+# scripts/build_r2_fiscal_bundles.py nesse prefixo:
+#   fiscal_offline.enc
+#   fiscal_offline.meta.json
+VITE_FISCAL_R2_BASE_URL=https://pub-example.r2.dev/fiscal
+# Deve ser o mesmo valor usado em OFFLINE_DB_APP_SEED ao gerar os bundles.
+VITE_OFFLINE_DB_PUBLIC_SEED=change_me_32_byte_hex
 # Em site publicado, use a publishable key live do Clerk (pk_live_...)
 VITE_CLERK_PUBLISHABLE_KEY=pk_live_change_me
 VITE_CLERK_TOKEN_TEMPLATE=backend_api

--- a/client/src/context/offlineDatabase.types.ts
+++ b/client/src/context/offlineDatabase.types.ts
@@ -114,7 +114,12 @@ export type OfflineDatabaseWorkerRequest =
         type: 'INIT';
         id: string | null;
         payload:
-            | { chunkSize: number; pbkdf2Iterations: number; seed?: string }
+            | {
+                chunkSize: number;
+                pbkdf2Iterations: number;
+                seed?: string;
+                publicSeed?: string;
+            }
             | {
                 chunkSize: number;
                 pbkdf2Iterations: number;
@@ -127,6 +132,11 @@ export type OfflineDatabaseWorkerRequest =
         id: string | null;
         payload:
             | { apiBase: string; clerkToken?: string | null }
+            | {
+                r2BaseUrl: string;
+                publicSeed: string;
+                metadata: OfflineDatabaseMetadata;
+            }
             | {
                 source: OfflineFiscalSourceId;
                 r2BaseUrl: string;

--- a/client/src/context/offlineDatabaseMutations.ts
+++ b/client/src/context/offlineDatabaseMutations.ts
@@ -3,7 +3,6 @@ import { useCallback } from 'react';
 import {
     compareOfflineVersions,
     formatOfflineDatabaseErrorMessage,
-    isOfflineSourceMetadata,
 } from '../utils/offlineDatabase';
 
 import {
@@ -88,26 +87,23 @@ export function useOfflineDatabaseMutations({
 
             const r2BaseUrl = getFiscalR2BaseUrl();
             const publicSeed = getOfflineDbPublicSeed();
-            const sourceMetadata = isOfflineSourceMetadata(metadata) ? metadata : null;
-            const hasInvalidSourceMetadata = Boolean(
-                metadata
-                && typeof metadata === 'object'
-                && 'source' in metadata
-                && !sourceMetadata,
-            );
-            if (r2BaseUrl && publicSeed && hasInvalidSourceMetadata) {
+            if (r2BaseUrl && !publicSeed) {
                 throw new Error(
-                    'Metadados da fonte fiscal estão corrompidos. Limpe o cache do navegador e tente novamente.',
+                    'VITE_OFFLINE_DB_PUBLIC_SEED precisa estar configurado para instalar a base fiscal pelo R2.',
+                );
+            }
+            if (r2BaseUrl && publicSeed && !metadata) {
+                throw new Error(
+                    'Metadados da base fiscal no R2 indisponíveis. Verifique VITE_FISCAL_R2_BASE_URL e o arquivo fiscal_offline.meta.json.',
                 );
             }
 
             const installPayload =
-                r2BaseUrl && publicSeed && sourceMetadata
+                r2BaseUrl && publicSeed && metadata
                     ? {
-                        source: sourceMetadata.source,
                         r2BaseUrl,
                         publicSeed,
-                        metadata: sourceMetadata,
+                        metadata,
                     }
                     : {
                         apiBase: getOfflineDatabaseApiBaseUrl(),

--- a/client/src/context/offlineDatabaseMutations.ts
+++ b/client/src/context/offlineDatabaseMutations.ts
@@ -92,11 +92,6 @@ export function useOfflineDatabaseMutations({
                     'VITE_OFFLINE_DB_PUBLIC_SEED precisa estar configurado para instalar a base fiscal pelo R2.',
                 );
             }
-            if (r2BaseUrl && publicSeed && !metadata) {
-                throw new Error(
-                    'Metadados da base fiscal no R2 indisponíveis. Verifique VITE_FISCAL_R2_BASE_URL e o arquivo fiscal_offline.meta.json.',
-                );
-            }
 
             const installPayload =
                 r2BaseUrl && publicSeed && metadata
@@ -184,9 +179,7 @@ export function useOfflineDatabaseMutations({
                 {
                     type: 'REMOVE',
                     id: null,
-                    payload: getFiscalR2BaseUrl() && getOfflineDbPublicSeed()
-                        ? { source: LEGACY_MONOLITHIC_BUNDLE_SOURCE }
-                        : {},
+                    payload: {},
                 },
                 10_000,
             );

--- a/client/src/context/offlineDatabaseRuntime.ts
+++ b/client/src/context/offlineDatabaseRuntime.ts
@@ -19,12 +19,11 @@ import {
     persistStoredOfflineDatabaseMetadata,
     persistStoredOfflineSourceMetadata,
     readStoredOfflineDatabaseMetadata,
-    readStoredOfflineSourceMetadata,
     runOfflineDatabaseTaskInBackground,
     type OfflineDatabaseSupportReport,
 } from './offlineDatabaseStorage';
 import {
-    fetchOfflineSourceAvailabilityMetadata,
+    fetchFiscalR2DatabaseAvailabilityMetadata,
     fetchOfflineDatabaseAvailabilityMetadata,
     getFiscalR2BaseUrl,
     getOfflineDbPublicSeed,
@@ -40,11 +39,9 @@ import { useOfflineDatabaseBroadcastChannel } from './offlineDatabaseRuntime/use
 import { useOfflineDatabaseSyncWaiter } from './offlineDatabaseRuntime/useOfflineDatabaseSyncWaiter';
 import { useOfflineDatabaseWorkerBridge } from './offlineDatabaseRuntime/useOfflineDatabaseWorkerBridge';
 
-const LEGACY_MONOLITHIC_BUNDLE_SOURCE = 'nesh';
-
 function readInitialOfflineMetadata(): OfflineDatabaseMetadata | null {
     if (getFiscalR2BaseUrl() && getOfflineDbPublicSeed()) {
-        return readStoredOfflineSourceMetadata(LEGACY_MONOLITHIC_BUNDLE_SOURCE);
+        return readStoredOfflineDatabaseMetadata();
     }
 
     return readStoredOfflineDatabaseMetadata();
@@ -162,13 +159,6 @@ export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
             try {
                 const seed = sessionStorage.getItem('offline_db_seed');
                 const publicSeed = getOfflineDbPublicSeed();
-                const sourcePayload =
-                    publicSeed && isOfflineSourceMetadata(initMetadata)
-                        ? {
-                            source: initMetadata.source,
-                            publicSeed,
-                        }
-                        : {};
                 await sendToWorker(
                     {
                         type: 'INIT',
@@ -176,7 +166,7 @@ export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
                         payload: {
                             ...buildOfflineDatabaseInitPayload(initMetadata),
                             seed: seed || undefined,
-                            ...sourcePayload,
+                            publicSeed: publicSeed || undefined,
                         },
                     },
                     30_000,
@@ -208,25 +198,16 @@ export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
                     const publicSeed = getOfflineDbPublicSeed();
                     let metadata: OfflineDatabaseMetadata | null = null;
                     if (r2BaseUrl && publicSeed) {
-                        try {
-                            metadata = await fetchOfflineSourceAvailabilityMetadata(
-                                r2BaseUrl,
-                                LEGACY_MONOLITHIC_BUNDLE_SOURCE,
-                            );
-                        } catch (sourceErr) {
-                            console.warn(
-                                'fetchOfflineSourceAvailabilityMetadata failed',
-                                sourceErr,
-                            );
-                        }
+                        metadata = await fetchFiscalR2DatabaseAvailabilityMetadata(
+                            r2BaseUrl,
+                        );
+                    } else {
+                        metadata = await fetchOfflineDatabaseAvailabilityMetadata(
+                            getOfflineDatabaseApiBaseUrl(),
+                        );
                     }
-                    metadata ||= await fetchOfflineDatabaseAvailabilityMetadata(
-                        getOfflineDatabaseApiBaseUrl(),
-                    );
                     remoteMetaRef.current = metadata;
-                    if (isOfflineSourceMetadata(metadata)) {
-                        persistStoredOfflineSourceMetadata(metadata.source, metadata);
-                    }
+                    persistStoredOfflineDatabaseMetadata(metadata);
                     setRemoteVersion(metadata?.version ?? null);
                     setDbSizeBytes((current) => current ?? metadata?.size_bytes ?? null);
                     return metadata;

--- a/client/src/context/offlineDatabaseSync.ts
+++ b/client/src/context/offlineDatabaseSync.ts
@@ -6,6 +6,7 @@ import {
     type OfflineSourceMetadata,
 } from '../utils/offlineDatabase';
 import {
+    buildFiscalOfflineDatabaseUrls,
     buildFiscalBundleUrls,
     normalizeFiscalR2BaseUrl,
     type FiscalSourceId,
@@ -50,6 +51,52 @@ export async function fetchOfflineSourceAvailabilityMetadata(
     throw lastError instanceof Error
         ? lastError
         : new Error('Source metadata check failed for an unknown reason');
+}
+
+export async function fetchFiscalR2DatabaseAvailabilityMetadata(
+    r2BaseUrl: string,
+): Promise<OfflineDatabaseMetadata | null> {
+    let lastError: unknown = null;
+    for (const timeoutMs of OFFLINE_METADATA_TIMEOUTS_MS) {
+        try {
+            return await fetchFiscalR2DatabaseAvailabilityMetadataOnce(
+                r2BaseUrl,
+                timeoutMs,
+            );
+        } catch (err) {
+            lastError = err;
+            if (!isRetryableOfflineMetadataError(err)) break;
+        }
+    }
+
+    throw lastError instanceof Error
+        ? lastError
+        : new Error('R2 metadata check failed for an unknown reason');
+}
+
+async function fetchFiscalR2DatabaseAvailabilityMetadataOnce(
+    r2BaseUrl: string,
+    timeoutMs: number,
+): Promise<OfflineDatabaseMetadata | null> {
+    const { metadataUrl } = buildFiscalOfflineDatabaseUrls(r2BaseUrl);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+        const response = await fetch(metadataUrl, {
+            method: 'GET',
+            headers: { Accept: 'application/json' },
+            signal: controller.signal,
+        });
+
+        if (!response.ok) {
+            throw new Error(`R2 metadata check failed (${response.status})`);
+        }
+
+        return sanitizeOfflineMetadata(await response.json());
+    } finally {
+        clearTimeout(timer);
+    }
 }
 
 async function fetchOfflineSourceAvailabilityMetadataOnce(

--- a/client/src/context/offlineDatabaseSync.ts
+++ b/client/src/context/offlineDatabaseSync.ts
@@ -93,7 +93,8 @@ async function fetchFiscalR2DatabaseAvailabilityMetadataOnce(
             throw new Error(`R2 metadata check failed (${response.status})`);
         }
 
-        return sanitizeOfflineMetadata(await response.json());
+        const metadata = sanitizeOfflineMetadata(await response.json());
+        return metadata?.encrypted_sha256?.trim() ? metadata : null;
     } finally {
         clearTimeout(timer);
     }

--- a/client/src/context/offlineSources.ts
+++ b/client/src/context/offlineSources.ts
@@ -46,3 +46,15 @@ export function buildFiscalBundleUrls(
     encryptedUrl: `${normalizedBaseUrl}/${source}/${source}.enc`,
   };
 }
+
+export function buildFiscalOfflineDatabaseUrls(baseUrl: string): FiscalBundleUrls {
+  const normalizedBaseUrl = normalizeFiscalR2BaseUrl(baseUrl);
+  if (!normalizedBaseUrl) {
+    throw new Error('baseUrl is required for fiscal database URLs');
+  }
+
+  return {
+    metadataUrl: `${normalizedBaseUrl}/fiscal_offline.meta.json`,
+    encryptedUrl: `${normalizedBaseUrl}/fiscal_offline.enc`,
+  };
+}

--- a/client/src/workers/dbWorker/messages.js
+++ b/client/src/workers/dbWorker/messages.js
@@ -299,54 +299,52 @@ export function getStaticR2InstallPayloadIntent(payload) {
 }
 
 export function validateStaticR2InstallPayload(payload) {
-  if (!payload || typeof payload !== "object") {
-    return { ok: false, error: "Static R2 install payload is incomplete" };
-  }
-
-  if (
-    typeof payload.r2BaseUrl !== "string"
-      || !payload.r2BaseUrl.trim()
-      || typeof payload.publicSeed !== "string"
-      || !payload.publicSeed.trim()
-      || !payload.metadata
-      || typeof payload.metadata !== "object"
-      || typeof payload.metadata.version !== "string"
-      || !payload.metadata.version.trim()
-      || typeof payload.metadata.encrypted_sha256 !== "string"
-      || !payload.metadata.encrypted_sha256.trim()
-  ) {
-    return { ok: false, error: "Static R2 install payload is incomplete" };
-  }
-
-  return { ok: true };
+  return validateR2InstallPayloadFields(
+    payload,
+    "Static R2 install payload is incomplete"
+  );
 }
 
 export function validateSourceAwareInstallPayload(payload) {
-  if (!payload || typeof payload !== "object") {
-    return { ok: false, error: "Source-aware install payload is incomplete" };
-  }
+  const fieldValidation = validateR2InstallPayloadFields(
+    payload,
+    "Source-aware install payload is incomplete"
+  );
+  if (!fieldValidation.ok) return fieldValidation;
 
   if (!isFiscalSourceId(payload.source)) {
     return { ok: false, error: "Invalid source-aware install source" };
   }
 
+  if (payload.metadata.source !== payload.source) {
+    return { ok: false, error: "Source metadata does not match install source" };
+  }
+
+  return { ok: true };
+}
+
+function validateR2InstallPayloadFields(payload, incompleteError) {
+  if (!payload || typeof payload !== "object") {
+    return { ok: false, error: incompleteError };
+  }
+
+  const metadata = payload.metadata;
+  const hasRequiredMetadata =
+    metadata
+    && typeof metadata === "object"
+    && typeof metadata.version === "string"
+    && metadata.version.trim()
+    && typeof metadata.encrypted_sha256 === "string"
+    && metadata.encrypted_sha256.trim();
+
   if (
     typeof payload.r2BaseUrl !== "string"
       || !payload.r2BaseUrl.trim()
       || typeof payload.publicSeed !== "string"
       || !payload.publicSeed.trim()
-      || !payload.metadata
-      || typeof payload.metadata !== "object"
-      || typeof payload.metadata.version !== "string"
-      || !payload.metadata.version.trim()
-      || typeof payload.metadata.encrypted_sha256 !== "string"
-      || !payload.metadata.encrypted_sha256.trim()
+      || !hasRequiredMetadata
   ) {
-    return { ok: false, error: "Source-aware install payload is incomplete" };
-  }
-
-  if (payload.metadata.source !== payload.source) {
-    return { ok: false, error: "Source metadata does not match install source" };
+    return { ok: false, error: incompleteError };
   }
 
   return { ok: true };

--- a/client/src/workers/dbWorker/messages.js
+++ b/client/src/workers/dbWorker/messages.js
@@ -96,7 +96,12 @@ async function handleInitMessage(id, payload) {
   const version = source ? await readSourceVersion(source) : await readVersion();
   const opfsSeed = source ? null : await readSeed();
   const seed = source ? payload?.publicSeed : opfsSeed || payload?.seed || payload?.publicSeed;
-  const usedPayloadSeedFallback = !opfsSeed && Boolean(payload?.seed);
+  const payloadSeedFallback = payload?.seed || payload?.publicSeed;
+  const usedPayloadSeedFallback =
+    !source &&
+    !opfsSeed &&
+    Boolean(payloadSeedFallback) &&
+    seed === payloadSeedFallback;
 
   if (!encData || !version || !seed) {
     setWorkerStatus("not_installed");
@@ -349,61 +354,61 @@ export function validateSourceAwareInstallPayload(payload) {
 
 async function fetchEncryptedSourceBundle(r2BaseUrl, source) {
   const { encryptedUrl } = buildFiscalBundleUrls(r2BaseUrl, source);
-  const dlResp = await fetch(encryptedUrl, {
-    method: "GET",
-    headers: { Accept: "application/octet-stream" },
-  });
-
-  if (dlResp.ok) {
-    return dlResp;
-  }
-
-  const errText = await dlResp.text();
-  throw new Error(
-    `Offline source bundle retrieval failed (${dlResp.status}): ${errText}`
+  return fetchEncryptedR2Bundle(
+    encryptedUrl,
+    "Offline source bundle retrieval failed"
   );
 }
 
 async function fetchEncryptedStaticR2Bundle(r2BaseUrl) {
   const { encryptedUrl } = buildFiscalOfflineDatabaseUrls(r2BaseUrl);
-  const dlResp = await fetch(encryptedUrl, {
-    method: "GET",
-    headers: { Accept: "application/octet-stream" },
-  });
+  return fetchEncryptedR2Bundle(
+    encryptedUrl,
+    "Offline fiscal bundle retrieval failed"
+  );
+}
+
+async function fetchEncryptedR2Bundle(encryptedUrl, errorPrefix) {
+  const dlResp = await fetchWithTimeout(
+    encryptedUrl,
+    {
+      method: "GET",
+      headers: { Accept: "application/octet-stream" },
+    },
+    OFFLINE_FETCH_TIMEOUT_MS,
+    "download",
+  );
 
   if (dlResp.ok) {
     return dlResp;
   }
 
   const errText = await dlResp.text();
-  throw new Error(
-    `Offline fiscal bundle retrieval failed (${dlResp.status}): ${errText}`
-  );
+  throw new Error(`${errorPrefix} (${dlResp.status}): ${errText}`);
 }
 
 async function fetchEncryptedStaticR2BundleWithRetry(r2BaseUrl, id) {
-  let lastError = null;
-
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    try {
-      return await fetchEncryptedStaticR2Bundle(r2BaseUrl);
-    } catch (error) {
-      lastError = error;
-      if (!isRetryableOfflineDownloadError(error) || attempt === 1) break;
-      postWorkerProgress(id, 10, "retrying_download");
-      await waitBeforeOfflineDownloadRetry();
-    }
-  }
-
-  throw lastError instanceof Error ? lastError : new Error("Offline fiscal bundle download failed");
+  return fetchEncryptedR2BundleWithRetry(
+    () => fetchEncryptedStaticR2Bundle(r2BaseUrl),
+    id,
+    "Offline fiscal bundle download failed"
+  );
 }
 
 async function fetchEncryptedSourceBundleWithRetry(r2BaseUrl, source, id) {
+  return fetchEncryptedR2BundleWithRetry(
+    () => fetchEncryptedSourceBundle(r2BaseUrl, source),
+    id,
+    "Offline source bundle download failed"
+  );
+}
+
+async function fetchEncryptedR2BundleWithRetry(fetchBundle, id, fallbackMessage) {
   let lastError = null;
 
   for (let attempt = 0; attempt < 2; attempt += 1) {
     try {
-      return await fetchEncryptedSourceBundle(r2BaseUrl, source);
+      return await fetchBundle();
     } catch (error) {
       lastError = error;
       if (!isRetryableOfflineDownloadError(error) || attempt === 1) break;
@@ -412,7 +417,7 @@ async function fetchEncryptedSourceBundleWithRetry(r2BaseUrl, source, id) {
     }
   }
 
-  throw lastError instanceof Error ? lastError : new Error("Offline source bundle download failed");
+  throw lastError instanceof Error ? lastError : new Error(fallbackMessage);
 }
 
 async function updateInstalledVersion(apiBase) {
@@ -442,92 +447,64 @@ async function updateInstalledVersion(apiBase) {
 }
 
 async function handleSourceAwareInstallMessage(id, payload) {
-  setWorkerStatus("installing");
-  postWorkerProgress(id, 0, "fetching_database");
-
   const {
     source,
     r2BaseUrl,
     publicSeed,
     metadata,
   } = payload;
-  /** @type {Uint8Array | null} */
-  let plaintext = null;
 
-  try {
-    const dlResp = await fetchEncryptedSourceBundleWithRetry(r2BaseUrl, source, id);
-    const encryptedBlob = await readEncryptedDatabaseBlob(dlResp, id);
-    const {
-      encrypted_sha256: expectedEncryptedSha256,
-      chunk_size: chunkSize = 65536,
-      pbkdf2_iterations: iterations = 600000,
-    } = metadata;
-
-    postWorkerProgress(id, 72, "verifying_integrity");
-    const actualEncryptedSha256 = await sha256Hex(encryptedBlob);
-    if (actualEncryptedSha256 !== expectedEncryptedSha256) {
-      throw new Error("Offline database integrity verification failed");
-    }
-
-    setAppSeed(publicSeed);
-
-    postWorkerProgress(id, 75, "decrypting");
-    plaintext = await decryptDatabase(encryptedBlob, chunkSize, iterations);
-
-    postWorkerProgress(id, 85, "loading");
-    await loadDatabaseFromBytes(plaintext);
-
-    postWorkerProgress(id, 90, "saving");
-    try {
+  await installR2Bundle(id, {
+    publicSeed,
+    metadata,
+    fetchBundle: () => fetchEncryptedSourceBundleWithRetry(r2BaseUrl, source, id),
+    saveBundle: async (encryptedBlob) => {
       await saveSourceToOpfs(source, encryptedBlob);
       await saveSourceVersion(source, metadata.version || "unknown");
-    } catch (error) {
-      await removeSourceFromOpfs(source);
-      throw error;
-    }
-
-    setWorkerVersion(metadata.version || "unknown");
-    setWorkerStatus("ready");
-    postWorkerProgress(id, 100, "done");
-    postWorkerStatus(id, {
-      status: "ready",
-      version: getWorkerVersion(),
-      sizeBytes: encryptedBlob.length,
-      seed: publicSeed,
-    });
-  } catch (error) {
-    setWorkerStatus("error");
-    const message = error instanceof Error ? error.message : "Unknown error";
-    const recoverableMessage = `${message}. Reinstale o banco offline para continuar.`;
-    postWorkerStatus(id, {
-      status: "error",
-      error: recoverableMessage,
-      recoverable: true,
-    });
-    postWorkerError(id, recoverableMessage);
-    await removeSourceFromOpfs(source).catch(() => undefined);
-    return;
-  } finally {
-    if (plaintext) {
-      plaintext.fill(0);
-    }
-  }
+    },
+    cleanupAfterSaveError: () => removeSourceFromOpfs(source),
+    cleanupAfterInstallError: () => removeSourceFromOpfs(source),
+  });
 }
 
 async function handleStaticR2InstallMessage(id, payload) {
-  setWorkerStatus("installing");
-  postWorkerProgress(id, 0, "fetching_database");
-
   const {
     r2BaseUrl,
     publicSeed,
     metadata,
   } = payload;
+
+  await installR2Bundle(id, {
+    publicSeed,
+    metadata,
+    fetchBundle: () => fetchEncryptedStaticR2BundleWithRetry(r2BaseUrl, id),
+    saveBundle: async (encryptedBlob) => {
+      await saveToOpfs(encryptedBlob);
+      await saveSeed(publicSeed);
+      await saveVersion(metadata.version || "unknown");
+    },
+    cleanupAfterSaveError: removeFromOpfs,
+    cleanupAfterInstallError: removeFromOpfs,
+  });
+}
+
+async function installR2Bundle(id, options) {
+  setWorkerStatus("installing");
+  postWorkerProgress(id, 0, "fetching_database");
+
+  const {
+    publicSeed,
+    metadata,
+    fetchBundle,
+    saveBundle,
+    cleanupAfterSaveError,
+    cleanupAfterInstallError,
+  } = options;
   /** @type {Uint8Array | null} */
   let plaintext = null;
 
   try {
-    const dlResp = await fetchEncryptedStaticR2BundleWithRetry(r2BaseUrl, id);
+    const dlResp = await fetchBundle();
     const encryptedBlob = await readEncryptedDatabaseBlob(dlResp, id);
     const {
       encrypted_sha256: expectedEncryptedSha256,
@@ -551,11 +528,9 @@ async function handleStaticR2InstallMessage(id, payload) {
 
     postWorkerProgress(id, 90, "saving");
     try {
-      await saveToOpfs(encryptedBlob);
-      await saveSeed(publicSeed);
-      await saveVersion(metadata.version || "unknown");
+      await saveBundle(encryptedBlob);
     } catch (error) {
-      await removeFromOpfs();
+      await cleanupAfterSaveError();
       throw error;
     }
 
@@ -578,6 +553,7 @@ async function handleStaticR2InstallMessage(id, payload) {
       recoverable: true,
     });
     postWorkerError(id, recoverableMessage);
+    await cleanupAfterInstallError().catch(() => undefined);
     return;
   } finally {
     if (plaintext) {

--- a/client/src/workers/dbWorker/messages.js
+++ b/client/src/workers/dbWorker/messages.js
@@ -95,7 +95,7 @@ async function handleInitMessage(id, payload) {
   const encData = source ? await readSourceFromOpfs(source) : await readFromOpfs();
   const version = source ? await readSourceVersion(source) : await readVersion();
   const opfsSeed = source ? null : await readSeed();
-  const seed = source ? payload?.publicSeed : opfsSeed || payload?.seed;
+  const seed = source ? payload?.publicSeed : opfsSeed || payload?.seed || payload?.publicSeed;
   const usedPayloadSeedFallback = !opfsSeed && Boolean(payload?.seed);
 
   if (!encData || !version || !seed) {
@@ -258,6 +258,13 @@ function buildFiscalBundleUrls(r2BaseUrl, source) {
   };
 }
 
+function buildFiscalOfflineDatabaseUrls(r2BaseUrl) {
+  const normalizedBaseUrl = trimTrailingSlashes(String(r2BaseUrl || ""));
+  return {
+    encryptedUrl: `${normalizedBaseUrl}/fiscal_offline.enc`,
+  };
+}
+
 function trimTrailingSlashes(value) {
   let end = value.length;
   while (end > 0 && value.charCodeAt(end - 1) === 47) {
@@ -273,6 +280,40 @@ export function getSourceAwareInstallPayloadIntent(payload) {
       && "source" in payload
       && "r2BaseUrl" in payload
   );
+}
+
+export function getStaticR2InstallPayloadIntent(payload) {
+  return Boolean(
+    payload
+      && typeof payload === "object"
+      && !("source" in payload)
+      && "r2BaseUrl" in payload
+      && "publicSeed" in payload
+      && "metadata" in payload
+  );
+}
+
+export function validateStaticR2InstallPayload(payload) {
+  if (!payload || typeof payload !== "object") {
+    return { ok: false, error: "Static R2 install payload is incomplete" };
+  }
+
+  if (
+    typeof payload.r2BaseUrl !== "string"
+      || !payload.r2BaseUrl.trim()
+      || typeof payload.publicSeed !== "string"
+      || !payload.publicSeed.trim()
+      || !payload.metadata
+      || typeof payload.metadata !== "object"
+      || typeof payload.metadata.version !== "string"
+      || !payload.metadata.version.trim()
+      || typeof payload.metadata.encrypted_sha256 !== "string"
+      || !payload.metadata.encrypted_sha256.trim()
+  ) {
+    return { ok: false, error: "Static R2 install payload is incomplete" };
+  }
+
+  return { ok: true };
 }
 
 export function validateSourceAwareInstallPayload(payload) {
@@ -321,6 +362,40 @@ async function fetchEncryptedSourceBundle(r2BaseUrl, source) {
   throw new Error(
     `Offline source bundle retrieval failed (${dlResp.status}): ${errText}`
   );
+}
+
+async function fetchEncryptedStaticR2Bundle(r2BaseUrl) {
+  const { encryptedUrl } = buildFiscalOfflineDatabaseUrls(r2BaseUrl);
+  const dlResp = await fetch(encryptedUrl, {
+    method: "GET",
+    headers: { Accept: "application/octet-stream" },
+  });
+
+  if (dlResp.ok) {
+    return dlResp;
+  }
+
+  const errText = await dlResp.text();
+  throw new Error(
+    `Offline fiscal bundle retrieval failed (${dlResp.status}): ${errText}`
+  );
+}
+
+async function fetchEncryptedStaticR2BundleWithRetry(r2BaseUrl, id) {
+  let lastError = null;
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      return await fetchEncryptedStaticR2Bundle(r2BaseUrl);
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableOfflineDownloadError(error) || attempt === 1) break;
+      postWorkerProgress(id, 10, "retrying_download");
+      await waitBeforeOfflineDownloadRetry();
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("Offline fiscal bundle download failed");
 }
 
 async function fetchEncryptedSourceBundleWithRetry(r2BaseUrl, source, id) {
@@ -439,6 +514,78 @@ async function handleSourceAwareInstallMessage(id, payload) {
   }
 }
 
+async function handleStaticR2InstallMessage(id, payload) {
+  setWorkerStatus("installing");
+  postWorkerProgress(id, 0, "fetching_database");
+
+  const {
+    r2BaseUrl,
+    publicSeed,
+    metadata,
+  } = payload;
+  /** @type {Uint8Array | null} */
+  let plaintext = null;
+
+  try {
+    const dlResp = await fetchEncryptedStaticR2BundleWithRetry(r2BaseUrl, id);
+    const encryptedBlob = await readEncryptedDatabaseBlob(dlResp, id);
+    const {
+      encrypted_sha256: expectedEncryptedSha256,
+      chunk_size: chunkSize = 65536,
+      pbkdf2_iterations: iterations = 600000,
+    } = metadata;
+
+    postWorkerProgress(id, 72, "verifying_integrity");
+    const actualEncryptedSha256 = await sha256Hex(encryptedBlob);
+    if (actualEncryptedSha256 !== expectedEncryptedSha256) {
+      throw new Error("Offline database integrity verification failed");
+    }
+
+    setAppSeed(publicSeed);
+
+    postWorkerProgress(id, 75, "decrypting");
+    plaintext = await decryptDatabase(encryptedBlob, chunkSize, iterations);
+
+    postWorkerProgress(id, 85, "loading");
+    await loadDatabaseFromBytes(plaintext);
+
+    postWorkerProgress(id, 90, "saving");
+    try {
+      await saveToOpfs(encryptedBlob);
+      await saveSeed(publicSeed);
+      await saveVersion(metadata.version || "unknown");
+    } catch (error) {
+      await removeFromOpfs();
+      throw error;
+    }
+
+    setWorkerVersion(metadata.version || "unknown");
+    setWorkerStatus("ready");
+    postWorkerProgress(id, 100, "done");
+    postWorkerStatus(id, {
+      status: "ready",
+      version: getWorkerVersion(),
+      sizeBytes: encryptedBlob.length,
+      seed: publicSeed,
+    });
+  } catch (error) {
+    setWorkerStatus("error");
+    const message = error instanceof Error ? error.message : "Unknown error";
+    const recoverableMessage = `${message}. Reinstale o banco offline para continuar.`;
+    postWorkerStatus(id, {
+      status: "error",
+      error: recoverableMessage,
+      recoverable: true,
+    });
+    postWorkerError(id, recoverableMessage);
+    return;
+  } finally {
+    if (plaintext) {
+      plaintext.fill(0);
+    }
+  }
+}
+
 async function handleLegacyInstallMessage(id, payload) {
   setWorkerStatus("installing");
   postWorkerProgress(id, 0, "requesting_token");
@@ -514,6 +661,22 @@ async function handleLegacyInstallMessage(id, payload) {
 }
 
 async function handleInstallMessage(id, payload) {
+  if (getStaticR2InstallPayloadIntent(payload)) {
+    const validation = validateStaticR2InstallPayload(payload);
+    if (!validation.ok) {
+      setWorkerStatus("error");
+      postWorkerStatus(id, {
+        status: "error",
+        error: validation.error,
+        recoverable: true,
+      });
+      postWorkerError(id, validation.error);
+      return;
+    }
+    await handleStaticR2InstallMessage(id, payload);
+    return;
+  }
+
   if (getSourceAwareInstallPayloadIntent(payload)) {
     const validation = validateSourceAwareInstallPayload(payload);
     if (!validation.ok) {

--- a/client/src/workers/dbWorker/messages.test.js
+++ b/client/src/workers/dbWorker/messages.test.js
@@ -59,8 +59,11 @@ import {
 import {
   removeFromOpfs,
   removeSourceFromOpfs,
+  saveSeed,
   saveSourceToOpfs,
   saveSourceVersion,
+  saveToOpfs,
+  saveVersion,
 } from './opfs.js';
 import { decryptDatabase, setAppSeed, sha256Hex } from './crypto.js';
 import { postWorkerError, postWorkerStatus } from './protocol.js';
@@ -230,6 +233,52 @@ describe('dbWorker messages network helpers', () => {
     expect(removeSourceFromOpfs).not.toHaveBeenCalled();
     expect(postWorkerStatus).toHaveBeenCalledWith(
       'install-source',
+      expect.objectContaining({ status: 'ready' }),
+    );
+  });
+
+  it('installs a static consolidated R2 fiscal bundle without requesting backend tokens', async () => {
+    const encryptedBlob = new Uint8Array([9, 8, 7]);
+    sha256Hex.mockResolvedValue('static-encrypted-sha');
+    decryptDatabase.mockResolvedValue(new Uint8Array([6, 5, 4]));
+    loadDatabaseFromBytes.mockResolvedValue(undefined);
+    saveToOpfs.mockResolvedValue(undefined);
+    saveSeed.mockResolvedValue(undefined);
+    saveVersion.mockResolvedValue(undefined);
+    getWorkerVersion.mockReturnValue('2026.05.11');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(encryptedBlob, {
+          status: 200,
+          headers: { 'content-length': String(encryptedBlob.length) },
+        }),
+      ),
+    );
+
+    await dispatchWorkerMessage('INSTALL', 'install-r2-static', {
+      r2BaseUrl: 'https://r2.example.test/fiscal',
+      publicSeed: 'public-seed',
+      metadata: {
+        version: '2026.05.11',
+        encrypted_sha256: 'static-encrypted-sha',
+      },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://r2.example.test/fiscal/fiscal_offline.enc',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining('/database/token'),
+      expect.anything(),
+    );
+    expect(setAppSeed).toHaveBeenCalledWith('public-seed');
+    expect(saveToOpfs).toHaveBeenCalledWith(encryptedBlob);
+    expect(saveSeed).toHaveBeenCalledWith('public-seed');
+    expect(saveVersion).toHaveBeenCalledWith('2026.05.11');
+    expect(postWorkerStatus).toHaveBeenCalledWith(
+      'install-r2-static',
       expect.objectContaining({ status: 'ready' }),
     );
   });

--- a/client/src/workers/dbWorker/messages.test.js
+++ b/client/src/workers/dbWorker/messages.test.js
@@ -57,6 +57,9 @@ import {
   fetchWithTimeout,
 } from './messages.js';
 import {
+  readFromOpfs,
+  readSeed,
+  readVersion,
   removeFromOpfs,
   removeSourceFromOpfs,
   saveSeed,
@@ -280,6 +283,28 @@ describe('dbWorker messages network helpers', () => {
     expect(postWorkerStatus).toHaveBeenCalledWith(
       'install-r2-static',
       expect.objectContaining({ status: 'ready' }),
+    );
+  });
+
+  it('removes the stale generic bundle when publicSeed fallback cannot decrypt', async () => {
+    readFromOpfs.mockResolvedValue(new Uint8Array([1, 2, 3]));
+    readVersion.mockResolvedValue('2026.05.11');
+    readSeed.mockResolvedValue(null);
+    decryptDatabase.mockRejectedValue(new Error('bad seed'));
+    removeFromOpfs.mockResolvedValue(undefined);
+
+    await dispatchWorkerMessage('INIT', 'init-public-seed', {
+      publicSeed: 'public-seed',
+    });
+
+    expect(setAppSeed).toHaveBeenCalledWith('public-seed');
+    expect(removeFromOpfs).toHaveBeenCalledTimes(1);
+    expect(postWorkerStatus).toHaveBeenCalledWith(
+      'init-public-seed',
+      expect.objectContaining({
+        status: 'error',
+        recoverable: true,
+      }),
     );
   });
 

--- a/client/tests/unit/LocalDatabaseContext.autoinstall.test.tsx
+++ b/client/tests/unit/LocalDatabaseContext.autoinstall.test.tsx
@@ -144,10 +144,9 @@ function makeVersionResponse(version: string) {
   );
 }
 
-function makeSourceMetadataResponse(version: string) {
+function makeR2MetadataResponse(version: string) {
   return new Response(
     JSON.stringify({
-      source: 'nesh',
       version,
       size_bytes: 4096,
       sha256: 'plain-sha',
@@ -303,7 +302,7 @@ describe('LocalDatabaseContext auto-install behavior', () => {
       if (url.includes('/database/version') || url.includes('/database/token')) {
         return Promise.reject(new Error(`legacy endpoint called: ${url}`));
       }
-      return Promise.resolve(makeSourceMetadataResponse('2026.05.01'));
+      return Promise.resolve(makeR2MetadataResponse('2026.05.01'));
     });
 
     renderLocalDatabaseProvider();
@@ -313,18 +312,16 @@ describe('LocalDatabaseContext auto-install behavior', () => {
     const fetchUrls = (fetch as ReturnType<typeof vi.fn>).mock.calls.map((call) =>
       String(call[0]),
     );
-    expect(fetchUrls).toContain('https://r2.example.com/fiscal/nesh/nesh.meta.json');
+    expect(fetchUrls).toContain('https://r2.example.com/fiscal/fiscal_offline.meta.json');
     expect(fetchUrls.join('\n')).not.toContain('/database/version');
     expect(fetchUrls.join('\n')).not.toContain('/database/token');
     expect(getPostedWorkerMessages()).toContainEqual(
       expect.objectContaining({
         type: 'INSTALL',
         payload: {
-          source: 'nesh',
           r2BaseUrl: 'https://r2.example.com/fiscal',
           publicSeed: 'public-seed',
           metadata: expect.objectContaining({
-            source: 'nesh',
             version: '2026.05.01',
             encrypted_sha256: 'enc-sha',
           }),
@@ -360,7 +357,7 @@ describe('LocalDatabaseContext auto-install behavior', () => {
 
   it('falls back to the legacy install payload when R2 metadata is unavailable', async () => {
     configureR2Install((url: string) => {
-      if (url.includes('/nesh/nesh.meta.json')) {
+      if (url.includes('/fiscal_offline.meta.json')) {
         return Promise.reject(new Error('source metadata unavailable'));
       }
       return Promise.resolve(makeVersionResponse('2026.05.01'));
@@ -371,6 +368,30 @@ describe('LocalDatabaseContext auto-install behavior', () => {
     await installCurrentDatabase();
 
     expectLegacyInstallPayload();
+  });
+
+  it('uses the monolithic remove payload for static R2 installs', async () => {
+    MockWorker.initStatus = 'ready';
+    MockWorker.initVersion = '2026.05.01';
+    MockWorker.initSizeBytes = 4096;
+    configureR2Install(() => Promise.resolve(makeR2MetadataResponse('2026.05.01')));
+
+    renderLocalDatabaseProvider();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('status')).toHaveTextContent('ready'),
+    );
+
+    await act(async () => {
+      await currentContext!.remove();
+    });
+
+    expect(getPostedWorkerMessages()).toContainEqual(
+      expect.objectContaining({
+        type: 'REMOVE',
+        payload: {},
+      }),
+    );
   });
 
   it('clears the auto-install opt-out when install is started manually', async () => {

--- a/scripts/build_r2_fiscal_bundles.py
+++ b/scripts/build_r2_fiscal_bundles.py
@@ -21,7 +21,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts.build_offline_db import (
+from scripts.build_offline_db import (  # noqa: E402
     DB_DIR,
     OUTPUT_DB,
     OfflineBundleOutput,

--- a/scripts/build_r2_fiscal_bundles.py
+++ b/scripts/build_r2_fiscal_bundles.py
@@ -1,7 +1,11 @@
 """
 Build R2-ready per-source fiscal bundles.
 
-Each fiscal source is written to its own directory:
+The default output is a single SQLite bundle containing every fiscal source:
+    database/r2/fiscal_offline.enc
+    database/r2/fiscal_offline.meta.json
+
+Per-source bundles can also be generated for future source-scoped installs:
     database/r2/<source>/<source>.enc
     database/r2/<source>/<source>.meta.json
 """
@@ -9,12 +13,26 @@ Each fiscal source is written to its own directory:
 from __future__ import annotations
 
 import argparse
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from scripts.build_offline_db import DB_DIR, OfflineBundleOutput, build_source_bundle
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.build_offline_db import (
+    DB_DIR,
+    OUTPUT_DB,
+    OfflineBundleOutput,
+    _consolidate_databases,
+    _encrypt_database,
+    _write_bundle_metadata,
+    build_source_bundle,
+)
 
 DEFAULT_OUTPUT_ROOT = DB_DIR / "r2"
+DEFAULT_BUNDLE_NAME = "fiscal_offline"
 
 
 @dataclass(frozen=True)
@@ -64,7 +82,11 @@ def normalize_source_filter(source: str | None) -> set[str] | None:
 def build_all(
     output_root: Path = DEFAULT_OUTPUT_ROOT,
     source_filter: set[str] | None = None,
+    split_sources: bool = False,
 ) -> list[OfflineBundleOutput]:
+    if not split_sources:
+        return [build_monolithic_bundle(output_root)]
+
     outputs: list[OfflineBundleOutput] = []
     for source in FISCAL_SOURCES:
         if source_filter is not None and source.id not in source_filter:
@@ -80,11 +102,50 @@ def build_all(
     return outputs
 
 
+def build_monolithic_bundle(
+    output_root: Path = DEFAULT_OUTPUT_ROOT,
+    bundle_name: str = DEFAULT_BUNDLE_NAME,
+) -> OfflineBundleOutput:
+    encrypted_path = output_root / f"{bundle_name}.enc"
+    metadata_path = output_root / f"{bundle_name}.meta.json"
+    plaintext_path = output_root / f"{bundle_name}.db"
+
+    encrypted_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+
+    _consolidate_databases(plaintext_path)
+    try:
+        crypto_info = _encrypt_database(plaintext_path, encrypted_path)
+        version, built_at = _write_bundle_metadata(
+            "fiscal",
+            plaintext_path,
+            metadata_path,
+            crypto_info,
+        )
+    finally:
+        plaintext_path.unlink(missing_ok=True)
+        OUTPUT_DB.unlink(missing_ok=True)
+
+    return OfflineBundleOutput(
+        source="fiscal",
+        encrypted_path=encrypted_path,
+        metadata_path=metadata_path,
+        version=version,
+        built_at=built_at,
+        size_bytes=int(crypto_info["size_bytes"]),
+    )
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Build R2-ready fiscal bundles")
     parser.add_argument(
         "--source",
         help="Build only one source, or a comma-separated list of sources",
+    )
+    parser.add_argument(
+        "--split-sources",
+        action="store_true",
+        help="Build source-scoped bundles instead of the consolidated fiscal bundle",
     )
     parser.add_argument(
         "--output-root",
@@ -103,7 +164,11 @@ def main(argv: list[str] | None = None) -> int:
         print(str(exc))
         return 2
 
-    outputs = build_all(args.output_root, source_filter)
+    if source_filter and not args.split_sources:
+        print("--source requires --split-sources")
+        return 2
+
+    outputs = build_all(args.output_root, source_filter, args.split_sources)
     for output in outputs:
         print(f"{output.source}: {output.encrypted_path} ({output.size_bytes} bytes)")
     return 0

--- a/scripts/build_r2_fiscal_bundles.py
+++ b/scripts/build_r2_fiscal_bundles.py
@@ -114,6 +114,7 @@ def build_monolithic_bundle(
     metadata_path.parent.mkdir(parents=True, exist_ok=True)
 
     _consolidate_databases(plaintext_path)
+    success = False
     try:
         crypto_info = _encrypt_database(plaintext_path, encrypted_path)
         version, built_at = _write_bundle_metadata(
@@ -122,9 +123,13 @@ def build_monolithic_bundle(
             metadata_path,
             crypto_info,
         )
+        success = True
     finally:
         plaintext_path.unlink(missing_ok=True)
         OUTPUT_DB.unlink(missing_ok=True)
+        if not success:
+            encrypted_path.unlink(missing_ok=True)
+            metadata_path.unlink(missing_ok=True)
 
     return OfflineBundleOutput(
         source="fiscal",

--- a/tests/unit/test_build_r2_fiscal_bundles.py
+++ b/tests/unit/test_build_r2_fiscal_bundles.py
@@ -256,7 +256,7 @@ def test_build_all_builds_each_source_with_resolved_paths(tmp_path: Path, monkey
         fake_build_source_bundle,
     )
 
-    outputs = build_r2_fiscal_bundles.build_all(tmp_path)
+    outputs = build_r2_fiscal_bundles.build_all(tmp_path, split_sources=True)
 
     assert calls == [
         (
@@ -293,7 +293,11 @@ def test_build_all_can_filter_sources(tmp_path: Path, monkeypatch):
         fake_build_source_bundle,
     )
 
-    outputs = build_r2_fiscal_bundles.build_all(tmp_path, {"nbs"})
+    outputs = build_r2_fiscal_bundles.build_all(
+        tmp_path,
+        {"nbs"},
+        split_sources=True,
+    )
 
     assert [call[0] for call in calls] == ["nbs"]
     assert [output.source for output in outputs] == ["nbs"]

--- a/tests/unit/test_build_r2_fiscal_bundles.py
+++ b/tests/unit/test_build_r2_fiscal_bundles.py
@@ -299,6 +299,64 @@ def test_build_all_can_filter_sources(tmp_path: Path, monkeypatch):
     assert [output.source for output in outputs] == ["nbs"]
 
 
+def test_build_monolithic_bundle_removes_partial_outputs_when_metadata_fails(
+    tmp_path: Path,
+    monkeypatch,
+):
+    encrypted_path = tmp_path / "fiscal_offline.enc"
+    metadata_path = tmp_path / "fiscal_offline.meta.json"
+    plaintext_path = tmp_path / "fiscal_offline.db"
+    output_db = tmp_path / "build-output.db"
+
+    def fake_consolidate_databases(output_path: Path) -> None:
+        output_path.write_bytes(b"plain")
+        output_db.write_bytes(b"temporary")
+
+    def fake_encrypt_database(source_path: Path, output_path: Path) -> dict:
+        assert source_path == plaintext_path
+        output_path.write_bytes(b"encrypted")
+        return {
+            "sha256": "plain-sha",
+            "encrypted_sha256": "encrypted-sha",
+            "salt": "salt",
+            "size_bytes": output_path.stat().st_size,
+            "chunks": 1,
+        }
+
+    def fake_write_bundle_metadata(*args) -> tuple[str, str]:
+        metadata_path.write_text("{", encoding="utf-8")
+        raise RuntimeError("metadata failed")
+
+    monkeypatch.setattr(
+        build_r2_fiscal_bundles,
+        "_consolidate_databases",
+        fake_consolidate_databases,
+    )
+    monkeypatch.setattr(
+        build_r2_fiscal_bundles,
+        "_encrypt_database",
+        fake_encrypt_database,
+    )
+    monkeypatch.setattr(
+        build_r2_fiscal_bundles,
+        "_write_bundle_metadata",
+        fake_write_bundle_metadata,
+    )
+    monkeypatch.setattr(build_r2_fiscal_bundles, "OUTPUT_DB", output_db)
+
+    try:
+        build_r2_fiscal_bundles.build_monolithic_bundle(tmp_path)
+    except RuntimeError as exc:
+        assert str(exc) == "metadata failed"
+    else:
+        raise AssertionError("Expected metadata failure")
+
+    assert not plaintext_path.exists()
+    assert not output_db.exists()
+    assert not encrypted_path.exists()
+    assert not metadata_path.exists()
+
+
 def test_copy_plaintext_rejects_output_outside_test_bundle_dir(tmp_path: Path):
     plaintext_path = tmp_path / "unspsc.db"
     plaintext_path.write_bytes(b"bundle")


### PR DESCRIPTION
## Summary
- add a consolidated R2 fiscal bundle builder for the offline database
- make the frontend install the encrypted fiscal bundle directly from R2 when Vite R2 env vars are configured
- document the Pages/R2 env contract and add focused worker coverage

## Scope
- NESH, TIPI, and NBS only
- UNSPSC is intentionally out of scope for now
- generated database/r2 artifacts are not committed and should be uploaded to R2 separately

## Validation
- python scripts\\build_r2_fiscal_bundles.py
- python -m py_compile scripts\\build_r2_fiscal_bundles.py scripts\\build_offline_db.py
- npm run type-check
- npm test -- src/workers/dbWorker/messages.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support installing fiscal offline bundles directly from a public R2 URL and added R2 availability checks.

* **Configuration**
  * Two new frontend env vars to configure the R2 base URL and the public seed for offline bundles.

* **Chores**
  * Build tooling can produce a consolidated (monolithic) fiscal bundle or per-source bundles.

* **Tests**
  * Updated and added tests covering R2/static bundle install flows and build cleanup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YsraEstudos/FiscalConsultas/pull/273)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->