### PR TITLE
Fix GitHub Pages offline bundle deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ htmlcov/
 *.db-journal
 *.sqlite3
 database/r2/
+!database/r2/
+database/r2/*
+!database/r2/fiscal_offline.meta.json
+!database/r2/fiscal_offline.enc
 
 # Data and Heavy Files
 data/

--- a/database/r2/fiscal_offline.meta.json
+++ b/database/r2/fiscal_offline.meta.json
@@ -1,0 +1,13 @@
+{
+  "source": "fiscal",
+  "version": "2026.05.13.104323",
+  "sha256": "4dd93d007c0d501ab896cb2c1139d06f2221d22eb37e123a3aa345fa2d31ade8",
+  "encrypted_sha256": "b31a69d5dd0ad136685ee18bf7511914c320891a59c78ba4d84116df4383166c",
+  "salt": "1c1845185465748bbf05c13875f35bf6e57d6316c8bfaf1985e822e6613811b6",
+  "size_bytes": 23545766,
+  "chunks": 360,
+  "built_at": "2026-05-13T10:43:23Z",
+  "format_version": 1,
+  "chunk_size": 65536,
+  "pbkdf2_iterations": 600000
+}


### PR DESCRIPTION
## Summary
- allowlist the generated fiscal offline fallback bundle files in gitignore
- add the current fiscal_offline metadata and encrypted bundle required by the Pages deploy guard

## Validation
- npm run build -- --base=/FiscalConsultas/ with REQUIRE_FISCAL_FALLBACK_ASSETS=true and no R2 URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database metadata including build version, checksums, and timestamps for fiscal data components.
  * Refined repository configuration to optimize file management and version control practices for database resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YsraEstudos/FiscalConsultas/pull/285)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->