### PR TITLE
[codex] Fix NESH comparator rendering

### DIFF
--- a/client/src/components/ComparatorModal.tsx
+++ b/client/src/components/ComparatorModal.tsx
@@ -1,235 +1,273 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { toast } from 'react-hot-toast';
-import { useLocalDatabase } from '../context/LocalDatabaseContext';
-import { useSettings } from '../context/SettingsContext';
-import { buildLocalCodeSearchResponse, resolveSearchResponseMarkup } from '../utils/searchResultMarkup';
-import { MarkdownPane } from './MarkdownPane';
-import { Loading } from './Loading';
-import styles from './ComparatorModal.module.css';
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { toast } from 'react-hot-toast'
+import { useLocalDatabase } from '../context/LocalDatabaseContext'
+import { useSettings } from '../context/SettingsContext'
+import {
+  buildLocalCodeSearchResponse,
+  resolveSearchResponseMarkup,
+} from '../utils/searchResultMarkup'
+import { MarkdownPane } from './MarkdownPane'
+import { Loading } from './Loading'
+import styles from './ComparatorModal.module.css'
 
-type DocType = 'nesh' | 'tipi';
-const LOCAL_COMPARE_MESSAGE = 'Instale as bases locais para comparar NCMs sem backend.';
+type DocType = 'nesh' | 'tipi'
+const LOCAL_COMPARE_MESSAGE =
+  'Instale as bases locais para comparar NCMs sem backend.'
 
 interface ComparatorModalProps {
-    isOpen: boolean;
-    onClose: () => void;
-    defaultDoc?: DocType;
+  isOpen: boolean
+  onClose: () => void
+  defaultDoc?: DocType
 }
 
 type PanelState = {
-    title: string;
-    markdown: string | null;
-    loading: boolean;
-};
+  title: string
+  markdown: string | null
+  loading: boolean
+}
 
 const emptyPanel = (title: string): PanelState => ({
-    title,
-    markdown: null,
-    loading: false
-});
+  title,
+  markdown: null,
+  loading: false,
+})
 
-export function ComparatorModal({ isOpen, onClose, defaultDoc = 'nesh' }: ComparatorModalProps) {
-    const { tipiViewMode } = useSettings();
-    const { status: dbStatus, searchLocal } = useLocalDatabase();
+export function ComparatorModal({
+  isOpen,
+  onClose,
+  defaultDoc = 'nesh',
+}: ComparatorModalProps) {
+  const { tipiViewMode } = useSettings()
+  const { status: dbStatus, searchLocal } = useLocalDatabase()
 
-    const [doc, setDoc] = useState<DocType>(defaultDoc);
-    const [leftQuery, setLeftQuery] = useState('');
-    const [rightQuery, setRightQuery] = useState('');
-    const [leftPanel, setLeftPanel] = useState<PanelState>(() => emptyPanel('Esquerda'));
-    const [rightPanel, setRightPanel] = useState<PanelState>(() => emptyPanel('Direita'));
+  const [doc, setDoc] = useState<DocType>(defaultDoc)
+  const [leftQuery, setLeftQuery] = useState('')
+  const [rightQuery, setRightQuery] = useState('')
+  const [leftPanel, setLeftPanel] = useState<PanelState>(() =>
+    emptyPanel('Esquerda')
+  )
+  const [rightPanel, setRightPanel] = useState<PanelState>(() =>
+    emptyPanel('Direita')
+  )
 
-    // Keep modal state in sync when opening
-    useEffect(() => {
-        if (!isOpen) return;
-        setDoc(defaultDoc);
-        setLeftQuery('');
-        setRightQuery('');
-        setLeftPanel(emptyPanel('Esquerda'));
-        setRightPanel(emptyPanel('Direita'));
-    }, [isOpen, defaultDoc]);
+  // Keep modal state in sync when opening
+  useEffect(() => {
+    if (!isOpen) return
+    setDoc(defaultDoc)
+    setLeftQuery('')
+    setRightQuery('')
+    setLeftPanel(emptyPanel('Esquerda'))
+    setRightPanel(emptyPanel('Direita'))
+  }, [isOpen, defaultDoc])
 
-    // Body scroll lock
-    useEffect(() => {
-        if (!isOpen) return;
-        const prevOverflow = document.body.style.overflow;
-        document.body.style.overflow = 'hidden';
-        return () => {
-            document.body.style.overflow = prevOverflow;
-        };
-    }, [isOpen]);
+  // Body scroll lock
+  useEffect(() => {
+    if (!isOpen) return
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prevOverflow
+    }
+  }, [isOpen])
 
-    // Close on ESC
-    useEffect(() => {
-        if (!isOpen) return;
-        const onKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') onClose();
-        };
-        window.addEventListener('keydown', onKeyDown);
-        return () => window.removeEventListener('keydown', onKeyDown);
-    }, [isOpen, onClose]);
+  // Close on ESC
+  useEffect(() => {
+    if (!isOpen) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [isOpen, onClose])
 
-    const canCompare = useMemo(() => {
-        return leftQuery.trim().length > 0 && rightQuery.trim().length > 0;
-    }, [leftQuery, rightQuery]);
+  const canCompare = useMemo(() => {
+    return leftQuery.trim().length > 0 && rightQuery.trim().length > 0
+  }, [leftQuery, rightQuery])
 
-    const fetchSide = useCallback(async (ncm: string, side: 'left' | 'right') => {
-        const clean = ncm.trim();
-        if (!clean) return;
+  const fetchSide = useCallback(
+    async (ncm: string, side: 'left' | 'right') => {
+      const clean = ncm.trim()
+      if (!clean) return
 
-        const setPanel = side === 'left' ? setLeftPanel : setRightPanel;
-        setPanel(prev => ({ ...prev, loading: true, title: `Buscando ${clean}...` }));
+      const setPanel = side === 'left' ? setLeftPanel : setRightPanel
+      setPanel((prev) => ({
+        ...prev,
+        loading: true,
+        title: `Buscando ${clean}...`,
+      }))
 
-        try {
-            let markdown: string | null = null;
-            // The worker currently uses viewMode only for TIPI code search.
-            const viewModeForDoc = doc === 'tipi' ? tipiViewMode : undefined;
+      try {
+        let markdown: string | null = null
+        // The worker currently uses viewMode only for TIPI code search.
+        const viewModeForDoc = doc === 'tipi' ? tipiViewMode : undefined
 
-            if (dbStatus === 'ready') {
-                const localResponse = await searchLocal(
-                    doc,
-                    clean,
-                    viewModeForDoc,
-                );
+        if (dbStatus === 'ready') {
+          const localResponse = await searchLocal(doc, clean, viewModeForDoc)
 
-                if (localResponse?.searchType === 'code' && localResponse.results && typeof localResponse.results === 'object') {
-                    const normalizedLocalResponse = buildLocalCodeSearchResponse(
-                        doc,
-                        clean,
-                        localResponse.results as Record<string, any>,
-                    );
-                    markdown = resolveSearchResponseMarkup(doc, normalizedLocalResponse);
-                }
-            }
-
-            if (!markdown || typeof markdown !== 'string') {
-                throw new Error(LOCAL_COMPARE_MESSAGE);
-            }
-
-            setPanel({
-                title: `${doc.toUpperCase()} ${clean}`,
-                markdown,
-                loading: false
-            });
-        } catch (e: any) {
-            console.error(e);
-            setPanel(prev => ({
-                ...prev,
-                loading: false,
-                title: `${doc.toUpperCase()} ${clean}`,
-                markdown: null
-            }));
-            toast.error(e instanceof Error ? e.message : LOCAL_COMPARE_MESSAGE);
+          if (
+            localResponse?.searchType === 'code' &&
+            localResponse.results &&
+            typeof localResponse.results === 'object'
+          ) {
+            const normalizedLocalResponse = buildLocalCodeSearchResponse(
+              doc,
+              clean,
+              localResponse.results as Record<string, any>
+            )
+            markdown = resolveSearchResponseMarkup(doc, normalizedLocalResponse)
+          }
         }
-    }, [dbStatus, doc, searchLocal, tipiViewMode]);
 
-    const onCompare = useCallback(async () => {
-        if (!canCompare) {
-            toast.error('Preencha ambos os NCMs.');
-            return;
+        if (!markdown || typeof markdown !== 'string') {
+          throw new Error(LOCAL_COMPARE_MESSAGE)
         }
-        await Promise.all([
-            fetchSide(leftQuery, 'left'),
-            fetchSide(rightQuery, 'right')
-        ]);
-    }, [canCompare, fetchSide, leftQuery, rightQuery]);
 
-    const onSubmit = useCallback((e: React.FormEvent) => {
-        e.preventDefault();
-        onCompare();
-    }, [onCompare]);
+        setPanel({
+          title: `${doc.toUpperCase()} ${clean}`,
+          markdown,
+          loading: false,
+        })
+      } catch (e: any) {
+        console.error(e)
+        setPanel((prev) => ({
+          ...prev,
+          loading: false,
+          title: `${doc.toUpperCase()} ${clean}`,
+          markdown: null,
+        }))
+        toast.error(e instanceof Error ? e.message : LOCAL_COMPARE_MESSAGE)
+      }
+    },
+    [dbStatus, doc, searchLocal, tipiViewMode]
+  )
 
-    if (!isOpen) return null;
+  const onCompare = useCallback(async () => {
+    if (!canCompare) {
+      toast.error('Preencha ambos os NCMs.')
+      return
+    }
+    await Promise.all([
+      fetchSide(leftQuery, 'left'),
+      fetchSide(rightQuery, 'right'),
+    ])
+  }, [canCompare, fetchSide, leftQuery, rightQuery])
 
-    return (
-        <div
-            className={styles.overlay}
-            onMouseDown={(e) => {
-                if (e.target === e.currentTarget) onClose();
-            }}
-        >
-            <div className={styles.content}>
-                <div className={styles.header}>
-                    <div className={styles.headerTitle}>
-                        <h2 className={styles.headerHeading}>⚖️ Comparar NCMs</h2>
-                        <div className={`${styles.docSelector} ${styles.docSelectorInline}`}>
-                            <button
-                                className={`${styles.docButton} ${doc === 'nesh' ? styles.docButtonActive : ''}`}
-                                type="button"
-                                onClick={() => setDoc('nesh')}
-                            >
-                                NESH
-                            </button>
-                            <button
-                                className={`${styles.docButton} ${doc === 'tipi' ? styles.docButtonActive : ''}`}
-                                type="button"
-                                onClick={() => setDoc('tipi')}
-                            >
-                                TIPI
-                            </button>
-                        </div>
-                    </div>
-                    <button className={styles.closeButton} onClick={onClose} aria-label="Fechar">×</button>
-                </div>
+  const onSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault()
+      onCompare()
+    },
+    [onCompare]
+  )
 
-                <form className={styles.inputs} onSubmit={onSubmit}>
-                    <div className={styles.inputGroup}>
-                        <label htmlFor="compareLeft">NCM Esquerda</label>
-                        <input
-                            id="compareLeft"
-                            className={styles.input}
-                            value={leftQuery}
-                            onChange={(e) => setLeftQuery(e.target.value)}
-                            placeholder="Ex: 8517"
-                        />
-                    </div>
-                    <div className={styles.vs}>VS</div>
-                    <div className={styles.inputGroup}>
-                        <label htmlFor="compareRight">NCM Direita</label>
-                        <input
-                            id="compareRight"
-                            className={styles.input}
-                            value={rightQuery}
-                            onChange={(e) => setRightQuery(e.target.value)}
-                            placeholder="Ex: 8471"
-                        />
-                    </div>
+  if (!isOpen) return null
 
-                    <button
-                        className={styles.compareButton}
-                        type="submit"
-                        disabled={!canCompare}
-                        title="Comparar"
-                    >
-                        ⚖️ Comparar
-                    </button>
-                </form>
-
-                <div className={styles.body}>
-                    <div className={styles.panel}>
-                        <div className={styles.panelHeader}>{leftPanel.title}</div>
-                        <div className={styles.panelContent}>
-                            {leftPanel.loading ? (
-                                <Loading />
-                            ) : leftPanel.markdown ? (
-                                <MarkdownPane markdown={leftPanel.markdown} className="markdown-body" wrapSections={false} />
-                            ) : null}
-                        </div>
-                    </div>
-
-                    <div className={styles.divider} />
-
-                    <div className={styles.panel}>
-                        <div className={styles.panelHeader}>{rightPanel.title}</div>
-                        <div className={styles.panelContent}>
-                            {rightPanel.loading ? (
-                                <Loading />
-                            ) : rightPanel.markdown ? (
-                                <MarkdownPane markdown={rightPanel.markdown} className="markdown-body" wrapSections={false} />
-                            ) : null}
-                        </div>
-                    </div>
-                </div>
+  return (
+    <div
+      className={styles.overlay}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className={styles.content}>
+        <div className={styles.header}>
+          <div className={styles.headerTitle}>
+            <h2 className={styles.headerHeading}>⚖️ Comparar NCMs</h2>
+            <div
+              className={`${styles.docSelector} ${styles.docSelectorInline}`}
+            >
+              <button
+                className={`${styles.docButton} ${doc === 'nesh' ? styles.docButtonActive : ''}`}
+                type="button"
+                onClick={() => setDoc('nesh')}
+              >
+                NESH
+              </button>
+              <button
+                className={`${styles.docButton} ${doc === 'tipi' ? styles.docButtonActive : ''}`}
+                type="button"
+                onClick={() => setDoc('tipi')}
+              >
+                TIPI
+              </button>
             </div>
+          </div>
+          <button
+            className={styles.closeButton}
+            onClick={onClose}
+            aria-label="Fechar"
+          >
+            ×
+          </button>
         </div>
-    );
+
+        <form className={styles.inputs} onSubmit={onSubmit}>
+          <div className={styles.inputGroup}>
+            <label htmlFor="compareLeft">NCM Esquerda</label>
+            <input
+              id="compareLeft"
+              className={styles.input}
+              value={leftQuery}
+              onChange={(e) => setLeftQuery(e.target.value)}
+              placeholder="Ex: 8517"
+            />
+          </div>
+          <div className={styles.vs}>VS</div>
+          <div className={styles.inputGroup}>
+            <label htmlFor="compareRight">NCM Direita</label>
+            <input
+              id="compareRight"
+              className={styles.input}
+              value={rightQuery}
+              onChange={(e) => setRightQuery(e.target.value)}
+              placeholder="Ex: 8471"
+            />
+          </div>
+
+          <button
+            className={styles.compareButton}
+            type="submit"
+            disabled={!canCompare}
+            title="Comparar"
+          >
+            ⚖️ Comparar
+          </button>
+        </form>
+
+        <div className={styles.body}>
+          <div className={styles.panel}>
+            <div className={styles.panelHeader}>{leftPanel.title}</div>
+            <div className={styles.panelContent}>
+              {leftPanel.loading ? (
+                <Loading />
+              ) : leftPanel.markdown ? (
+                <MarkdownPane
+                  markdown={leftPanel.markdown}
+                  className="markdown-body"
+                  wrapSections={false}
+                />
+              ) : null}
+            </div>
+          </div>
+
+          <div className={styles.divider} />
+
+          <div className={styles.panel}>
+            <div className={styles.panelHeader}>{rightPanel.title}</div>
+            <div className={styles.panelContent}>
+              {rightPanel.loading ? (
+                <Loading />
+              ) : rightPanel.markdown ? (
+                <MarkdownPane
+                  markdown={rightPanel.markdown}
+                  className="markdown-body"
+                  wrapSections={false}
+                />
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/client/src/components/ComparatorModal.tsx
+++ b/client/src/components/ComparatorModal.tsx
@@ -211,7 +211,7 @@ export function ComparatorModal({ isOpen, onClose, defaultDoc = 'nesh' }: Compar
                             {leftPanel.loading ? (
                                 <Loading />
                             ) : leftPanel.markdown ? (
-                                <MarkdownPane markdown={leftPanel.markdown} className="markdown-body" />
+                                <MarkdownPane markdown={leftPanel.markdown} className="markdown-body" wrapSections={false} />
                             ) : null}
                         </div>
                     </div>
@@ -224,7 +224,7 @@ export function ComparatorModal({ isOpen, onClose, defaultDoc = 'nesh' }: Compar
                             {rightPanel.loading ? (
                                 <Loading />
                             ) : rightPanel.markdown ? (
-                                <MarkdownPane markdown={rightPanel.markdown} className="markdown-body" />
+                                <MarkdownPane markdown={rightPanel.markdown} className="markdown-body" wrapSections={false} />
                             ) : null}
                         </div>
                     </div>

--- a/client/src/components/MarkdownPane.test.tsx
+++ b/client/src/components/MarkdownPane.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MarkdownPane } from './MarkdownPane';
+
+describe('MarkdownPane', () => {
+    it('renders indented NESH html as html instead of a markdown code block', async () => {
+        render(
+            <MarkdownPane
+                className="markdown-body"
+                markdown={`
+                    <div class="section-notas" id="chapter-85-notas">
+                        <h3 class="section-header notas-header">Notas do Capítulo</h3>
+                        <blockquote class="nesh-blockquote">
+                            Ver posição <a href="#" class="smart-link" data-ncm="8501">85.01</a>.
+                        </blockquote>
+                    </div>
+                `}
+            />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByRole('link', { name: '85.01' })).toBeInTheDocument();
+        });
+
+        expect(document.querySelector('.section-notas .nesh-blockquote')).toHaveTextContent('Ver posição 85.01.');
+        expect(document.querySelector('pre code')).not.toBeInTheDocument();
+    });
+
+    it('does not wrap standalone NESH headings in section cards for comparison results', async () => {
+        render(
+            <MarkdownPane
+                className="markdown-body"
+                markdown={`
+                    <h3 class="nesh-section" id="pos-85-02" data-ncm="8502">
+                        <strong><a href="#" class="smart-link" data-ncm="8502">85.02</a></strong> - Grupos eletrogêneos.
+                    </h3>
+                    <p class="nesh-paragraph">Conteúdo da posição.</p>
+                `}
+            />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByRole('link', { name: '85.02' })).toBeInTheDocument();
+        });
+
+        expect(document.querySelector('section.nesh-section-card[data-ncm="8502"]')).not.toBeInTheDocument();
+        expect(document.querySelector('h3.nesh-section[data-ncm="8502"]')).toBeInTheDocument();
+        expect(document.querySelector('.nesh-paragraph')).toHaveTextContent('Conteúdo da posição.');
+        expect(document.querySelector('pre code')).not.toBeInTheDocument();
+    });
+});

--- a/client/src/components/MarkdownPane.test.tsx
+++ b/client/src/components/MarkdownPane.test.tsx
@@ -50,4 +50,36 @@ describe('MarkdownPane', () => {
         expect(document.querySelector('.nesh-paragraph')).toHaveTextContent('Conteúdo da posição.');
         expect(document.querySelector('pre code')).not.toBeInTheDocument();
     });
+
+    it('wraps standalone NESH headings in section cards by default', async () => {
+        render(
+            <MarkdownPane
+                className="markdown-body"
+                markdown={`
+                    <h3 class="nesh-section" id="pos-85-02" data-ncm="8502">
+                        <strong><a href="#" class="smart-link" data-ncm="8502">85.02</a></strong> - Grupos eletrogêneos.
+                    </h3>
+                    <p class="nesh-paragraph">Conteúdo da posição.</p>
+                `}
+            />
+        );
+
+        await waitFor(() => {
+            expect(screen.getByRole('link', { name: '85.02' })).toBeInTheDocument();
+        });
+
+        const sectionCard = document.querySelector('section.nesh-section-card[data-ncm="8502"]');
+        expect(sectionCard).toBeInTheDocument();
+        expect(sectionCard?.getAttribute('data-ncm')).toBe('8502');
+
+        // The original h3 heading is no longer a top-level child of .markdown-body, but is nested inside the section card
+        expect(document.querySelector('.markdown-body > h3.nesh-section')).not.toBeInTheDocument();
+        expect(sectionCard?.querySelector('h3.nesh-section')).toBeInTheDocument();
+
+        // The subsequent sibling elements are nested within the section body
+        const sectionBody = sectionCard?.querySelector('.nesh-section-body');
+        expect(sectionBody).toBeInTheDocument();
+        expect(sectionBody?.querySelector('.nesh-paragraph')).toHaveTextContent('Conteúdo da posição.');
+        expect(document.querySelector('pre code')).not.toBeInTheDocument();
+    });
 });

--- a/client/src/components/MarkdownPane.test.tsx
+++ b/client/src/components/MarkdownPane.test.tsx
@@ -37,6 +37,7 @@ describe('MarkdownPane', () => {
                     </h3>
                     <p class="nesh-paragraph">Conteúdo da posição.</p>
                 `}
+                wrapSections={false}
             />
         );
 

--- a/client/src/components/MarkdownPane.test.tsx
+++ b/client/src/components/MarkdownPane.test.tsx
@@ -1,14 +1,14 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
 
-import { MarkdownPane } from './MarkdownPane';
+import { MarkdownPane } from './MarkdownPane'
 
 describe('MarkdownPane', () => {
-    it('renders indented NESH html as html instead of a markdown code block', async () => {
-        render(
-            <MarkdownPane
-                className="markdown-body"
-                markdown={`
+  it('renders indented NESH html as html instead of a markdown code block', async () => {
+    render(
+      <MarkdownPane
+        className="markdown-body"
+        markdown={`
                     <div class="section-notas" id="chapter-85-notas">
                         <h3 class="section-header notas-header">Notas do Capítulo</h3>
                         <blockquote class="nesh-blockquote">
@@ -16,70 +16,84 @@ describe('MarkdownPane', () => {
                         </blockquote>
                     </div>
                 `}
-            />
-        );
+      />
+    )
 
-        await waitFor(() => {
-            expect(screen.getByRole('link', { name: '85.01' })).toBeInTheDocument();
-        });
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: '85.01' })).toBeInTheDocument()
+    })
 
-        expect(document.querySelector('.section-notas .nesh-blockquote')).toHaveTextContent('Ver posição 85.01.');
-        expect(document.querySelector('pre code')).not.toBeInTheDocument();
-    });
+    expect(
+      document.querySelector('.section-notas .nesh-blockquote')
+    ).toHaveTextContent('Ver posição 85.01.')
+    expect(document.querySelector('pre code')).not.toBeInTheDocument()
+  })
 
-    it('does not wrap standalone NESH headings in section cards for comparison results', async () => {
-        render(
-            <MarkdownPane
-                className="markdown-body"
-                markdown={`
+  it('does not wrap standalone NESH headings in section cards for comparison results', async () => {
+    render(
+      <MarkdownPane
+        className="markdown-body"
+        markdown={`
                     <h3 class="nesh-section" id="pos-85-02" data-ncm="8502">
                         <strong><a href="#" class="smart-link" data-ncm="8502">85.02</a></strong> - Grupos eletrogêneos.
                     </h3>
                     <p class="nesh-paragraph">Conteúdo da posição.</p>
                 `}
-                wrapSections={false}
-            />
-        );
+        wrapSections={false}
+      />
+    )
 
-        await waitFor(() => {
-            expect(screen.getByRole('link', { name: '85.02' })).toBeInTheDocument();
-        });
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: '85.02' })).toBeInTheDocument()
+    })
 
-        expect(document.querySelector('section.nesh-section-card[data-ncm="8502"]')).not.toBeInTheDocument();
-        expect(document.querySelector('h3.nesh-section[data-ncm="8502"]')).toBeInTheDocument();
-        expect(document.querySelector('.nesh-paragraph')).toHaveTextContent('Conteúdo da posição.');
-        expect(document.querySelector('pre code')).not.toBeInTheDocument();
-    });
+    expect(
+      document.querySelector('section.nesh-section-card[data-ncm="8502"]')
+    ).not.toBeInTheDocument()
+    expect(
+      document.querySelector('h3.nesh-section[data-ncm="8502"]')
+    ).toBeInTheDocument()
+    expect(document.querySelector('.nesh-paragraph')).toHaveTextContent(
+      'Conteúdo da posição.'
+    )
+    expect(document.querySelector('pre code')).not.toBeInTheDocument()
+  })
 
-    it('wraps standalone NESH headings in section cards by default', async () => {
-        render(
-            <MarkdownPane
-                className="markdown-body"
-                markdown={`
+  it('wraps standalone NESH headings in section cards by default', async () => {
+    render(
+      <MarkdownPane
+        className="markdown-body"
+        markdown={`
                     <h3 class="nesh-section" id="pos-85-02" data-ncm="8502">
                         <strong><a href="#" class="smart-link" data-ncm="8502">85.02</a></strong> - Grupos eletrogêneos.
                     </h3>
                     <p class="nesh-paragraph">Conteúdo da posição.</p>
                 `}
-            />
-        );
+      />
+    )
 
-        await waitFor(() => {
-            expect(screen.getByRole('link', { name: '85.02' })).toBeInTheDocument();
-        });
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: '85.02' })).toBeInTheDocument()
+    })
 
-        const sectionCard = document.querySelector('section.nesh-section-card[data-ncm="8502"]');
-        expect(sectionCard).toBeInTheDocument();
-        expect(sectionCard?.getAttribute('data-ncm')).toBe('8502');
+    const sectionCard = document.querySelector(
+      'section.nesh-section-card[data-ncm="8502"]'
+    )
+    expect(sectionCard).toBeInTheDocument()
+    expect(sectionCard?.getAttribute('data-ncm')).toBe('8502')
 
-        // The original h3 heading is no longer a top-level child of .markdown-body, but is nested inside the section card
-        expect(document.querySelector('.markdown-body > h3.nesh-section')).not.toBeInTheDocument();
-        expect(sectionCard?.querySelector('h3.nesh-section')).toBeInTheDocument();
+    // The original h3 heading is no longer a top-level child of .markdown-body, but is nested inside the section card
+    expect(
+      document.querySelector('.markdown-body > h3.nesh-section')
+    ).not.toBeInTheDocument()
+    expect(sectionCard?.querySelector('h3.nesh-section')).toBeInTheDocument()
 
-        // The subsequent sibling elements are nested within the section body
-        const sectionBody = sectionCard?.querySelector('.nesh-section-body');
-        expect(sectionBody).toBeInTheDocument();
-        expect(sectionBody?.querySelector('.nesh-paragraph')).toHaveTextContent('Conteúdo da posição.');
-        expect(document.querySelector('pre code')).not.toBeInTheDocument();
-    });
-});
+    // The subsequent sibling elements are nested within the section body
+    const sectionBody = sectionCard?.querySelector('.nesh-section-body')
+    expect(sectionBody).toBeInTheDocument()
+    expect(sectionBody?.querySelector('.nesh-paragraph')).toHaveTextContent(
+      'Conteúdo da posição.'
+    )
+    expect(document.querySelector('pre code')).not.toBeInTheDocument()
+  })
+})

--- a/client/src/components/MarkdownPane.tsx
+++ b/client/src/components/MarkdownPane.tsx
@@ -7,6 +7,13 @@ interface MarkdownPaneProps {
     className?: string;
 }
 
+function isFiscalResultHtml(content: string): boolean {
+    const trimmed = content.trimStart();
+    if (!trimmed.startsWith('<')) return false;
+
+    return /\b(?:nesh-|tipi-|section-notas|section-consideracoes|section-definicoes)/.test(trimmed);
+}
+
 export function MarkdownPane({ markdown, className }: MarkdownPaneProps) {
     const containerRef = useRef<HTMLDivElement>(null);
 
@@ -19,41 +26,8 @@ export function MarkdownPane({ markdown, className }: MarkdownPaneProps) {
         }
 
         try {
-            const rawHtml = marked.parse(markdown) as string;
+            const rawHtml = isFiscalResultHtml(markdown) ? markdown : marked.parse(markdown) as string;
             replaceElementWithSanitizedHtml(containerRef.current, rawHtml);
-
-            const container = containerRef.current;
-            const headings = Array.from(container.querySelectorAll('h3.nesh-section'));
-
-            headings.forEach((heading) => {
-                if (heading.parentElement?.classList.contains('nesh-section-card')) return;
-
-                const section = document.createElement('section');
-                section.className = 'nesh-section-card';
-
-                const dataNcm = heading.getAttribute('data-ncm');
-                if (dataNcm) {
-                    section.setAttribute('data-ncm', dataNcm);
-                }
-
-                const body = document.createElement('div');
-                body.className = 'nesh-section-body';
-
-                const parent = heading.parentNode;
-                if (!parent) return;
-
-                parent.insertBefore(section, heading);
-                section.appendChild(heading);
-
-                let next = section.nextSibling;
-                while (next && !(next instanceof HTMLElement && next.matches('h3.nesh-section'))) {
-                    const current = next;
-                    next = next.nextSibling;
-                    body.appendChild(current);
-                }
-
-                section.appendChild(body);
-            });
         } catch (e) {
             console.error('Markdown parse error:', e);
             containerRef.current.textContent = 'Erro ao renderizar conteúdo.';

--- a/client/src/components/MarkdownPane.tsx
+++ b/client/src/components/MarkdownPane.tsx
@@ -1,74 +1,88 @@
-import { marked } from 'marked';
-import { useEffect, useRef } from 'react';
-import { replaceElementWithSanitizedHtml } from '../utils/contentSecurity';
+import { marked } from 'marked'
+import { useEffect, useRef } from 'react'
+import { replaceElementWithSanitizedHtml } from '../utils/contentSecurity'
 
 interface MarkdownPaneProps {
-    markdown: string | null | undefined;
-    className?: string;
-    wrapSections?: boolean;
+  markdown: string | null | undefined
+  className?: string
+  wrapSections?: boolean
 }
 
 function isFiscalResultHtml(content: string): boolean {
-    const trimmed = content.trimStart();
-    if (!trimmed.startsWith('<')) return false;
+  const trimmed = content.trimStart()
+  if (!trimmed.startsWith('<')) return false
 
-    return /\b(?:nesh-|tipi-|section-notas|section-consideracoes|section-definicoes)/.test(trimmed);
+  return /\b(?:nesh-|tipi-|section-notas|section-consideracoes|section-definicoes)/.test(
+    trimmed
+  )
 }
 
-export function MarkdownPane({ markdown, className, wrapSections = true }: MarkdownPaneProps) {
-    const containerRef = useRef<HTMLDivElement>(null);
+export function MarkdownPane({
+  markdown,
+  className,
+  wrapSections = true,
+}: MarkdownPaneProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
 
-    useEffect(() => {
-        if (!containerRef.current) return;
+  useEffect(() => {
+    if (!containerRef.current) return
 
-        if (!markdown) {
-            containerRef.current.replaceChildren();
-            return;
-        }
+    if (!markdown) {
+      containerRef.current.replaceChildren()
+      return
+    }
 
-        try {
-            const rawHtml = isFiscalResultHtml(markdown) ? markdown : marked.parse(markdown) as string;
-            replaceElementWithSanitizedHtml(containerRef.current, rawHtml);
+    try {
+      const rawHtml = isFiscalResultHtml(markdown)
+        ? markdown
+        : (marked.parse(markdown) as string)
+      replaceElementWithSanitizedHtml(containerRef.current, rawHtml)
 
-            if (wrapSections) {
-                const container = containerRef.current;
-                const headings = Array.from(container.querySelectorAll('h3.nesh-section'));
+      if (wrapSections) {
+        const container = containerRef.current
+        const headings = Array.from(
+          container.querySelectorAll('h3.nesh-section')
+        )
 
-                headings.forEach((heading) => {
-                    if (heading.parentElement?.classList.contains('nesh-section-card')) return;
+        headings.forEach((heading) => {
+          if (heading.parentElement?.classList.contains('nesh-section-card'))
+            return
 
-                    const section = document.createElement('section');
-                    section.className = 'nesh-section-card';
+          const section = document.createElement('section')
+          section.className = 'nesh-section-card'
 
-                    const dataNcm = heading.getAttribute('data-ncm');
-                    if (dataNcm) {
-                        section.setAttribute('data-ncm', dataNcm);
-                    }
+          const dataNcm = heading.getAttribute('data-ncm')
+          if (dataNcm) {
+            section.setAttribute('data-ncm', dataNcm)
+          }
 
-                    const body = document.createElement('div');
-                    body.className = 'nesh-section-body';
+          const body = document.createElement('div')
+          body.className = 'nesh-section-body'
 
-                    const parent = heading.parentNode;
-                    if (!parent) return;
+          const parent = heading.parentNode
+          if (!parent) return
 
-                    parent.insertBefore(section, heading);
-                    section.appendChild(heading);
+          parent.insertBefore(section, heading)
+          section.appendChild(heading)
 
-                    let next = section.nextSibling;
-                    while (next && !(next instanceof HTMLElement && next.matches('h3.nesh-section'))) {
-                        const current = next;
-                        next = next.nextSibling;
-                        body.appendChild(current);
-                    }
+          let next = section.nextSibling
+          while (
+            next &&
+            !(next instanceof HTMLElement && next.matches('h3.nesh-section'))
+          ) {
+            const current = next
+            next = next.nextSibling
+            body.appendChild(current)
+          }
 
-                    section.appendChild(body);
-                });
-            }
-        } catch (e) {
-            console.error('Markdown parse error:', e);
-            containerRef.current.textContent = 'Erro ao renderizar conteúdo.';
-        }
-    }, [markdown, wrapSections]);
+          section.appendChild(body)
+        })
+      }
+    } catch (e) {
+      console.error('Markdown parse error:', e)
+      containerRef.current.textContent = 'Erro ao renderizar conteúdo.'
+    }
+  }, [markdown, wrapSections])
 
-    return <div ref={containerRef} className={className} />;
+  return <div ref={containerRef} className={className} />
 }

--- a/client/src/components/MarkdownPane.tsx
+++ b/client/src/components/MarkdownPane.tsx
@@ -5,6 +5,7 @@ import { replaceElementWithSanitizedHtml } from '../utils/contentSecurity';
 interface MarkdownPaneProps {
     markdown: string | null | undefined;
     className?: string;
+    wrapSections?: boolean;
 }
 
 function isFiscalResultHtml(content: string): boolean {
@@ -14,7 +15,7 @@ function isFiscalResultHtml(content: string): boolean {
     return /\b(?:nesh-|tipi-|section-notas|section-consideracoes|section-definicoes)/.test(trimmed);
 }
 
-export function MarkdownPane({ markdown, className }: MarkdownPaneProps) {
+export function MarkdownPane({ markdown, className, wrapSections = true }: MarkdownPaneProps) {
     const containerRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
@@ -28,11 +29,46 @@ export function MarkdownPane({ markdown, className }: MarkdownPaneProps) {
         try {
             const rawHtml = isFiscalResultHtml(markdown) ? markdown : marked.parse(markdown) as string;
             replaceElementWithSanitizedHtml(containerRef.current, rawHtml);
+
+            if (wrapSections) {
+                const container = containerRef.current;
+                const headings = Array.from(container.querySelectorAll('h3.nesh-section'));
+
+                headings.forEach((heading) => {
+                    if (heading.parentElement?.classList.contains('nesh-section-card')) return;
+
+                    const section = document.createElement('section');
+                    section.className = 'nesh-section-card';
+
+                    const dataNcm = heading.getAttribute('data-ncm');
+                    if (dataNcm) {
+                        section.setAttribute('data-ncm', dataNcm);
+                    }
+
+                    const body = document.createElement('div');
+                    body.className = 'nesh-section-body';
+
+                    const parent = heading.parentNode;
+                    if (!parent) return;
+
+                    parent.insertBefore(section, heading);
+                    section.appendChild(heading);
+
+                    let next = section.nextSibling;
+                    while (next && !(next instanceof HTMLElement && next.matches('h3.nesh-section'))) {
+                        const current = next;
+                        next = next.nextSibling;
+                        body.appendChild(current);
+                    }
+
+                    section.appendChild(body);
+                });
+            }
         } catch (e) {
             console.error('Markdown parse error:', e);
             containerRef.current.textContent = 'Erro ao renderizar conteúdo.';
         }
-    }, [markdown]);
+    }, [markdown, wrapSections]);
 
     return <div ref={containerRef} className={className} />;
 }

--- a/uv.lock
+++ b/uv.lock
@@ -797,11 +797,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- render fiscal HTML directly in the comparator instead of passing it through Markdown parsing
- remove comparator-only NESH section-card wrapping so it matches the normal search presentation
- add regression coverage for formatted NESH HTML and standalone section headings

## Validation
- npm run test -- src/components/MarkdownPane.test.tsx src/utils/NeshRenderer.test.ts
- npm run type-check
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to control automatic wrapping of section headings into section cards and improved handling of certain raw HTML fiscal-result content (sanitized instead of parsed).

* **Behavior Changes**
  * Comparison view panels now render content without automatic section-card wrapping.

* **Tests**
  * Expanded test coverage for Markdown rendering and section-wrapping scenarios (including default and opt-out cases).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YsraEstudos/FiscalConsultas/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->