### PR TITLE
[codex] Fix security incident reporting auth

### DIFF
--- a/backend/server/middleware.py
+++ b/backend/server/middleware.py
@@ -346,6 +346,7 @@ class TenantMiddleware:
         "/api/admin/reload-secrets",
         "/api/debug/anchors",
         "/api/glossary",
+        "/api/security/incident",
         "/api/webhooks",
     }
     PUBLIC_PREFIX_PATHS = ("/api/database/", "/api/webhooks/")

--- a/client/src/utils/security/devtoolsGuard.test.ts
+++ b/client/src/utils/security/devtoolsGuard.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('devtoolsGuard', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.stubEnv('DEV', false);
+        vi.stubEnv('VITE_API_URL', 'https://api.example.test');
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllEnvs();
+        vi.restoreAllMocks();
+    });
+
+    it('reports the backend-supported devtools incident type once', async () => {
+        vi.resetModules();
+        const fetchSpy = vi
+            .spyOn(globalThis, 'fetch')
+            .mockResolvedValue(new Response(null, { status: 200 }));
+        vi.spyOn(window, 'outerWidth', 'get').mockReturnValue(1200);
+        vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(800);
+        vi.spyOn(window, 'outerHeight', 'get').mockReturnValue(900);
+        vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(900);
+
+        const { installDevToolsGuard } = await import('./devtoolsGuard');
+        installDevToolsGuard();
+
+        vi.advanceTimersByTime(4_000);
+        vi.advanceTimersByTime(4_000);
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(fetchSpy).toHaveBeenCalledWith(
+            'https://api.example.test/api/security/incident',
+            expect.objectContaining({
+                body: expect.stringContaining('"type":"devtools"'),
+                method: 'POST',
+            }),
+        );
+    });
+});

--- a/client/src/utils/security/devtoolsGuard.ts
+++ b/client/src/utils/security/devtoolsGuard.ts
@@ -40,7 +40,7 @@ function reportIncidentToServer(type: string) {
 function onDevToolsDetected() {
     if (_detected) return; // fire once per session
     _detected = true;
-    reportIncidentToServer('devtools_detected');
+    reportIncidentToServer('devtools');
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/test_middleware_additional.py
+++ b/tests/unit/test_middleware_additional.py
@@ -687,7 +687,7 @@ async def test_dispatch_allows_only_non_fiscal_public_routes_in_prod_postgres_wi
         await response(scope, receive, send)
 
     mw = middleware.TenantMiddleware(app=app)
-    public_paths = ["/api/glossary"]
+    public_paths = ["/api/glossary", "/api/security/incident"]
 
     for path in public_paths:
         status, _ = await _invoke_middleware(mw, _build_scope(path))


### PR DESCRIPTION
## Summary
- allow /api/security/incident through the tenant middleware without Clerk auth
- send the backend-supported devtools incident type from the browser guard
- add backend and frontend regression coverage

## Root cause
The DevTools guard reports incidents from production browser code without an Authorization header, but the tenant middleware did not classify /api/security/incident as public, so production rejected the request with 401 before the route could acknowledge it.

## Validation
- uv run python -m pytest -q tests/unit/test_security_incident_route.py tests/unit/test_middleware_additional.py -x
- npm run test -- src/utils/security/devtoolsGuard.test.ts
- npm run type-check
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Security incident reporting endpoint (`/api/security/incident`) is now accessible as a public API without authentication requirements.

* **Bug Fixes**
  * Updated devtools detection incident payload format for improved security monitoring compatibility.

* **Tests**
  * Added comprehensive test coverage for devtools guard security monitoring functionality.
  * Updated existing tests to verify public endpoint accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YsraEstudos/FiscalConsultas/pull/280)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->