### PR TITLE
Fix GitHub Pages fiscal bundle seed validation

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -92,6 +92,9 @@ jobs:
             echo "::notice::VITE_FISCAL_R2_BASE_URL is not set; Pages will rely on bundled fiscal-bases fallback."
           fi
 
+      - name: Validate bundled fiscal decryptability
+        run: node scripts/validate-fiscal-r2-bundle.mjs ../database/r2
+
       - name: Patch app for GitHub Pages project path
         run: |
           node -e "const fs=require('node:fs'); const indexPath='index.html'; let html=fs.readFileSync(indexPath,'utf8'); html=html.replace('href=\"/vite.svg\"','href=\"./vite.svg\"'); html=html.replace('src=\"/src/main.tsx\"','src=\"./src/main.tsx\"'); fs.writeFileSync(indexPath,html);"

--- a/client/scripts/validate-fiscal-r2-bundle.mjs
+++ b/client/scripts/validate-fiscal-r2-bundle.mjs
@@ -1,0 +1,66 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { decryptDatabase, setAppSeed, sha256Hex } from '../src/workers/dbWorker/crypto.js';
+
+const DEFAULT_BUNDLE_DIR = '../database/r2';
+const SQLITE_HEADER = new TextEncoder().encode('SQLite format 3\0');
+
+function getBundleDir() {
+  return resolve(process.cwd(), process.argv[2] || DEFAULT_BUNDLE_DIR);
+}
+
+function getPublicSeed() {
+  const seed = (process.env.VITE_OFFLINE_DB_PUBLIC_SEED || '').trim();
+  if (!seed) {
+    throw new Error('VITE_OFFLINE_DB_PUBLIC_SEED must be set to validate the fiscal R2 bundle.');
+  }
+  return seed;
+}
+
+async function readMetadata(bundleDir) {
+  const metadataPath = resolve(bundleDir, 'fiscal_offline.meta.json');
+  return JSON.parse(await readFile(metadataPath, 'utf8'));
+}
+
+async function main() {
+  const bundleDir = getBundleDir();
+  const metadata = await readMetadata(bundleDir);
+  const encryptedPath = resolve(bundleDir, 'fiscal_offline.enc');
+  const encrypted = new Uint8Array(await readFile(encryptedPath));
+
+  if (metadata.size_bytes !== encrypted.byteLength) {
+    throw new Error(
+      `fiscal_offline.enc size mismatch: metadata=${metadata.size_bytes}, actual=${encrypted.byteLength}.`,
+    );
+  }
+
+  const actualSha256 = await sha256Hex(encrypted);
+  if (actualSha256 !== metadata.encrypted_sha256) {
+    throw new Error(
+      `fiscal_offline.enc SHA-256 mismatch: metadata=${metadata.encrypted_sha256}, actual=${actualSha256}.`,
+    );
+  }
+
+  setAppSeed(getPublicSeed());
+  const plaintext = await decryptDatabase(
+    encrypted,
+    metadata.chunk_size || 65536,
+    metadata.pbkdf2_iterations || 600000,
+  );
+  try {
+    const hasSqliteHeader = SQLITE_HEADER.every((byte, index) => plaintext[index] === byte);
+    if (!hasSqliteHeader) {
+      throw new Error('Decrypted fiscal bundle is not a SQLite database.');
+    }
+  } finally {
+    plaintext.fill(0);
+  }
+
+  console.log(`Fiscal R2 bundle decrypts successfully: ${metadata.version}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/database/r2/fiscal_offline.meta.json
+++ b/database/r2/fiscal_offline.meta.json
@@ -1,12 +1,12 @@
 {
   "source": "fiscal",
-  "version": "2026.05.13.104323",
-  "sha256": "4dd93d007c0d501ab896cb2c1139d06f2221d22eb37e123a3aa345fa2d31ade8",
-  "encrypted_sha256": "b31a69d5dd0ad136685ee18bf7511914c320891a59c78ba4d84116df4383166c",
-  "salt": "1c1845185465748bbf05c13875f35bf6e57d6316c8bfaf1985e822e6613811b6",
+  "version": "2026.05.14.115005",
+  "sha256": "5794a3cba3477ba3442324344997780b287ca6c5fe44362b12c7731c58a08e56",
+  "encrypted_sha256": "adc70cb735c876d138cc31b673729868396f79019cf4af3be7435c474055faca",
+  "salt": "415e31d35f55ab909eaebbc3790f51da7fa69379eca2b24854c61828694178ff",
   "size_bytes": 23545766,
   "chunks": 360,
-  "built_at": "2026-05-13T10:43:23Z",
+  "built_at": "2026-05-14T11:50:05Z",
   "format_version": 1,
   "chunk_size": 65536,
   "pbkdf2_iterations": 600000


### PR DESCRIPTION
## Summary
- regenerate the GitHub Pages fallback fiscal bundle with the deployed public seed
- add a deploy-time validation that checks size, SHA-256, and decryptability of database/r2/fiscal_offline.enc
- keep the R2 404 fallback protected by proving the bundled Pages copy can actually open

## Validation
- VITE_OFFLINE_DB_PUBLIC_SEED=<public seed> node scripts/validate-fiscal-r2-bundle.mjs ../database/r2
- npm run build -- --base=/FiscalConsultas/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a pre-deployment validation step to verify offline fiscal data integrity and ensure proper decryption before application builds.
  * Updated offline fiscal data bundle with refreshed metadata including new version and integrity checksums.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YsraEstudos/FiscalConsultas/pull/286)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->