### PR TITLE
[codex] Fix Pages offline deploy errors

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -30,7 +30,9 @@ jobs:
       VITE_OFFLINE_DB_PUBLIC_SEED: ${{ vars.VITE_OFFLINE_DB_PUBLIC_SEED }}
       VITE_CLERK_PUBLISHABLE_KEY: ${{ vars.VITE_CLERK_PUBLISHABLE_KEY }}
       VITE_CLERK_TOKEN_TEMPLATE: backend_api
-      ALLOW_TEST_CLERK_KEY: "true" # Temporary explicit override while using pk_test on Pages
+      # Temporary: GitHub Pages is deployed without a custom domain, so Clerk pk_live cannot be used yet.
+      # Remove this override after moving Pages to a Clerk production domain and setting pk_live.
+      ALLOW_TEST_CLERK_KEY: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -59,6 +61,13 @@ jobs:
             echo "Missing GitHub repository variable VITE_OFFLINE_DB_PUBLIC_SEED"
             exit 1
           fi
+
+      - name: Validate public R2 offline bundle
+        run: |
+          metadata_url="${VITE_FISCAL_R2_BASE_URL%/}/fiscal_offline.meta.json"
+          bundle_url="${VITE_FISCAL_R2_BASE_URL%/}/fiscal_offline.enc"
+          curl --fail --silent --show-error --head "$metadata_url" >/dev/null
+          curl --fail --silent --show-error --head "$bundle_url" >/dev/null
 
       - name: Patch app for GitHub Pages project path
         run: |

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -66,8 +66,8 @@ jobs:
         run: |
           metadata_url="${VITE_FISCAL_R2_BASE_URL%/}/fiscal_offline.meta.json"
           bundle_url="${VITE_FISCAL_R2_BASE_URL%/}/fiscal_offline.enc"
-          curl --fail --silent --show-error --head "$metadata_url" >/dev/null
-          curl --fail --silent --show-error --head "$bundle_url" >/dev/null
+          curl --fail --silent --show-error --head --connect-timeout 10 --max-time 30 "$metadata_url" >/dev/null
+          curl --fail --silent --show-error --head --connect-timeout 10 --max-time 30 "$bundle_url" >/dev/null
 
       - name: Patch app for GitHub Pages project path
         run: |

--- a/client/src/context/offlineDatabaseRuntime.ts
+++ b/client/src/context/offlineDatabaseRuntime.ts
@@ -209,7 +209,9 @@ export function useOfflineDatabaseRuntime(): OfflineDatabaseRuntimeValue {
                         r2BaseUrl,
                     );
                     remoteMetaRef.current = metadata;
-                    persistStoredOfflineDatabaseMetadata(metadata);
+                    if (metadata) {
+                        persistStoredOfflineDatabaseMetadata(metadata);
+                    }
                     setRemoteVersion(metadata?.version ?? null);
                     setDbSizeBytes((current) => current ?? metadata?.size_bytes ?? null);
                     return metadata;

--- a/client/src/context/offlineDatabaseSync.test.ts
+++ b/client/src/context/offlineDatabaseSync.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    fetchFiscalR2DatabaseAvailabilityMetadata,
+    fetchOfflineSourceAvailabilityMetadata,
+} from './offlineDatabaseSync';
+
+describe('offlineDatabaseSync R2 metadata checks', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('treats missing consolidated R2 metadata as unavailable without retrying', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response('not found', { status: 404 }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(
+            fetchFiscalR2DatabaseAvailabilityMetadata('https://r2.example.test/fiscal'),
+        ).resolves.toBeNull();
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://r2.example.test/fiscal/fiscal_offline.meta.json',
+            expect.objectContaining({ method: 'GET' }),
+        );
+    });
+
+    it('treats missing source R2 metadata as unavailable without retrying', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response('not found', { status: 404 }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(
+            fetchOfflineSourceAvailabilityMetadata(
+                'https://r2.example.test/fiscal',
+                'nesh',
+            ),
+        ).resolves.toBeNull();
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://r2.example.test/fiscal/nesh/nesh.meta.json',
+            expect.objectContaining({ method: 'GET' }),
+        );
+    });
+});

--- a/client/src/context/offlineDatabaseSync.ts
+++ b/client/src/context/offlineDatabaseSync.ts
@@ -105,6 +105,10 @@ async function fetchFiscalR2DatabaseAvailabilityMetadataOnce(
             signal: controller.signal,
         });
 
+        if (response.status === 404) {
+            return null;
+        }
+
         if (!response.ok) {
             throw new Error(`R2 metadata check failed (${response.status})`);
         }
@@ -131,6 +135,10 @@ async function fetchOfflineSourceAvailabilityMetadataOnce(
             headers: { Accept: 'application/json' },
             signal: controller.signal,
         });
+
+        if (response.status === 404) {
+            return null;
+        }
 
         if (!response.ok) {
             throw new Error(`Source metadata check failed (${response.status})`);

--- a/client/src/services/api/apiFailure.test.ts
+++ b/client/src/services/api/apiFailure.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
+
+import { reportApiFailure } from './apiFailure';
+import { reportClientError } from '../../utils/errorMonitoring';
+
+vi.mock('../../utils/errorMonitoring', () => ({
+    reportClientError: vi.fn(),
+}));
+
+function buildAxiosError(
+    url: string,
+    code: string | undefined,
+    status?: number,
+): AxiosError {
+    return {
+        code,
+        config: {
+            url,
+            method: 'get',
+            timeout: 8000,
+        } as InternalAxiosRequestConfig,
+        response: status
+            ? {
+                status,
+            }
+            : undefined,
+    } as AxiosError;
+}
+
+describe('reportApiFailure', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does not report auth capability cold-start timeouts as fatal network errors', () => {
+        const error = buildAxiosError('/auth/me', 'ECONNABORTED');
+
+        reportApiFailure(error, error.config, 'request-1', undefined);
+
+        expect(reportClientError).not.toHaveBeenCalled();
+    });
+
+    it('still reports non-auth network failures without a response', () => {
+        const error = buildAxiosError('/nesh/search', 'ECONNABORTED');
+
+        reportApiFailure(error, error.config, 'request-2', undefined);
+
+        expect(reportClientError).toHaveBeenCalledWith(
+            expect.objectContaining({
+                source: 'network',
+                path: '/nesh/search',
+                requestId: 'request-2',
+                message: 'API request failed before receiving a response',
+            }),
+        );
+    });
+});

--- a/client/src/services/api/apiFailure.ts
+++ b/client/src/services/api/apiFailure.ts
@@ -13,8 +13,27 @@ function isCanceledRequestError(error: AxiosError | Error | unknown): boolean {
     return candidate?.code === 'ERR_CANCELED' || candidate?.name === 'CanceledError';
 }
 
-function shouldReportApiFailure(status: number | undefined, error: AxiosError): boolean {
+function isRecoverableStartupTimeout(
+    error: AxiosError,
+    originalRequest: InternalAxiosRequestConfig | undefined,
+): boolean {
+    const rawPath = getRequestPath(originalRequest?.url);
+    const normalizedPath = rawPath ? normalizeRequestPath(rawPath) : undefined;
+    return normalizedPath === '/auth/me'
+        && error.code === 'ECONNABORTED'
+        && !error.response;
+}
+
+function shouldReportApiFailure(
+    status: number | undefined,
+    error: AxiosError,
+    originalRequest: InternalAxiosRequestConfig | undefined,
+): boolean {
     if (isCanceledRequestError(error)) {
+        return false;
+    }
+
+    if (isRecoverableStartupTimeout(error, originalRequest)) {
         return false;
     }
 
@@ -31,7 +50,7 @@ export function reportApiFailure(
     requestId: string | undefined,
     status: number | undefined,
 ): void {
-    if (!shouldReportApiFailure(status, error)) {
+    if (!shouldReportApiFailure(status, error, originalRequest)) {
         return;
     }
 

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -146,7 +146,9 @@ If there is no formatter, agree on one and add it to CI.
 - Do not add Render, FastAPI route, Postgres, Redis, Upstash, Neon, or any online backend dependency back into fiscal search.
 - `/api/database/*` remains public only as a legacy offline installer compatibility path; keep new fiscal search work on static R2 bundles.
 - Cloud backend work is reserved for future user-account features only: comments, favorites, profile, and preferences via Clerk, Cloudflare Workers, and Cloudflare D1.
-- R2 bundle layout is source-scoped: `nesh/nesh.meta.json`, `nesh/nesh.enc`, `tipi/tipi.meta.json`, `tipi/tipi.enc`, `nbs/nbs.meta.json`, `nbs/nbs.enc`, `unspsc/unspsc.meta.json`, and `unspsc/unspsc.enc`.
+- GitHub Pages currently runs without a custom domain. Clerk `pk_test_` is an accepted temporary tradeoff there; `pk_live_` requires a Clerk production domain, so keep `ALLOW_TEST_CLERK_KEY` until a custom domain exists.
+- The current Pages production deploy uses the consolidated static R2 bundle: `fiscal_offline.meta.json` and `fiscal_offline.enc` must exist at `VITE_FISCAL_R2_BASE_URL` before publishing the frontend.
+- Future/source-scoped R2 layout is: `nesh/nesh.meta.json`, `nesh/nesh.enc`, `tipi/tipi.meta.json`, `tipi/tipi.enc`, `nbs/nbs.meta.json`, `nbs/nbs.enc`, `unspsc/unspsc.meta.json`, and `unspsc/unspsc.enc`.
 
 ## Git hygiene
 


### PR DESCRIPTION
## Summary
- Treat missing R2 offline metadata as recoverable instead of noisy repeated failures.
- Validate consolidated R2 offline artifacts before GitHub Pages deploy.
- Keep Clerk test-key override documented while Pages has no custom domain, and avoid reporting /auth/me cold-start timeouts as fatal client errors.

## Test Plan
- npm test -- src/context src/services/api/apiFailure.test.ts src/workers/dbWorker/messages.test.js tests/unit/validate-production-env.test.ts
- npm run type-check
- uv run python scripts\build_r2_fiscal_bundles.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline bundle validation added to deployment workflow

* **Bug Fixes**
  * Improved null handling for offline database metadata persistence
  * HTTP 404 responses now correctly treated as unavailable
  * Authentication startup timeouts no longer misreported as fatal network errors

* **Tests**
  * Added test coverage for offline database sync functionality
  * Added test coverage for API failure reporting

* **Documentation**
  * Updated R2 bundle deployment guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YsraEstudos/FiscalConsultas/pull/281)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->