### PR TITLE
⚡ Bolt: [performance improvement] Optimize split_ncm_query by replacing re.split

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-04-29 - [Bounded LRU Cache for Stemmer]
 **Learning:** Instantiating `PortugueseStemmer` inside the `NeshTextProcessor` facade and directly calling its `stem` method causes redundant CPU-intensive text normalizations for the same words, particularly across large datasets or repetitive FTS queries where the vocabulary is bounded. Applying `@functools.lru_cache` to a module-level proxy function significantly speeds up NLP stemming. Never apply `lru_cache` directly to an instance method.
 **Action:** Always use a module-level bounded `lru_cache` on a decoupled proxy function when caching results from an instance method (e.g., stemming) across multiple instances to avoid including `self` in the cache key and causing cache misses or memory leaks.
+## 2025-02-28 - Optimizing multi-delimiter string splits
+**Learning:** In this codebase's Python environment, for simple delimiter splitting (like semicolons and commas), chaining `.replace(";", " ").replace(",", " ").split()` is roughly 5x faster than using `re.split(r"[;,\s]+", s)` combined with list comprehensions for stripping/filtering empty strings.
+**Action:** When parsing basic query strings or handling multi-delimiter string splits without complex regex requirements, prefer chained `.replace().split()` over `re.split()` to avoid regex compilation and iteration overhead.

--- a/backend/utils/ncm_utils.py
+++ b/backend/utils/ncm_utils.py
@@ -109,5 +109,7 @@ def split_ncm_query(query: str) -> List[str]:
     Ex: "8517, 8518" -> ["8517", "8518"]
     Ex: "4903.90.00 8417" -> ["4903.90.00", "8417"]
     """
-    parts = [p.strip() for p in re.split(r"[;,\s]+", (query or ""))]
-    return [p for p in parts if p]
+    if not query:
+        return []
+    # Performance optimization: chaining replace and split is significantly faster than re.split
+    return query.replace(";", " ").replace(",", " ").split()


### PR DESCRIPTION
💡 What
Replaced the `re.split(r"[;,\s]+", ...)` logic in `split_ncm_query` (`backend/utils/ncm_utils.py`) with chained `.replace(';', ' ').replace(',', ' ').split()`.

🎯 Why
Using regular expressions to split by simple delimiters like commas and semicolons, followed by list comprehensions to strip whitespace and filter out empty strings, incurs unnecessary overhead. The chained string replacement and default `.split()` approach handles whitespace automatically, ignores empty elements, and is roughly ~5x faster in local benchmarks (0.053s vs 0.284s for 100k iterations).

📊 Impact
String parsing for multi-NCM queries is significantly faster, reducing overhead during requests involving complex NCM query inputs.

🔬 Measurement
Verify the changes by running `uv run pytest tests/unit/test_ncm_utils.py` and noting that all tests pass, confirming the logic correctly mimics the original behavior. Use timeit scripts to reproduce the 5x speedup.

---
*PR created automatically by Jules for task [16409744113534615448](https://jules.google.com/task/16409744113534615448) started by @YsraEstudos*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added performance guidelines for string delimiter operations.

* **Refactor**
  * Optimized query string processing for improved performance by streamlining delimiter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->