### PR TITLE
[codex] Speed up admin telemetry dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ data/
 !client/src/data/
 !client/src/data/*.json
 raw_data/
+database/Raw/
 *.zip
 *.xlsx
 # Specific large markdown from raw_data

--- a/backend/presentation/routes/admin_dashboard.py
+++ b/backend/presentation/routes/admin_dashboard.py
@@ -197,6 +197,7 @@ async def get_admin_dashboard(request: Request) -> DashboardResponse:
 
     today_start = _today_start()
     cutoff = _active_cutoff()
+    retention_cutoff = _now_utc() - timedelta(days=RETENTION_DAYS)
 
     async with get_session() as session:
         # Searches by type today
@@ -214,7 +215,17 @@ async def get_admin_dashboard(request: Request) -> DashboardResponse:
             searches_by_type[row[0]] = row[1]
             total_today += row[1]
 
-        # Device summaries
+        recent_device_fingerprints = (
+            select(SearchEvent.device_fingerprint)
+            .where(SearchEvent.created_at >= retention_cutoff)
+            .group_by(SearchEvent.device_fingerprint)
+            .order_by(func.max(SearchEvent.created_at).desc())
+            .limit(200)
+            .subquery()
+        )
+
+        # Device summaries stay within the retention window, so stale rows that
+        # have not been purged yet cannot make the admin panel slow.
         devices_result = await session.execute(
             select(
                 SearchEvent.device_fingerprint,
@@ -230,9 +241,16 @@ async def get_admin_dashboard(request: Request) -> DashboardResponse:
                     )
                 ).label("today"),
             )
+            .where(
+                and_(
+                    SearchEvent.created_at >= retention_cutoff,
+                    SearchEvent.device_fingerprint.in_(
+                        select(recent_device_fingerprints.c.device_fingerprint)
+                    ),
+                )
+            )
             .group_by(SearchEvent.device_fingerprint)
             .order_by(func.max(SearchEvent.created_at).desc())
-            .limit(200)
         )
 
         devices: list[DeviceSummary] = []

--- a/client/src/components/UserProfilePage.tsx
+++ b/client/src/components/UserProfilePage.tsx
@@ -14,6 +14,7 @@ import {
     updateMyProfile,
     getMyContributions,
     deleteMyAccount,
+    prefetchAdminDashboard,
 } from '../services/api';
 import type {
     MyContributionHistoryApiResponse,
@@ -225,6 +226,12 @@ export function UserProfilePage({ isOpen, onClose }: Readonly<UserProfilePagePro
             .catch(console.error)
             .finally(() => setLoading(false));
     }, [isOpen]);
+
+    useEffect(() => {
+        if (isOpen && isAdmin) {
+            prefetchAdminDashboard();
+        }
+    }, [isOpen, isAdmin]);
 
     // Fetch contributions
     const fetchContributions = useCallback(async (page: number, search: string) => {

--- a/client/src/hooks/useSearch.ts
+++ b/client/src/hooks/useSearch.ts
@@ -120,6 +120,15 @@ export function useSearch(
         return nextResults;
     }, []);
 
+    const recordSearchEvent = useCallback((doc: DocType, query: string) => {
+        logSearchEvent({
+            search_type: doc,
+            search_query: query,
+            device_fingerprint: getDeviceFingerprint(),
+            device_label: getDeviceLabel(),
+        });
+    }, []);
+
     const executeSearchForTab = useCallback(async (tabId: string, doc: DocType, query: string, saveHistory: boolean = true) => {
         if (!query) return;
 
@@ -150,6 +159,7 @@ export function useSearch(
                 results: updateResultsQuery(currentTab.results, query),
                 isNewSearch: true
             });
+            recordSearchEvent(doc, trimmedQuery);
             return; // Early exit - sem chamada a API
         }
 
@@ -232,12 +242,7 @@ export function useSearch(
             });
 
             // Telemetry: fire-and-forget search event for admin dashboard
-            logSearchEvent({
-                search_type: doc,
-                search_query: trimmedQuery,
-                device_fingerprint: getDeviceFingerprint(),
-                device_label: getDeviceLabel(),
-            });
+            recordSearchEvent(doc, trimmedQuery);
         } catch (err: any) {
             if (import.meta.env.DEV) {
                 console.error(err);
@@ -252,7 +257,7 @@ export function useSearch(
                 loading: false
             });
         }
-    }, [addToHistory, updateResultsQuery, updateTab, dbStatus, searchLocal]);
+    }, [addToHistory, updateResultsQuery, updateTab, recordSearchEvent, dbStatus, searchLocal]);
 
     return { executeSearchForTab };
 }

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -38,4 +38,5 @@ export {
     logSearchEvent,
     getAdminDashboard,
     getDeviceHistory,
+    prefetchAdminDashboard,
 } from './api/adminDashboard';

--- a/client/src/services/api/adminDashboard.ts
+++ b/client/src/services/api/adminDashboard.ts
@@ -12,19 +12,65 @@ import type {
     SearchEventPayload,
 } from '../../types/apiAdmin.types';
 
+const DASHBOARD_CACHE_TTL_MS = 30_000;
+
+let dashboardCache: {
+    data: AdminDashboardResponse;
+    fetchedAt: number;
+} | null = null;
+let dashboardRequest: Promise<AdminDashboardResponse> | null = null;
+
+function isDashboardCacheFresh(): boolean {
+    return !!dashboardCache && Date.now() - dashboardCache.fetchedAt < DASHBOARD_CACHE_TTL_MS;
+}
+
 /**
  * Fire-and-forget: logs a search event for telemetry.
  * Silently ignores errors to never impact UX.
  */
 export function logSearchEvent(data: SearchEventPayload): void {
-    api.post('/admin/search-event', data).catch(() => {
+    api.post('/admin/search-event', data).then(() => {
+        dashboardCache = null;
+    }).catch(() => {
         // Intentionally silent — telemetry must never block or toast errors
     });
 }
 
-export async function getAdminDashboard(): Promise<AdminDashboardResponse> {
-    const { data } = await api.get<AdminDashboardResponse>('/admin/dashboard');
-    return data;
+export async function getAdminDashboard(forceRefresh = false): Promise<AdminDashboardResponse> {
+    if (!forceRefresh && isDashboardCacheFresh() && dashboardCache) {
+        return dashboardCache.data;
+    }
+
+    if (!forceRefresh && dashboardRequest) {
+        return dashboardRequest;
+    }
+
+    dashboardRequest = fetchAdminDashboard();
+    return dashboardRequest;
+}
+
+export function prefetchAdminDashboard(): void {
+    if (isDashboardCacheFresh() || dashboardRequest) {
+        return;
+    }
+
+    dashboardRequest = fetchAdminDashboard();
+    dashboardRequest.catch(() => {
+        // Prefetch is best effort; the mounted dashboard will surface load errors.
+    });
+}
+
+async function fetchAdminDashboard(): Promise<AdminDashboardResponse> {
+    try {
+        const { data } = await api.get<AdminDashboardResponse>('/admin/dashboard');
+        dashboardCache = {
+            data,
+            fetchedAt: Date.now(),
+        };
+        return data;
+    } finally {
+        dashboardRequest = null;
+    }
 }
 
 export async function getDeviceHistory(fingerprint: string): Promise<DeviceHistoryResponse> {

--- a/client/tests/unit/UserProfilePage.test.tsx
+++ b/client/tests/unit/UserProfilePage.test.tsx
@@ -18,6 +18,7 @@ vi.mock('../../src/services/api', () => ({
     updateMyProfile: vi.fn(),
     getMyContributions: vi.fn(),
     deleteMyAccount: vi.fn(),
+    prefetchAdminDashboard: vi.fn(),
 }));
 
 // ─── Mocks de Clerk ──────────────────────────────────────────────────────────
@@ -54,12 +55,14 @@ import {
     updateMyProfile,
     getMyContributions,
     deleteMyAccount,
+    prefetchAdminDashboard,
 } from '../../src/services/api';
 
 const mockGetMyProfile = vi.mocked(getMyProfile);
 const mockUpdateMyProfile = vi.mocked(updateMyProfile);
 const mockGetMyContributions = vi.mocked(getMyContributions);
 const mockDeleteMyAccount = vi.mocked(deleteMyAccount);
+const mockPrefetchAdminDashboard = vi.mocked(prefetchAdminDashboard);
 let UserProfilePage: typeof import('../../src/components/UserProfilePage').UserProfilePage;
 
 // ─── Dados de fixture ─────────────────────────────────────────────────────────
@@ -350,6 +353,15 @@ describe('UserProfilePage', () => {
 
         fireEvent.click(screen.getByRole('button', { name: /organização/i }));
         expect(screen.getByTestId('clerk-org-profile')).toBeInTheDocument();
+    });
+
+    it('precarrega o Painel Admin ao abrir o modal para administradores', async () => {
+        isAdminRef.value = true;
+        render(<UserProfilePage isOpen={true} onClose={vi.fn()} />);
+
+        await waitFor(() => expect(mockGetMyProfile).toHaveBeenCalled());
+
+        expect(mockPrefetchAdminDashboard).toHaveBeenCalledTimes(1);
     });
 
     // --- Delete Account (double-confirmation) ---

--- a/client/tests/unit/adminDashboard.test.ts
+++ b/client/tests/unit/adminDashboard.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const refs = vi.hoisted(() => ({
+    apiGetMock: vi.fn(),
+    apiPostMock: vi.fn(),
+}));
+
+vi.mock('../../src/services/api/httpClient', () => ({
+    api: {
+        get: refs.apiGetMock,
+        post: refs.apiPostMock,
+    },
+}));
+
+const dashboardResponse = {
+    total_active_devices: 1,
+    total_searches_today: 2,
+    searches_by_type: { nesh: 2 },
+    devices: [],
+};
+
+describe('admin dashboard API cache', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.clearAllMocks();
+        refs.apiGetMock.mockResolvedValue({ data: dashboardResponse });
+        refs.apiPostMock.mockResolvedValue({});
+    });
+
+    it('deduplicates concurrent dashboard loads', async () => {
+        const { getAdminDashboard } = await import('../../src/services/api/adminDashboard');
+
+        const [first, second] = await Promise.all([
+            getAdminDashboard(),
+            getAdminDashboard(),
+        ]);
+
+        expect(first).toBe(dashboardResponse);
+        expect(second).toBe(dashboardResponse);
+        expect(refs.apiGetMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('serves a warm dashboard cache without another request', async () => {
+        const { getAdminDashboard } = await import('../../src/services/api/adminDashboard');
+
+        await getAdminDashboard();
+        await getAdminDashboard();
+
+        expect(refs.apiGetMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('prefetches data before the dashboard mounts', async () => {
+        const { getAdminDashboard, prefetchAdminDashboard } = await import(
+            '../../src/services/api/adminDashboard'
+        );
+
+        prefetchAdminDashboard();
+        await Promise.resolve();
+        await getAdminDashboard();
+
+        expect(refs.apiGetMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidates dashboard cache after successful telemetry write', async () => {
+        const { getAdminDashboard, logSearchEvent } = await import('../../src/services/api/adminDashboard');
+
+        await getAdminDashboard();
+        logSearchEvent({
+            search_type: 'nesh',
+            search_query: '0101',
+            device_fingerprint: 'fp',
+            device_label: 'Chrome / Windows',
+        });
+        await Promise.resolve();
+        await getAdminDashboard();
+
+        expect(refs.apiGetMock).toHaveBeenCalledTimes(2);
+    });
+});

--- a/client/tests/unit/useSearch.behavior.test.tsx
+++ b/client/tests/unit/useSearch.behavior.test.tsx
@@ -9,6 +9,7 @@ const refs = vi.hoisted(() => ({
   searchNCMMock: vi.fn(),
   searchTipiMock: vi.fn(),
   searchNbsServicesMock: vi.fn(),
+  logSearchEventMock: vi.fn(),
   searchLocalMock: vi.fn(),
   toastErrorMock: vi.fn(),
   dbStatus: 'not_installed',
@@ -18,7 +19,7 @@ vi.mock('../../src/services/api', () => ({
   searchNCM: refs.searchNCMMock,
   searchTipi: refs.searchTipiMock,
   searchNbsServices: refs.searchNbsServicesMock,
-  logSearchEvent: vi.fn(),
+  logSearchEvent: refs.logSearchEventMock,
 }));
 
 vi.mock('react-hot-toast', () => ({
@@ -70,6 +71,7 @@ describe('useSearch local-only behavior', () => {
     refs.searchNCMMock.mockReset();
     refs.searchTipiMock.mockReset();
     refs.searchNbsServicesMock.mockReset();
+    refs.logSearchEventMock.mockReset();
     refs.searchLocalMock.mockReset();
     refs.toastErrorMock.mockReset();
     refs.dbStatus = 'not_installed';
@@ -222,6 +224,12 @@ describe('useSearch local-only behavior', () => {
 
     expect(refs.searchLocalMock).not.toHaveBeenCalled();
     expect(refs.searchNCMMock).not.toHaveBeenCalled();
+    expect(refs.logSearchEventMock).toHaveBeenCalledWith(expect.objectContaining({
+      search_type: 'nesh',
+      search_query: '0102',
+      device_fingerprint: expect.any(String),
+      device_label: expect.any(String),
+    }));
     expect(updateTab).toHaveBeenLastCalledWith('tab-1', expect.objectContaining({
       ncm: '0102',
       title: '0102',

--- a/migrations/versions/016_search_events_dashboard_indexes.py
+++ b/migrations/versions/016_search_events_dashboard_indexes.py
@@ -1,0 +1,44 @@
+"""Add dashboard-friendly search event indexes.
+
+Revision ID: 016_search_events_dashboard_indexes
+Revises: 015_search_events
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "016_search_events_dashboard_indexes"
+down_revision = "015_search_events"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if "search_events" not in inspector.get_table_names():
+        return
+
+    existing_indexes = {
+        index_name
+        for index in inspector.get_indexes("search_events")
+        if isinstance(index_name := index["name"], str)
+    }
+    if "ix_search_events_created_fp" not in existing_indexes:
+        op.create_index(
+            "ix_search_events_created_fp",
+            "search_events",
+            ["created_at", "device_fingerprint"],
+        )
+
+
+def downgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if "search_events" not in inspector.get_table_names():
+        return
+
+    has_created_fp_index = any(
+        index["name"] == "ix_search_events_created_fp"
+        for index in inspector.get_indexes("search_events")
+    )
+    if has_created_fp_index:
+        op.drop_index("ix_search_events_created_fp", table_name="search_events")

--- a/tests/unit/test_admin_dashboard.py
+++ b/tests/unit/test_admin_dashboard.py
@@ -170,7 +170,7 @@ async def test_dashboard_routes_require_admin(fake_db):
 async def test_dashboard_routes_allow_admin(fake_db, monkeypatch):
     async def fake_decode_jwt(token: str) -> dict[str, Any]:
         return {
-            "email": "israelsena2@gmail.com",
+            "email": "admin@example.com",
             "sub": "admin123",
             "org_role": "org:admin",
         }
@@ -185,3 +185,35 @@ async def test_dashboard_routes_allow_admin(fake_db, monkeypatch):
     res = await admin_dashboard.get_admin_dashboard(req)
     assert res.total_active_devices == 0
     assert res.devices == []
+
+
+@pytest.mark.asyncio
+async def test_dashboard_device_query_uses_retention_window(fake_db, monkeypatch):
+    async def fake_decode_jwt(token: str) -> dict[str, Any]:
+        return {
+            "email": "admin@example.com",
+            "sub": "admin123",
+            "org_role": "org:admin",
+        }
+
+    monkeypatch.setattr(admin_dashboard, "decode_clerk_jwt", fake_decode_jwt)
+    monkeypatch.setattr(
+        admin_dashboard, "extract_bearer_token", lambda req: "fake-token"
+    )
+
+    req = _build_request("/admin/dashboard", auth_header="Bearer fake-token")
+
+    await admin_dashboard.get_admin_dashboard(req)
+
+    device_query = next(
+        (
+            str(stmt)
+            for stmt in fake_db.executed
+            if "GROUP BY search_events.device_fingerprint" in str(stmt)
+            and "search_events.created_at" in str(stmt)
+        ),
+        "",
+    )
+    assert device_query
+    assert "search_events.created_at >= " in device_query
+    assert "IN (SELECT" in device_query


### PR DESCRIPTION
## Summary
- Prefetch and cache the admin dashboard data when admins open the profile modal.
- Limit dashboard device aggregation to the telemetry retention window and add a supporting index.
- Ensure same-chapter fiscal searches still emit telemetry, and ignore local database/Raw artifacts.

## Validation
- uv run python -m pytest -q tests/unit/test_admin_dashboard.py -x
- npm run test -- tests/unit/adminDashboard.test.ts tests/unit/UserProfilePage.test.tsx tests/unit/useSearch.behavior.test.tsx
- npm run type-check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin dashboard now filters device summaries to respect the search-event retention window, displaying only recently active devices.
  * Implemented caching and prefetching for admin dashboard data to improve load performance when accessed by administrators.

* **Performance**
  * Added database index to optimize admin dashboard queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YsraEstudos/FiscalConsultas/pull/292)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->