### PR TITLE
fix(admin): record cross-device search telemetry

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Install Playwright browser dependencies
         working-directory: client
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps --only-shell chromium
 
       - name: Run Playwright P0 offline/service/scroll/auth specs
         working-directory: client

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -153,9 +153,8 @@ jobs:
         working-directory: client
         run: npm ci
 
-      - name: Install Playwright browser dependencies
-        working-directory: client
-        run: npx playwright install --with-deps --only-shell chromium
+      - name: Verify runner Chrome
+        run: google-chrome --version
 
       - name: Run Playwright P0 offline/service/scroll/auth specs
         working-directory: client

--- a/backend/presentation/routes/admin_dashboard.py
+++ b/backend/presentation/routes/admin_dashboard.py
@@ -222,15 +222,6 @@ async def get_admin_dashboard(request: Request) -> DashboardResponse:
             searches_by_type[row[0]] = row[1]
             total_today += row[1]
 
-        recent_device_fingerprints = (
-            select(SearchEvent.device_fingerprint)
-            .where(SearchEvent.created_at >= retention_cutoff)
-            .group_by(SearchEvent.device_fingerprint)
-            .order_by(func.max(SearchEvent.created_at).desc())
-            .limit(200)
-            .subquery()
-        )
-
         # Device summaries stay within the retention window, so stale rows that
         # have not been purged yet cannot make the admin panel slow.
         devices_result = await session.execute(
@@ -248,16 +239,10 @@ async def get_admin_dashboard(request: Request) -> DashboardResponse:
                     )
                 ).label("today"),
             )
-            .where(
-                and_(
-                    SearchEvent.created_at >= retention_cutoff,
-                    SearchEvent.device_fingerprint.in_(
-                        select(recent_device_fingerprints.c.device_fingerprint)
-                    ),
-                )
-            )
+            .where(SearchEvent.created_at >= retention_cutoff)
             .group_by(SearchEvent.device_fingerprint)
             .order_by(func.max(SearchEvent.created_at).desc())
+            .limit(200)
         )
 
         devices: list[DeviceSummary] = []

--- a/backend/presentation/routes/admin_dashboard.py
+++ b/backend/presentation/routes/admin_dashboard.py
@@ -17,8 +17,8 @@ from pydantic import BaseModel, Field
 from sqlalchemy import and_, case, delete, func, select
 
 from backend.domain.sqlmodels import SearchEvent
-from backend.infrastructure.db_engine import get_session
-from backend.server.middleware import decode_clerk_jwt
+from backend.infrastructure.db_engine import get_session, tenant_context
+from backend.server.middleware import decode_clerk_jwt, ensure_clerk_entities
 from backend.server.rate_limit import RedisBackedRateLimiter
 from backend.utils.auth import extract_bearer_token, is_admin_payload
 
@@ -112,6 +112,8 @@ async def _extract_user_info(
     )
     session_id = payload.get("sid")
     org_id = payload.get("org_id")
+    if org_id:
+        await ensure_clerk_entities(payload, org_id)
     return user_id, email, session_id, org_id
 
 
@@ -157,18 +159,23 @@ async def log_search_event(body: SearchEventRequest, request: Request):
 
     user_id, email, session_id, org_id = await _extract_user_info(request)
 
-    async with get_session() as session:
-        event = SearchEvent(
-            user_id=user_id,
-            user_email=email,
-            session_id=session_id,
-            device_fingerprint=fingerprint,
-            device_label=(body.device_label or "").strip()[:255] or None,
-            search_type=search_type,
-            search_query=(body.search_query or "").strip()[:300] or None,
-            tenant_id=org_id,
-        )
-        session.add(event)
+    tenant_token = tenant_context.set(org_id) if org_id else None
+    try:
+        async with get_session() as session:
+            event = SearchEvent(
+                user_id=user_id,
+                user_email=email,
+                session_id=session_id,
+                device_fingerprint=fingerprint,
+                device_label=(body.device_label or "").strip()[:255] or None,
+                search_type=search_type,
+                search_query=(body.search_query or "").strip()[:300] or None,
+                tenant_id=org_id,
+            )
+            session.add(event)
+    finally:
+        if tenant_token is not None:
+            tenant_context.reset(tenant_token)
 
     # Opportunistic cleanup: 1-in-100 chance to purge old events
     import secrets

--- a/backend/server/middleware.py
+++ b/backend/server/middleware.py
@@ -343,6 +343,7 @@ class TenantMiddleware:
         "/api/status/details",
         "/api/cache-metrics",
         "/api/metrics",
+        "/api/admin/search-event",
         "/api/admin/reload-secrets",
         "/api/debug/anchors",
         "/api/glossary",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.0.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.0.0",
+      "version": "0.1.2",
       "dependencies": {
         "@clerk/react": "^6.4.2",
         "@sqlite.org/sqlite-wasm": "^3.51.2-build9",
@@ -1576,6 +1576,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -1649,13 +1661,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -1690,9 +1703,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1873,7 +1886,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2356,9 +2368,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2608,6 +2620,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2715,12 +2740,12 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/js-tokens": {
@@ -3288,7 +3313,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {

--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,8 @@
     "react-virtuoso": "^4.18.1"
   },
   "overrides": {
-    "follow-redirects": "^1.16.0"
+    "follow-redirects": "^1.16.0",
+    "js-cookie": "3.0.7"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -16,6 +16,7 @@ function resolveLiveBaseUrl(): string {
 
 const liveBaseUrl = resolveLiveBaseUrl();
 const ciBrowserChannel = process.env.CI ? 'chrome' : undefined;
+const failureVideoMode = process.env.CI ? 'off' : 'retain-on-failure';
 
 export default defineConfig({
   testDir: './tests/playwright',
@@ -30,7 +31,7 @@ export default defineConfig({
     baseURL: defaultBaseUrl,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    video: failureVideoMode,
   },
   webServer: {
     command: 'npm run build && npx vite preview --host localhost --port 4173 --strictPort',

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -15,6 +15,7 @@ function resolveLiveBaseUrl(): string {
 }
 
 const liveBaseUrl = resolveLiveBaseUrl();
+const ciBrowserChannel = process.env.CI ? 'chrome' : undefined;
 
 export default defineConfig({
   testDir: './tests/playwright',
@@ -48,13 +49,14 @@ export default defineConfig({
     {
       name: 'mocked-chromium',
       testIgnore: '**/*.live.spec.ts',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], channel: ciBrowserChannel },
     },
     {
       name: 'live-chromium',
       testMatch: '**/*.live.spec.ts',
       use: {
         ...devices['Desktop Chrome'],
+        channel: ciBrowserChannel,
         baseURL: liveBaseUrl,
       },
     },

--- a/client/src/components/AdminDashboard.tsx
+++ b/client/src/components/AdminDashboard.tsx
@@ -226,7 +226,7 @@ export function AdminDashboard() {
     const refreshDashboard = useCallback(async (forceRefresh = false, showLoading = false) => {
         if (!mountedRef.current) return;
         if (showLoading) setLoading(true);
-        if (showLoading || !dataRef.current) setError(null);
+        if (showLoading || dataRef.current) setError(null);
         try {
             const dashboard = await getAdminDashboard(forceRefresh);
             if (mountedRef.current) {

--- a/client/src/components/AdminDashboard.tsx
+++ b/client/src/components/AdminDashboard.tsx
@@ -6,7 +6,7 @@
  * - Pesquisas hoje por tipo (NESH, TIPI, NBS)
  * - Lista de dispositivos com drill-down
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { getAdminDashboard, getDeviceHistory } from '../services/api';
 import type {
     AdminDashboardResponse,
@@ -215,23 +215,48 @@ export function AdminDashboard() {
     const [data, setData] = useState<AdminDashboardResponse | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const mountedRef = useRef(true);
+    const dataRef = useRef<AdminDashboardResponse | null>(null);
 
     // Drill-down state
     const [selectedFp, setSelectedFp] = useState<string | null>(null);
     const [drillData, setDrillData] = useState<DeviceHistoryResponse | null>(null);
     const [drillLoading, setDrillLoading] = useState(false);
 
-    useEffect(() => {
-        setLoading(true);
-        setError(null);
-        getAdminDashboard()
-            .then(setData)
-            .catch((err) => {
-                console.error('Failed to load admin dashboard:', err);
+    const refreshDashboard = useCallback(async (forceRefresh = false, showLoading = false) => {
+        if (!mountedRef.current) return;
+        if (showLoading) setLoading(true);
+        if (showLoading || !dataRef.current) setError(null);
+        try {
+            const dashboard = await getAdminDashboard(forceRefresh);
+            if (mountedRef.current) {
+                dataRef.current = dashboard;
+                setData(dashboard);
+                setError(null);
+            }
+        } catch (err) {
+            console.error('Failed to load admin dashboard:', err);
+            if (mountedRef.current && !dataRef.current) {
                 setError('Erro ao carregar o painel de administração.');
-            })
-            .finally(() => setLoading(false));
+            }
+        } finally {
+            if (mountedRef.current) setLoading(false);
+        }
     }, []);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        void refreshDashboard(true, true);
+
+        const intervalId = window.setInterval(() => {
+            void refreshDashboard(true, false);
+        }, 15_000);
+
+        return () => {
+            mountedRef.current = false;
+            window.clearInterval(intervalId);
+        };
+    }, [refreshDashboard]);
 
     const handleDeviceClick = useCallback((fp: string) => {
         setSelectedFp(fp);

--- a/client/src/services/api/adminDashboard.ts
+++ b/client/src/services/api/adminDashboard.ts
@@ -31,8 +31,10 @@ function isDashboardCacheFresh(): boolean {
 export function logSearchEvent(data: SearchEventPayload): void {
     api.post('/admin/search-event', data).then(() => {
         dashboardCache = null;
-    }).catch(() => {
-        // Intentionally silent — telemetry must never block or toast errors
+    }).catch((error) => {
+        if (import.meta.env.DEV) {
+            console.warn('[adminDashboard] telemetry failed', error);
+        }
     });
 }
 
@@ -41,7 +43,7 @@ export async function getAdminDashboard(forceRefresh = false): Promise<AdminDash
         return dashboardCache.data;
     }
 
-    if (!forceRefresh && dashboardRequest) {
+    if (dashboardRequest) {
         return dashboardRequest;
     }
 

--- a/client/src/services/api/authLogging.ts
+++ b/client/src/services/api/authLogging.ts
@@ -3,6 +3,7 @@ import type { InternalAxiosRequestConfig } from 'axios';
 import type { ClerkTokenGetterOptions } from './authTypes';
 
 const PUBLIC_ROUTES = ['/status', '/glossary', '/services/', '/database/'];
+const OPTIONAL_AUTH_ROUTES = ['/admin/search-event'];
 const JWT_DEBUG_FIELDS = ['iss', 'sub', 'sid', 'azp', 'aud', 'org_id', 'exp', 'iat', 'nbf'] as const;
 
 export const AUTH_DEBUG_ENABLED =
@@ -30,6 +31,10 @@ export function normalizeRequestPath(path: string): string {
 
 export function isPublicRoutePath(path: string): boolean {
     return PUBLIC_ROUTES.some((route) => path.startsWith(route));
+}
+
+export function isOptionalAuthRoutePath(path: string): boolean {
+    return OPTIONAL_AUTH_ROUTES.some((route) => path.startsWith(route));
 }
 
 export function logRequestPrepared(

--- a/client/src/services/api/authSession.ts
+++ b/client/src/services/api/authSession.ts
@@ -46,12 +46,34 @@ function buildTokenGetterOptions(skipCache = false): ClerkTokenGetterOptions {
 }
 
 function canonicalizeAuthDetail(detail: string): string {
-    return detail
+    const withoutDiacritics = detail
         .normalize('NFD')
-        .replaceAll(/[\u0300-\u036f]/g, '')
-        .toLowerCase()
-        .replaceAll(/[.!?]+$/g, '')
-        .replaceAll(/\s+/g, ' ')
+        .split('')
+        .filter((char) => {
+            const code = char.charCodeAt(0);
+            return code < 0x0300 || code > 0x036f;
+        })
+        .join('')
+        .toLowerCase();
+
+    let end = withoutDiacritics.length;
+    while (end > 0 && ['.', '!', '?'].includes(withoutDiacritics[end - 1])) {
+        end -= 1;
+    }
+
+    return withoutDiacritics
+        .slice(0, end)
+        .trim()
+        .split('')
+        .reduce<string[]>((parts, char) => {
+            if (char.trim() === '') {
+                if (parts[parts.length - 1] !== ' ') parts.push(' ');
+                return parts;
+            }
+            parts.push(char);
+            return parts;
+        }, [])
+        .join('')
         .trim();
 }
 

--- a/client/src/services/api/authSession.ts
+++ b/client/src/services/api/authSession.ts
@@ -3,6 +3,7 @@ import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 import {
     AUTH_DEBUG_ENABLED,
     getRequestPath,
+    isOptionalAuthRoutePath,
     isPublicRoutePath,
     logAuthorizationAttached,
     logJwtDebug,
@@ -154,8 +155,8 @@ export function isAuthGetterRegistered(): boolean {
     return !!clerkGetToken;
 }
 
-export function shouldAuthenticateRequest(isPublicRoute: boolean): boolean {
-    return !!clerkGetToken && !isPublicRoute;
+export function shouldAuthenticateRequest(isPublicRoute: boolean, isOptionalAuthRoute = false): boolean {
+    return !!clerkGetToken && !isPublicRoute && !isOptionalAuthRoute;
 }
 
 export async function attachAuthorizationHeader(
@@ -175,6 +176,28 @@ export async function attachAuthorizationHeader(
         logJwtDebug('request', normalizedPath, requestId, token, options);
     } catch (error) {
         logRequestTokenFailure(error);
+    }
+}
+
+export async function attachOptionalAuthorizationHeader(
+    config: InternalAxiosRequestConfig,
+    normalizedPath: string,
+    requestId: string,
+): Promise<void> {
+    if (!clerkGetToken) return;
+
+    try {
+        const options = buildTokenGetterOptions(false);
+        const token = await clerkGetToken(options);
+        if (!token) return;
+
+        config.headers.set('Authorization', `Bearer ${token}`);
+        logAuthorizationAttached(requestId, normalizedPath);
+        logJwtDebug('request', normalizedPath, requestId, token, options);
+    } catch (error) {
+        if (AUTH_DEBUG_ENABLED) {
+            logRequestTokenFailure(error);
+        }
     }
 }
 
@@ -199,7 +222,7 @@ export async function retryUnauthorizedRequest(
     requestId: string | undefined,
 ): Promise<RetryUnauthorizedResult> {
     const normalizedPath = normalizeRequestPath(getRequestPath(originalRequest.url));
-    if (isPublicRoutePath(normalizedPath)) {
+    if (isPublicRoutePath(normalizedPath) || isOptionalAuthRoutePath(normalizedPath)) {
         return {
             response: null,
             refreshAttempt: 'skipped',

--- a/client/src/services/api/authTransport.ts
+++ b/client/src/services/api/authTransport.ts
@@ -11,6 +11,7 @@ import {
     getRequestPath,
     getOrCreateRequestId,
     getResponseRequestId,
+    isOptionalAuthRoutePath,
     isPublicRoutePath,
     logRequestPrepared,
     logUnauthorizedResponse,
@@ -19,6 +20,7 @@ import {
 } from './authLogging';
 import {
     attachAuthorizationHeader,
+    attachOptionalAuthorizationHeader,
     isAuthGetterRegistered,
     retryUnauthorizedRequest,
     shouldAuthenticateRequest,
@@ -44,6 +46,7 @@ export function configureApiAuthTransport(apiInstance: AxiosInstance): void {
         async (config: InternalAxiosRequestConfig) => {
             const normalizedPath = normalizeRequestPath(getRequestPath(config.url));
             const isPublicRoute = isPublicRoutePath(normalizedPath);
+            const isOptionalAuthRoute = isOptionalAuthRoutePath(normalizedPath);
             const requestId = getOrCreateRequestId();
 
             config.headers.set(REQUEST_ID_HEADER, requestId);
@@ -54,7 +57,9 @@ export function configureApiAuthTransport(apiInstance: AxiosInstance): void {
                 isAuthGetterRegistered(),
             );
 
-            if (shouldAuthenticateRequest(isPublicRoute)) {
+            if (isOptionalAuthRoute) {
+                await attachOptionalAuthorizationHeader(config, normalizedPath, requestId);
+            } else if (shouldAuthenticateRequest(isPublicRoute, isOptionalAuthRoute)) {
                 await attachAuthorizationHeader(config, normalizedPath, requestId);
             }
             return config;

--- a/client/tests/unit/AdminDashboard.test.tsx
+++ b/client/tests/unit/AdminDashboard.test.tsx
@@ -1,0 +1,69 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const refs = vi.hoisted(() => ({
+    getAdminDashboard: vi.fn(),
+    getDeviceHistory: vi.fn(),
+}));
+
+vi.mock('../../src/services/api', () => ({
+    getAdminDashboard: refs.getAdminDashboard,
+    getDeviceHistory: refs.getDeviceHistory,
+}));
+
+const dashboardResponse = {
+    total_active_devices: 1,
+    total_searches_today: 2,
+    searches_by_type: { nesh: 2 },
+    devices: [
+        {
+            fingerprint: 'fp1',
+            label: 'Chrome / Windows',
+            user_email: null,
+            user_id: null,
+            last_active: new Date().toISOString(),
+            is_active: true,
+            searches_today: 2,
+            total_searches: 2,
+        },
+    ],
+};
+
+describe('AdminDashboard', () => {
+    let AdminDashboard: typeof import('../../src/components/AdminDashboard').AdminDashboard;
+
+    beforeEach(async () => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+        refs.getAdminDashboard.mockResolvedValue(dashboardResponse);
+        refs.getDeviceHistory.mockResolvedValue({});
+        ({ AdminDashboard } = await import('../../src/components/AdminDashboard'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('keeps loaded dashboard visible when a background poll fails', async () => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        render(<AdminDashboard />);
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(screen.getByText('Pesquisas Hoje')).toBeInTheDocument();
+        expect(screen.getByText('NESH: 2')).toBeInTheDocument();
+
+        refs.getAdminDashboard.mockRejectedValueOnce(new Error('poll failed'));
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(15_000);
+        });
+
+        expect(screen.getByText('Pesquisas Hoje')).toBeInTheDocument();
+        expect(screen.getByText('NESH: 2')).toBeInTheDocument();
+        expect(screen.queryByText('Erro ao carregar o painel de administração.')).not.toBeInTheDocument();
+        errorSpy.mockRestore();
+    });
+});

--- a/client/tests/unit/adminDashboard.test.ts
+++ b/client/tests/unit/adminDashboard.test.ts
@@ -76,4 +76,45 @@ describe('admin dashboard API cache', () => {
 
         expect(refs.apiGetMock).toHaveBeenCalledTimes(2);
     });
+
+    it('logs telemetry warnings in DEV without throwing', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        refs.apiPostMock.mockRejectedValueOnce(new Error('telemetry failed'));
+
+        const { logSearchEvent } = await import('../../src/services/api/adminDashboard');
+
+        expect(() => logSearchEvent({
+            search_type: 'nesh',
+            search_query: '0101',
+            device_fingerprint: 'fp',
+            device_label: 'Chrome / Windows',
+        })).not.toThrow();
+
+        await vi.waitFor(() => {
+            expect(warnSpy).toHaveBeenCalled();
+        });
+        warnSpy.mockRestore();
+    });
+
+    it('force refresh bypasses warm dashboard cache', async () => {
+        const { getAdminDashboard } = await import('../../src/services/api/adminDashboard');
+
+        await getAdminDashboard();
+        await getAdminDashboard(true);
+
+        expect(refs.apiGetMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('deduplicates concurrent forced dashboard refreshes', async () => {
+        const { getAdminDashboard } = await import('../../src/services/api/adminDashboard');
+
+        const [first, second] = await Promise.all([
+            getAdminDashboard(true),
+            getAdminDashboard(true),
+        ]);
+
+        expect(first).toBe(dashboardResponse);
+        expect(second).toBe(dashboardResponse);
+        expect(refs.apiGetMock).toHaveBeenCalledTimes(1);
+    });
 });

--- a/client/tests/unit/authTransport.test.ts
+++ b/client/tests/unit/authTransport.test.ts
@@ -1,0 +1,53 @@
+import axios from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    configureApiAuthTransport,
+    registerClerkTokenGetter,
+    unregisterClerkTokenGetter,
+} from '../../src/services/api/authTransport';
+
+describe('API auth transport optional telemetry auth', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        unregisterClerkTokenGetter();
+    });
+
+    it('attaches auth to telemetry when a token is available', async () => {
+        registerClerkTokenGetter(vi.fn().mockResolvedValue('test-token'));
+        const api = axios.create({
+            adapter: async (config) => ({
+                config,
+                data: { authorization: config.headers?.Authorization },
+                headers: {},
+                status: 200,
+                statusText: 'OK',
+            }),
+        });
+        configureApiAuthTransport(api);
+
+        const response = await api.post('/admin/search-event', {});
+
+        expect(response.data.authorization).toBe('Bearer test-token');
+    });
+
+    it('does not force-refresh or fail telemetry when optional auth has no token', async () => {
+        const getToken = vi.fn().mockResolvedValue(null);
+        registerClerkTokenGetter(getToken);
+        const api = axios.create({
+            adapter: async (config) => ({
+                config,
+                data: { authorization: config.headers?.Authorization ?? null },
+                headers: {},
+                status: 200,
+                statusText: 'OK',
+            }),
+        });
+        configureApiAuthTransport(api);
+
+        const response = await api.post('/admin/search-event', {});
+
+        expect(response.data.authorization).toBeNull();
+        expect(getToken).toHaveBeenCalledTimes(1);
+    });
+});

--- a/docs/AI Context/AI_CONTEXT.md
+++ b/docs/AI Context/AI_CONTEXT.md
@@ -136,6 +136,14 @@ If there is no formatter, agree on one and add it to CI.
   them, never commit them.
 - Apply least-privilege: request only the permissions a module actually needs.
 
+## Admin Analytics
+
+- `GET /api/admin/dashboard` is admin/account telemetry, not fiscal search. Keep
+  it separate from offline-first fiscal query paths.
+- Dashboard queries over `search_events` must stay bounded by retention windows,
+  limited result counts, and migration-backed indexes; avoid nested aggregate
+  subqueries that scan the same retention range more than once.
+
 ## Git hygiene
 
 - One logical change per commit. Commits must build and pass tests in isolation.

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -150,6 +150,14 @@ If there is no formatter, agree on one and add it to CI.
 - The current Pages production deploy prefers the consolidated static R2 bundle at `VITE_FISCAL_R2_BASE_URL`, but also publishes `database/r2/fiscal_offline.meta.json` and `database/r2/fiscal_offline.enc` under `BASE_URL/fiscal-bases/` as a same-origin fallback.
 - Future/source-scoped R2 layout is: `nesh/nesh.meta.json`, `nesh/nesh.enc`, `tipi/tipi.meta.json`, `tipi/tipi.enc`, `nbs/nbs.meta.json`, `nbs/nbs.enc`, `unspsc/unspsc.meta.json`, and `unspsc/unspsc.enc`.
 
+## Admin Analytics
+
+- `GET /api/admin/dashboard` is admin/account telemetry, not fiscal search. Keep
+  it separate from offline-first fiscal query paths.
+- Dashboard queries over `search_events` must stay bounded by retention windows,
+  limited result counts, and migration-backed indexes; avoid nested aggregate
+  subqueries that scan the same retention range more than once.
+
 ## Git hygiene
 
 - One logical change per commit. Commits must build and pass tests in isolation.

--- a/migrations/versions/017_search_events_type_created_index.py
+++ b/migrations/versions/017_search_events_type_created_index.py
@@ -1,0 +1,44 @@
+"""Add dashboard search type/date index.
+
+Revision ID: 017_search_events_type_created_index
+Revises: 016_search_events_dashboard_indexes
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "017_search_events_type_created_index"
+down_revision = "016_search_events_dashboard_indexes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if "search_events" not in inspector.get_table_names():
+        return
+
+    existing_indexes = {
+        index_name
+        for index in inspector.get_indexes("search_events")
+        if isinstance(index_name := index["name"], str)
+    }
+    if "ix_search_events_created_type" not in existing_indexes:
+        op.create_index(
+            "ix_search_events_created_type",
+            "search_events",
+            ["created_at", "search_type"],
+        )
+
+
+def downgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if "search_events" not in inspector.get_table_names():
+        return
+
+    has_created_type_index = any(
+        index["name"] == "ix_search_events_created_type"
+        for index in inspector.get_indexes("search_events")
+    )
+    if has_created_type_index:
+        op.drop_index("ix_search_events_created_type", table_name="search_events")

--- a/tests/unit/test_admin_dashboard.py
+++ b/tests/unit/test_admin_dashboard.py
@@ -110,6 +110,54 @@ async def test_log_search_event_success(fake_db, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_log_search_event_with_auth_sets_tenant_context(monkeypatch):
+    captured_tenants: list[str] = []
+    session = FakeSession()
+
+    async def fake_decode_jwt(token: str) -> dict[str, Any]:
+        assert token == "fake-token"
+        return {
+            "sub": "user123",
+            "email": "user@example.com",
+            "sid": "session123",
+            "org_id": "org123",
+        }
+
+    async def fake_ensure_entities(payload: dict[str, Any], org_id: str) -> None:
+        assert payload["sub"] == "user123"
+        assert org_id == "org123"
+
+    @asynccontextmanager
+    async def fake_get_session():
+        captured_tenants.append(admin_dashboard.tenant_context.get())
+        yield session
+
+    monkeypatch.setattr(admin_dashboard, "decode_clerk_jwt", fake_decode_jwt)
+    monkeypatch.setattr(admin_dashboard, "ensure_clerk_entities", fake_ensure_entities)
+    monkeypatch.setattr(admin_dashboard, "get_session", fake_get_session)
+    monkeypatch.setattr("secrets.randbelow", lambda _: 1)
+
+    req = _build_request("/admin/search-event", auth_header="Bearer fake-token")
+    body = SearchEventRequest(
+        search_type="nesh",
+        search_query="test",
+        device_fingerprint="fp123",
+        device_label="my-pc",
+    )
+
+    res = await admin_dashboard.log_search_event(body, req)
+
+    assert res is None
+    assert captured_tenants == ["org123"]
+    event = session.added[0]
+    assert event.user_id == "user123"
+    assert event.user_email == "user@example.com"
+    assert event.session_id == "session123"
+    assert event.tenant_id == "org123"
+    assert admin_dashboard.tenant_context.get() == ""
+
+
+@pytest.mark.asyncio
 async def test_log_search_event_invalid_type():
     req = _build_request("/admin/search-event")
     body = SearchEventRequest(

--- a/tests/unit/test_admin_dashboard.py
+++ b/tests/unit/test_admin_dashboard.py
@@ -236,7 +236,9 @@ async def test_dashboard_routes_allow_admin(fake_db, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_dashboard_device_query_uses_retention_window(fake_db, monkeypatch):
+async def test_dashboard_device_query_uses_single_limited_retention_window(
+    fake_db, monkeypatch
+):
     async def fake_decode_jwt(token: str) -> dict[str, Any]:
         return {
             "email": "admin@example.com",
@@ -264,4 +266,7 @@ async def test_dashboard_device_query_uses_retention_window(fake_db, monkeypatch
     )
     assert device_query
     assert "search_events.created_at >= " in device_query
-    assert "IN (SELECT" in device_query
+    assert "GROUP BY search_events.device_fingerprint" in device_query
+    assert "ORDER BY max(search_events.created_at) DESC" in device_query
+    assert "LIMIT " in device_query
+    assert "IN (SELECT" not in device_query

--- a/tests/unit/test_middleware_additional.py
+++ b/tests/unit/test_middleware_additional.py
@@ -63,7 +63,9 @@ def test_public_search_event_path_is_exempt_from_tenant_requirement(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_public_search_event_passes_without_auth_in_production_postgres(monkeypatch):
+async def test_public_search_event_passes_without_auth_in_production_postgres(
+    monkeypatch,
+):
     monkeypatch.setattr(middleware.settings.server, "env", "production", raising=False)
     monkeypatch.setattr(
         middleware.settings.database, "engine", "postgresql", raising=False

--- a/tests/unit/test_middleware_additional.py
+++ b/tests/unit/test_middleware_additional.py
@@ -49,6 +49,63 @@ async def _invoke_middleware(
     return int(start_message["status"]), sent_messages
 
 
+def test_public_search_event_path_is_exempt_from_tenant_requirement(monkeypatch):
+    monkeypatch.setattr(middleware.settings.server, "env", "production", raising=False)
+    monkeypatch.setattr(
+        middleware.settings.database, "engine", "postgresql", raising=False
+    )
+
+    assert middleware.TenantMiddleware._is_public_path("/api/admin/search-event")
+    assert not middleware.TenantMiddleware._is_public_path("/api/admin/dashboard")
+    assert not middleware.TenantMiddleware._is_public_path(
+        "/api/admin/device/fp123/history"
+    )
+
+
+@pytest.mark.asyncio
+async def test_public_search_event_passes_without_auth_in_production_postgres(monkeypatch):
+    monkeypatch.setattr(middleware.settings.server, "env", "production", raising=False)
+    monkeypatch.setattr(
+        middleware.settings.database, "engine", "postgresql", raising=False
+    )
+
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 204,
+                "headers": [],
+            }
+        )
+
+    mw = middleware.TenantMiddleware(app)
+
+    status, _ = await _invoke_middleware(mw, _build_scope("/api/admin/search-event"))
+    assert status == 204
+
+
+@pytest.mark.asyncio
+async def test_protected_admin_routes_still_require_tenant(monkeypatch):
+    monkeypatch.setattr(middleware.settings.server, "env", "production", raising=False)
+    monkeypatch.setattr(
+        middleware.settings.database, "engine", "postgresql", raising=False
+    )
+
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 204,
+                "headers": [],
+            }
+        )
+
+    mw = middleware.TenantMiddleware(app)
+
+    status, _ = await _invoke_middleware(mw, _build_scope("/api/admin/dashboard"))
+    assert status == 401
+
+
 def test_get_payload_exp_variants():
     assert middleware._get_payload_exp({"exp": 123}) == pytest.approx(123.0)
     assert middleware._get_payload_exp({"exp": "123.5"}) == pytest.approx(123.5)


### PR DESCRIPTION
## Summary
- make search telemetry endpoint truly public to anonymous devices while preserving optional auth attribution
- add optional-auth transport handling for /admin/search-event without forced token refresh
- refresh the admin dashboard periodically without blanking loaded data on transient failures
- add backend/client regression tests for middleware, auth transport, cache, and polling behavior

## Tests
- pytest tests/unit/test_middleware_additional.py tests/unit/test_admin_dashboard.py
- npx vitest run tests/unit/adminDashboard.test.ts tests/unit/authTransport.test.ts tests/unit/AdminDashboard.test.tsx
- npm run type-check
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin dashboard now auto-refreshes every 15s.
  * Search-event API exposed as a public endpoint.
  * Added support for optional authentication on select API routes.

* **Bug Fixes**
  * Prevents state updates after the admin dashboard unmount to avoid errors.
  * Telemetry failures are non-blocking; DEV logs warnings only.

* **Tests**
  * Added/expanded tests for dashboard refresh, telemetry, optional-auth, and middleware.

* **Chores**
  * Pinned a client dependency; CI/browser tooling adjusted.
* **Documentation**
  * New Admin Analytics guidance added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->